### PR TITLE
fix(ci): preview workflow에 branches 필터 추가

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,6 +3,7 @@ name: Deploy Preview
 on:
   pull_request:
     types: [opened, synchronize]
+    branches: [main, develop]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- preview.yml에 `branches: [main, develop]` 필터 추가
- CI와 동일하게 브랜치 필터를 추가하여 워크플로우가 정상 트리거되도록 수정

## Related
- PR #6의 preview 배포가 작동하지 않는 문제 해결

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to ensure builds are triggered only for targeted branches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->