### PR TITLE
feat(#42): React Flow custom node components

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.69.0",
+    "reactflow": "^11.11.4",
     "tailwind-merge": "^3.4.0",
     "zod": "^3.25.76"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.69.0",
-    "reactflow": "^11.11.4",
+    "@xyflow/react": "^12.3.5",
     "tailwind-merge": "^3.4.0",
     "zod": "^3.25.76"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.12
         version: 5.90.12(react@19.2.3)
+      '@xyflow/react':
+        specifier: ^12.3.5
+        version: 12.10.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -77,9 +80,6 @@ importers:
       react-hook-form:
         specifier: ^7.69.0
         version: 7.69.0(react@19.2.3)
-      reactflow:
-        specifier: ^11.11.4
-        version: 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -1755,42 +1755,6 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@reactflow/background@11.3.14':
-    resolution: {integrity: sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
-  '@reactflow/controls@11.2.14':
-    resolution: {integrity: sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
-  '@reactflow/core@11.11.4':
-    resolution: {integrity: sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
-  '@reactflow/minimap@11.7.14':
-    resolution: {integrity: sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
-  '@reactflow/node-resizer@2.2.14':
-    resolution: {integrity: sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
-  '@reactflow/node-toolbar@1.3.14':
-    resolution: {integrity: sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
-
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
@@ -2433,98 +2397,23 @@ packages:
   '@types/conventional-commits-parser@5.0.2':
     resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
 
-  '@types/d3-array@3.2.2':
-    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
-
-  '@types/d3-axis@3.0.6':
-    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
-
-  '@types/d3-brush@3.0.6':
-    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
-
-  '@types/d3-chord@3.0.6':
-    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
-
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
-
-  '@types/d3-contour@3.0.6':
-    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
-
-  '@types/d3-delaunay@6.0.4':
-    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
-
-  '@types/d3-dispatch@3.0.7':
-    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
 
   '@types/d3-drag@3.0.7':
     resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
 
-  '@types/d3-dsv@3.0.7':
-    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
-
-  '@types/d3-ease@3.0.2':
-    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
-
-  '@types/d3-fetch@3.0.7':
-    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
-
-  '@types/d3-force@3.0.10':
-    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
-
-  '@types/d3-format@3.0.4':
-    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
-
-  '@types/d3-geo@3.1.0':
-    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
-
-  '@types/d3-hierarchy@3.1.7':
-    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
-
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
 
-  '@types/d3-path@3.1.1':
-    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
-
-  '@types/d3-polygon@3.0.2':
-    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
-
-  '@types/d3-quadtree@3.0.6':
-    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
-
-  '@types/d3-random@3.0.3':
-    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
-
-  '@types/d3-scale-chromatic@3.1.0':
-    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
-
-  '@types/d3-scale@4.0.9':
-    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
-
   '@types/d3-selection@3.0.11':
     resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
-
-  '@types/d3-shape@3.1.8':
-    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
-
-  '@types/d3-time-format@4.0.3':
-    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
-
-  '@types/d3-time@3.0.4':
-    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
-
-  '@types/d3-timer@3.0.2':
-    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/d3-transition@3.0.9':
     resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
 
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
-
-  '@types/d3@7.4.3':
-    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -2540,9 +2429,6 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
-
-  '@types/geojson@7946.0.16':
-    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -2861,6 +2747,15 @@ packages:
 
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  '@xyflow/react@12.10.0':
+    resolution: {integrity: sha512-eOtz3whDMWrB4KWVatIBrKuxECHqip6PfA8fTpaS2RUGVpiEAe+nqDKsLqkViVWxDGreq0lWX71Xth/SPAzXiw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.74':
+    resolution: {integrity: sha512-7v7B/PkiVrkdZzSbL+inGAo6tkR/WQHHG0/jhSvLQToCsfa8YubOGmBYd1s08tpKpihdHDZFwzQZeR69QSBb4Q==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -4912,12 +4807,6 @@ packages:
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
-
-  reactflow@11.11.4:
-    resolution: {integrity: sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==}
-    peerDependencies:
-      react: '>=17'
-      react-dom: '>=17'
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -7152,84 +7041,6 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@reactflow/background@11.3.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      classcat: 5.0.5
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
-  '@reactflow/controls@11.2.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      classcat: 5.0.5
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
-  '@reactflow/core@11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@types/d3': 7.4.3
-      '@types/d3-drag': 3.0.7
-      '@types/d3-selection': 3.0.11
-      '@types/d3-zoom': 3.0.8
-      classcat: 5.0.5
-      d3-drag: 3.0.0
-      d3-selection: 3.0.0
-      d3-zoom: 3.0.0
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
-  '@reactflow/minimap@11.7.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@types/d3-selection': 3.0.11
-      '@types/d3-zoom': 3.0.8
-      classcat: 5.0.5
-      d3-selection: 3.0.0
-      d3-zoom: 3.0.0
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
-  '@reactflow/node-resizer@2.2.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      classcat: 5.0.5
-      d3-drag: 3.0.0
-      d3-selection: 3.0.0
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
-  '@reactflow/node-toolbar@1.3.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      classcat: 5.0.5
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
   '@rollup/plugin-commonjs@28.0.1(rollup@4.54.0)':
@@ -7883,80 +7694,17 @@ snapshots:
     dependencies:
       '@types/node': 25.0.3
 
-  '@types/d3-array@3.2.2': {}
-
-  '@types/d3-axis@3.0.6':
-    dependencies:
-      '@types/d3-selection': 3.0.11
-
-  '@types/d3-brush@3.0.6':
-    dependencies:
-      '@types/d3-selection': 3.0.11
-
-  '@types/d3-chord@3.0.6': {}
-
   '@types/d3-color@3.1.3': {}
-
-  '@types/d3-contour@3.0.6':
-    dependencies:
-      '@types/d3-array': 3.2.2
-      '@types/geojson': 7946.0.16
-
-  '@types/d3-delaunay@6.0.4': {}
-
-  '@types/d3-dispatch@3.0.7': {}
 
   '@types/d3-drag@3.0.7':
     dependencies:
       '@types/d3-selection': 3.0.11
 
-  '@types/d3-dsv@3.0.7': {}
-
-  '@types/d3-ease@3.0.2': {}
-
-  '@types/d3-fetch@3.0.7':
-    dependencies:
-      '@types/d3-dsv': 3.0.7
-
-  '@types/d3-force@3.0.10': {}
-
-  '@types/d3-format@3.0.4': {}
-
-  '@types/d3-geo@3.1.0':
-    dependencies:
-      '@types/geojson': 7946.0.16
-
-  '@types/d3-hierarchy@3.1.7': {}
-
   '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
 
-  '@types/d3-path@3.1.1': {}
-
-  '@types/d3-polygon@3.0.2': {}
-
-  '@types/d3-quadtree@3.0.6': {}
-
-  '@types/d3-random@3.0.3': {}
-
-  '@types/d3-scale-chromatic@3.1.0': {}
-
-  '@types/d3-scale@4.0.9':
-    dependencies:
-      '@types/d3-time': 3.0.4
-
   '@types/d3-selection@3.0.11': {}
-
-  '@types/d3-shape@3.1.8':
-    dependencies:
-      '@types/d3-path': 3.1.1
-
-  '@types/d3-time-format@4.0.3': {}
-
-  '@types/d3-time@3.0.4': {}
-
-  '@types/d3-timer@3.0.2': {}
 
   '@types/d3-transition@3.0.9':
     dependencies:
@@ -7966,39 +7714,6 @@ snapshots:
     dependencies:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
-
-  '@types/d3@7.4.3':
-    dependencies:
-      '@types/d3-array': 3.2.2
-      '@types/d3-axis': 3.0.6
-      '@types/d3-brush': 3.0.6
-      '@types/d3-chord': 3.0.6
-      '@types/d3-color': 3.1.3
-      '@types/d3-contour': 3.0.6
-      '@types/d3-delaunay': 6.0.4
-      '@types/d3-dispatch': 3.0.7
-      '@types/d3-drag': 3.0.7
-      '@types/d3-dsv': 3.0.7
-      '@types/d3-ease': 3.0.2
-      '@types/d3-fetch': 3.0.7
-      '@types/d3-force': 3.0.10
-      '@types/d3-format': 3.0.4
-      '@types/d3-geo': 3.1.0
-      '@types/d3-hierarchy': 3.1.7
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-path': 3.1.1
-      '@types/d3-polygon': 3.0.2
-      '@types/d3-quadtree': 3.0.6
-      '@types/d3-random': 3.0.3
-      '@types/d3-scale': 4.0.9
-      '@types/d3-scale-chromatic': 3.1.0
-      '@types/d3-selection': 3.0.11
-      '@types/d3-shape': 3.1.8
-      '@types/d3-time': 3.0.4
-      '@types/d3-time-format': 4.0.3
-      '@types/d3-timer': 3.0.2
-      '@types/d3-transition': 3.0.9
-      '@types/d3-zoom': 3.0.8
 
   '@types/deep-eql@4.0.2': {}
 
@@ -8015,8 +7730,6 @@ snapshots:
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
-
-  '@types/geojson@7946.0.16': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -8415,6 +8128,29 @@ snapshots:
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
+
+  '@xyflow/react@12.10.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@xyflow/system': 0.0.74
+      classcat: 5.0.5
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.74':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
 
   JSONStream@1.3.5:
     dependencies:
@@ -10637,20 +10373,6 @@ snapshots:
       '@types/react': 19.2.7
 
   react@19.2.3: {}
-
-  reactflow@11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@reactflow/background': 11.3.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@reactflow/controls': 11.2.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@reactflow/minimap': 11.7.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@reactflow/node-resizer': 2.2.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@reactflow/node-toolbar': 1.3.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
 
   readdirp@3.6.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       react-hook-form:
         specifier: ^7.69.0
         version: 7.69.0(react@19.2.3)
+      reactflow:
+        specifier: ^11.11.4
+        version: 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -1752,6 +1755,42 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reactflow/background@11.3.14':
+    resolution: {integrity: sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/controls@11.2.14':
+    resolution: {integrity: sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/core@11.11.4':
+    resolution: {integrity: sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/minimap@11.7.14':
+    resolution: {integrity: sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/node-resizer@2.2.14':
+    resolution: {integrity: sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/node-toolbar@1.3.14':
+    resolution: {integrity: sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
@@ -2394,6 +2433,99 @@ packages:
   '@types/conventional-commits-parser@5.0.2':
     resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2408,6 +2540,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -3001,6 +3136,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
     engines: {node: '>=4'}
@@ -3103,6 +3241,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -4737,6 +4913,12 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
+  reactflow@11.11.4:
+    resolution: {integrity: sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -5536,6 +5718,21 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -6955,6 +7152,84 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reactflow/background@11.3.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      classcat: 5.0.5
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/controls@11.2.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      classcat: 5.0.5
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/core@11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@types/d3': 7.4.3
+      '@types/d3-drag': 3.0.7
+      '@types/d3-selection': 3.0.11
+      '@types/d3-zoom': 3.0.8
+      classcat: 5.0.5
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/minimap@11.7.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/d3-selection': 3.0.11
+      '@types/d3-zoom': 3.0.8
+      classcat: 5.0.5
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/node-resizer@2.2.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      classcat: 5.0.5
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/node-toolbar@1.3.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      classcat: 5.0.5
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      zustand: 4.5.7(@types/react@19.2.7)(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
   '@rollup/plugin-commonjs@28.0.1(rollup@4.54.0)':
@@ -7608,6 +7883,123 @@ snapshots:
     dependencies:
       '@types/node': 25.0.3
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -7623,6 +8015,8 @@ snapshots:
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -8307,6 +8701,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   clean-regexp@1.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -8409,6 +8805,42 @@ snapshots:
       lru-cache: 11.2.4
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   damerau-levenshtein@1.0.8: {}
 
@@ -10206,6 +10638,20 @@ snapshots:
 
   react@19.2.3: {}
 
+  reactflow@11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@reactflow/background': 11.3.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@reactflow/controls': 11.2.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@reactflow/core': 11.11.4(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@reactflow/minimap': 11.7.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@reactflow/node-resizer': 2.2.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@reactflow/node-toolbar': 1.3.14(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
@@ -11154,3 +11600,10 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zustand@4.5.7(@types/react@19.2.7)(react@19.2.3):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      react: 19.2.3

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -12,4 +12,7 @@ export const EDITOR_MESSAGES = {
   AI_MODIFY_ROADMAP: '로드맵 수정',
   AI_MENU_LABEL: 'AI 메뉴',
   RESOURCE_DELETE_CONFIRM: '자료를 삭제하시겠습니까?',
+  FLOW_NODE_DEFAULT_TITLE: 'Node',
+  FLOW_SECTION_DEFAULT_TITLE: '섹션',
+  FLOW_TEXT_DEFAULT_CONTENT: '텍스트',
 } as const;

--- a/src/features/editor/components/flow-nodes/BaseFlowNode/BaseFlowNode.test.tsx
+++ b/src/features/editor/components/flow-nodes/BaseFlowNode/BaseFlowNode.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BaseFlowNode } from './index';
+
+describe('BaseFlowNode', () => {
+  describe('렌더링', () => {
+    it('children을 렌더링한다', () => {
+      render(
+        <BaseFlowNode variant="white" state="default">
+          <span>Test Content</span>
+        </BaseFlowNode>,
+      );
+
+      expect(screen.getByText('Test Content')).toBeInTheDocument();
+    });
+
+    it('custom className을 적용한다', () => {
+      const { container } = render(
+        <BaseFlowNode variant="white" state="default" className="custom-class">
+          <span>Content</span>
+        </BaseFlowNode>,
+      );
+
+      expect(container.firstChild).toHaveClass('custom-class');
+    });
+  });
+
+  describe('색상 Variants', () => {
+    const variants = ['white', 'black', 'blue', 'purple', 'red', 'orange'] as const;
+
+    it.each(variants)('%s variant를 default state로 렌더링한다', (variant) => {
+      const { container } = render(
+        <BaseFlowNode variant={variant} state="default">
+          <span>Content</span>
+        </BaseFlowNode>,
+      );
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it.each(variants)('%s variant를 focus state로 렌더링한다', (variant) => {
+      const { container } = render(
+        <BaseFlowNode variant={variant} state="focus">
+          <span>Content</span>
+        </BaseFlowNode>,
+      );
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+
+  describe('스타일링', () => {
+    it('flex container로 렌더링된다', () => {
+      const { container } = render(
+        <BaseFlowNode variant="white" state="default">
+          <span>Content</span>
+        </BaseFlowNode>,
+      );
+
+      expect(container.firstChild).toHaveClass('flex');
+      expect(container.firstChild).toHaveClass('items-center');
+      expect(container.firstChild).toHaveClass('justify-center');
+    });
+
+    it('rounded border를 가진다', () => {
+      const { container } = render(
+        <BaseFlowNode variant="white" state="default">
+          <span>Content</span>
+        </BaseFlowNode>,
+      );
+
+      expect(container.firstChild).toHaveClass('rounded-lg');
+      expect(container.firstChild).toHaveClass('border-2');
+    });
+  });
+});

--- a/src/features/editor/components/flow-nodes/BaseFlowNode/index.tsx
+++ b/src/features/editor/components/flow-nodes/BaseFlowNode/index.tsx
@@ -1,0 +1,33 @@
+import type { NodeColorVariant, NodeState } from '@/features/editor/types/editor.types';
+import { getFlowNodeClasses } from '@/features/editor/utils';
+import { cn } from '@/lib/utils';
+
+interface BaseFlowNodeProps {
+  variant: NodeColorVariant;
+  state: NodeState;
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Base component for React Flow custom nodes
+ * Provides common styling based on color variant and state
+ * Internal use only - not exported from barrel files
+ */
+export function BaseFlowNode({ variant, state, children, className }: BaseFlowNodeProps) {
+  const colors = getFlowNodeClasses(variant, state);
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center rounded-lg border-2 transition-colors',
+        colors.bg,
+        colors.border,
+        colors.text,
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/features/editor/components/flow-nodes/FlowNode/FlowNode.test.tsx
+++ b/src/features/editor/components/flow-nodes/FlowNode/FlowNode.test.tsx
@@ -3,8 +3,8 @@ import { render, screen } from '@testing-library/react';
 import { FlowNode } from './index';
 import type { FlowNodeData } from '@/features/editor/types/editor.types';
 
-// Mock reactflow
-vi.mock('reactflow', () => ({
+// Mock @xyflow/react
+vi.mock('@xyflow/react', () => ({
   Handle: ({ position }: { position: string }) => <div data-testid={`handle-${position}`} />,
   Position: {
     Top: 'top',

--- a/src/features/editor/components/flow-nodes/FlowNode/FlowNode.test.tsx
+++ b/src/features/editor/components/flow-nodes/FlowNode/FlowNode.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FlowNode } from './index';
+import type { FlowNodeData } from '@/features/editor/types/editor.types';
+
+// Mock reactflow
+vi.mock('reactflow', () => ({
+  Handle: ({ position }: { position: string }) => <div data-testid={`handle-${position}`} />,
+  Position: {
+    Top: 'top',
+    Bottom: 'bottom',
+    Left: 'left',
+    Right: 'right',
+  },
+}));
+
+describe('FlowNode', () => {
+  const createMockData = (overrides?: Partial<FlowNodeData>): FlowNodeData => ({
+    title: 'Test Node',
+    description: 'Test Description',
+    resources: [],
+    color: '#000000',
+    locked: false,
+    variant: 'white',
+    state: 'default',
+    index: 1,
+    ...overrides,
+  });
+
+  describe('렌더링', () => {
+    it('Node 제목을 렌더링한다', () => {
+      const data = createMockData({ index: 5 });
+      render(<FlowNode data={data} />);
+
+      expect(screen.getByText('Node_5')).toBeInTheDocument();
+    });
+
+    it('index가 없으면 기본값 1을 사용한다', () => {
+      const data = createMockData();
+      // @ts-expect-error Testing without index
+      delete data.index;
+      render(<FlowNode data={data} />);
+
+      expect(screen.getByText('Node_1')).toBeInTheDocument();
+    });
+  });
+
+  describe('React Flow Integration', () => {
+    it('4개의 connection handles를 렌더링한다', () => {
+      const data = createMockData();
+      render(<FlowNode data={data} />);
+
+      expect(screen.getByTestId('handle-top')).toBeInTheDocument();
+      expect(screen.getByTestId('handle-bottom')).toBeInTheDocument();
+      expect(screen.getByTestId('handle-left')).toBeInTheDocument();
+      expect(screen.getByTestId('handle-right')).toBeInTheDocument();
+    });
+  });
+
+  describe('색상 Variants', () => {
+    const variants = ['white', 'black', 'blue', 'purple', 'red', 'orange'] as const;
+
+    it.each(variants)('%s variant를 default state로 렌더링한다', (variant) => {
+      const data = createMockData({ variant, state: 'default' });
+      render(<FlowNode data={data} />);
+
+      expect(screen.getByText('Node_1')).toBeInTheDocument();
+    });
+
+    it.each(variants)('%s variant를 focus state로 렌더링한다', (variant) => {
+      const data = createMockData({ variant, state: 'focus' });
+      render(<FlowNode data={data} />);
+
+      expect(screen.getByText('Node_1')).toBeInTheDocument();
+    });
+  });
+
+  describe('Selected State', () => {
+    it('selected가 true일 때 focus state를 적용한다', () => {
+      const data = createMockData({ state: 'default' });
+      const { container } = render(<FlowNode data={data} selected={true} />);
+
+      // BaseFlowNode가 focus state로 렌더링되는지 확인
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it('selected가 false일 때 data의 state를 사용한다', () => {
+      const data = createMockData({ state: 'default' });
+      const { container } = render(<FlowNode data={data} selected={false} />);
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/editor/components/flow-nodes/FlowNode/index.tsx
+++ b/src/features/editor/components/flow-nodes/FlowNode/index.tsx
@@ -1,4 +1,4 @@
-import { Handle, Position } from 'reactflow';
+import { Handle, Position } from '@xyflow/react';
 
 import type { FlowNodeData } from '@/features/editor/types/editor.types';
 import { getFlowNodeClasses } from '@/features/editor/utils';

--- a/src/features/editor/components/flow-nodes/FlowNode/index.tsx
+++ b/src/features/editor/components/flow-nodes/FlowNode/index.tsx
@@ -1,0 +1,57 @@
+import { Handle, Position } from 'reactflow';
+
+import type { FlowNodeData } from '@/features/editor/types/editor.types';
+import { getFlowNodeClasses } from '@/features/editor/utils';
+import { cn } from '@/lib/utils';
+
+import { BaseFlowNode } from '../BaseFlowNode';
+
+interface FlowNodeProps {
+  data: FlowNodeData;
+  selected?: boolean;
+}
+
+/**
+ * React Flow custom node component with 4 connection handles
+ * Displays "Node_N" title where N is the node index
+ */
+export function FlowNode({ data, selected }: FlowNodeProps) {
+  const { variant, state, index = 1 } = data;
+  const nodeState = selected ? 'focus' : state;
+  const colors = getFlowNodeClasses(variant, nodeState);
+
+  return (
+    <BaseFlowNode
+      variant={variant}
+      state={nodeState}
+      className="relative h-[60px] w-[120px] px-5 py-2.5"
+    >
+      {/* Connection Handles */}
+      <Handle
+        type="source"
+        position={Position.Top}
+        className={cn('!border-background !h-1.5 !w-1.5 !rounded-full !border-2', colors.handle)}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        className={cn('!border-background !h-1.5 !w-1.5 !rounded-full !border-2', colors.handle)}
+      />
+      <Handle
+        type="source"
+        position={Position.Left}
+        className={cn('!border-background !h-1.5 !w-1.5 !rounded-full !border-2', colors.handle)}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className={cn('!border-background !h-1.5 !w-1.5 !rounded-full !border-2', colors.handle)}
+      />
+
+      {/* Node Title */}
+      <div className="flex flex-col justify-center text-base leading-6 font-medium whitespace-nowrap">
+        Node_{index}
+      </div>
+    </BaseFlowNode>
+  );
+}

--- a/src/features/editor/components/flow-nodes/FlowSection/FlowSection.test.tsx
+++ b/src/features/editor/components/flow-nodes/FlowSection/FlowSection.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FlowSection } from './index';
+import type { FlowSectionData } from '@/features/editor/types/editor.types';
+import { EDITOR_MESSAGES } from '@/constants/messages';
+
+describe('FlowSection', () => {
+  const createMockData = (overrides?: Partial<FlowSectionData>): FlowSectionData => ({
+    title: '빈 섹션',
+    color: '#000000',
+    locked: false,
+    variant: 'white',
+    state: 'default',
+    ...overrides,
+  });
+
+  describe('렌더링', () => {
+    it('섹션 제목을 렌더링한다', () => {
+      const data = createMockData({ title: '테스트 섹션' });
+      render(<FlowSection data={data} />);
+
+      expect(screen.getByText('테스트 섹션')).toBeInTheDocument();
+    });
+
+    it('title이 없으면 기본 메시지를 렌더링한다', () => {
+      const data = createMockData({ title: '' });
+      render(<FlowSection data={data} />);
+
+      expect(screen.getByText(EDITOR_MESSAGES.FLOW_SECTION_DEFAULT_TITLE)).toBeInTheDocument();
+    });
+  });
+
+  describe('색상 Variants', () => {
+    const variants = ['white', 'black', 'blue', 'purple', 'red', 'orange'] as const;
+
+    it.each(variants)('%s variant를 default state로 렌더링한다', (variant) => {
+      const data = createMockData({ variant, state: 'default' });
+      render(<FlowSection data={data} />);
+
+      expect(screen.getByText('빈 섹션')).toBeInTheDocument();
+    });
+
+    it.each(variants)('%s variant를 focus state로 렌더링한다', (variant) => {
+      const data = createMockData({ variant, state: 'focus' });
+      render(<FlowSection data={data} />);
+
+      expect(screen.getByText('빈 섹션')).toBeInTheDocument();
+    });
+  });
+
+  describe('Selected State', () => {
+    it('selected가 true일 때 focus state를 적용한다', () => {
+      const data = createMockData({ state: 'default' });
+      const { container } = render(<FlowSection data={data} selected={true} />);
+
+      // Focus state corner handles가 렌더링되는지 확인
+      const handles = container.querySelectorAll('.border-blue-600');
+      expect(handles.length).toBeGreaterThan(0);
+    });
+
+    it('selected가 false일 때 focus handles를 표시하지 않는다', () => {
+      const data = createMockData({ state: 'default' });
+      const { container } = render(<FlowSection data={data} selected={false} />);
+
+      const handles = container.querySelectorAll('.border-blue-600');
+      expect(handles.length).toBe(0);
+    });
+  });
+
+  describe('구조', () => {
+    it('200x200px 컨테이너를 렌더링한다', () => {
+      const data = createMockData();
+      const { container } = render(<FlowSection data={data} />);
+
+      const containerElement = container.querySelector('.h-\\[200px\\]');
+      expect(containerElement).toBeInTheDocument();
+      expect(containerElement).toHaveClass('w-full');
+    });
+  });
+});

--- a/src/features/editor/components/flow-nodes/FlowSection/index.tsx
+++ b/src/features/editor/components/flow-nodes/FlowSection/index.tsx
@@ -1,0 +1,55 @@
+import { EDITOR_MESSAGES } from '@/constants/messages';
+import type { FlowSectionData } from '@/features/editor/types/editor.types';
+import { getFlowNodeClasses } from '@/features/editor/utils';
+import { cn } from '@/lib/utils';
+
+interface FlowSectionProps {
+  data: FlowSectionData;
+  selected?: boolean;
+}
+
+/**
+ * React Flow custom section component
+ * Container element with title badge and empty content area
+ * No connection handles
+ */
+export function FlowSection({ data, selected }: FlowSectionProps) {
+  const { variant, state, title } = data;
+  const sectionState = selected ? 'focus' : state;
+  const colors = getFlowNodeClasses(variant, sectionState);
+
+  const displayTitle = title || EDITOR_MESSAGES.FLOW_SECTION_DEFAULT_TITLE;
+
+  return (
+    <div className="flex w-[200px] flex-col items-start gap-1">
+      {/* Title Badge */}
+      <div
+        className={cn(
+          'flex items-center justify-center rounded px-2 py-1 text-sm font-medium',
+          colors.badge,
+        )}
+      >
+        {displayTitle}
+      </div>
+
+      {/* Empty Container */}
+      <div
+        className={cn(
+          'bg-background h-[200px] w-full rounded-lg border-2 transition-colors',
+          colors.border,
+          sectionState === 'focus' && 'relative',
+        )}
+      >
+        {/* Focus State Corner Handles */}
+        {sectionState === 'focus' && (
+          <>
+            <div className="bg-background absolute -top-1.5 -left-1.5 h-3 w-3 rounded-sm border-2 border-blue-600" />
+            <div className="bg-background absolute -top-1.5 -right-1.5 h-3 w-3 rounded-sm border-2 border-blue-600" />
+            <div className="bg-background absolute -bottom-1.5 -left-1.5 h-3 w-3 rounded-sm border-2 border-blue-600" />
+            <div className="bg-background absolute -right-1.5 -bottom-1.5 h-3 w-3 rounded-sm border-2 border-blue-600" />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/editor/components/flow-nodes/FlowText/FlowText.test.tsx
+++ b/src/features/editor/components/flow-nodes/FlowText/FlowText.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FlowText } from './index';
+import type { FlowTextData } from '@/features/editor/types/editor.types';
+import { EDITOR_MESSAGES } from '@/constants/messages';
+
+describe('FlowText', () => {
+  const createMockData = (overrides?: Partial<FlowTextData>): FlowTextData => ({
+    content: 'Text',
+    fontSize: 14,
+    fontWeight: 'normal',
+    color: '#000000',
+    locked: false,
+    variant: 'white',
+    state: 'default',
+    ...overrides,
+  });
+
+  describe('렌더링', () => {
+    it('텍스트 내용을 렌더링한다', () => {
+      const data = createMockData({ content: '테스트 텍스트' });
+      render(<FlowText data={data} />);
+
+      expect(screen.getByText('테스트 텍스트')).toBeInTheDocument();
+    });
+
+    it('content가 없으면 기본 메시지를 렌더링한다', () => {
+      const data = createMockData({ content: '' });
+      render(<FlowText data={data} />);
+
+      expect(screen.getByText(EDITOR_MESSAGES.FLOW_TEXT_DEFAULT_CONTENT)).toBeInTheDocument();
+    });
+  });
+
+  describe('폰트 스타일링', () => {
+    it('fontSize를 적용한다', () => {
+      const data = createMockData({ fontSize: 24 });
+      const { container } = render(<FlowText data={data} />);
+
+      const textElement = container.firstChild as HTMLElement;
+      expect(textElement).toHaveStyle({ fontSize: '24px' });
+    });
+
+    it('fontSize가 없으면 기본값 14를 사용한다', () => {
+      const data = createMockData();
+      // @ts-expect-error Testing without fontSize
+      delete data.fontSize;
+      const { container } = render(<FlowText data={data} />);
+
+      const textElement = container.firstChild as HTMLElement;
+      expect(textElement).toHaveStyle({ fontSize: '14px' });
+    });
+
+    it('fontWeight normal을 적용한다', () => {
+      const data = createMockData({ fontWeight: 'normal' });
+      const { container } = render(<FlowText data={data} />);
+
+      const textElement = container.firstChild as HTMLElement;
+      expect(textElement).toHaveStyle({ fontWeight: 400 });
+    });
+
+    it('fontWeight bold를 적용한다', () => {
+      const data = createMockData({ fontWeight: 'bold' });
+      const { container } = render(<FlowText data={data} />);
+
+      const textElement = container.firstChild as HTMLElement;
+      expect(textElement).toHaveStyle({ fontWeight: 600 });
+    });
+  });
+
+  describe('색상 Variants', () => {
+    const variants = ['white', 'black', 'blue', 'purple', 'red', 'orange'] as const;
+
+    it.each(variants)('%s variant를 default state로 렌더링한다', (variant) => {
+      const data = createMockData({ variant, state: 'default' });
+      render(<FlowText data={data} />);
+
+      expect(screen.getByText('Text')).toBeInTheDocument();
+    });
+
+    it.each(variants)('%s variant를 focus state로 렌더링한다', (variant) => {
+      const data = createMockData({ variant, state: 'focus' });
+      render(<FlowText data={data} />);
+
+      expect(screen.getByText('Text')).toBeInTheDocument();
+    });
+  });
+
+  describe('Selected State', () => {
+    it('selected가 true일 때 focus state를 적용한다', () => {
+      const data = createMockData({ state: 'default' });
+      const { container } = render(<FlowText data={data} selected={true} />);
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+
+    it('selected가 false일 때 data의 state를 사용한다', () => {
+      const data = createMockData({ state: 'default' });
+      const { container } = render(<FlowText data={data} selected={false} />);
+
+      expect(container.firstChild).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/editor/components/flow-nodes/FlowText/index.tsx
+++ b/src/features/editor/components/flow-nodes/FlowText/index.tsx
@@ -1,0 +1,34 @@
+import { EDITOR_MESSAGES } from '@/constants/messages';
+import type { FlowTextData } from '@/features/editor/types/editor.types';
+import { getFlowNodeClasses } from '@/features/editor/utils';
+import { cn } from '@/lib/utils';
+
+interface FlowTextProps {
+  data: FlowTextData;
+  selected?: boolean;
+}
+
+/**
+ * React Flow custom text component
+ * Simple text label with customizable font size and weight
+ * No border or connection handles
+ */
+export function FlowText({ data, selected }: FlowTextProps) {
+  const { variant, state, content, fontSize = 14, fontWeight = 'normal' } = data;
+  const textState = selected ? 'focus' : state;
+  const colors = getFlowNodeClasses(variant, textState);
+
+  const displayContent = content || EDITOR_MESSAGES.FLOW_TEXT_DEFAULT_CONTENT;
+
+  return (
+    <div
+      className={cn('min-w-[80px] px-1 transition-colors', colors.text)}
+      style={{
+        fontSize: `${fontSize}px`,
+        fontWeight: fontWeight === 'bold' ? 600 : 400,
+      }}
+    >
+      {displayContent}
+    </div>
+  );
+}

--- a/src/features/editor/components/flow-nodes/index.ts
+++ b/src/features/editor/components/flow-nodes/index.ts
@@ -1,0 +1,4 @@
+export { FlowNode } from './FlowNode';
+export { FlowSection } from './FlowSection';
+export { FlowText } from './FlowText';
+// BaseFlowNode is internal only - not exported

--- a/src/features/editor/components/index.ts
+++ b/src/features/editor/components/index.ts
@@ -1,5 +1,5 @@
-export { ResourceInput, ToolbarDropdown, ToolbarItem } from './atoms';
-export { EditorHeader, EditorToolbar } from './molecules';
+export { AIMenu, ResourceInput, ToolbarDropdown, ToolbarItem } from './atoms';
+export { EditorHeader, EditorToolbar, ResourceDisplay } from './molecules';
 export {
   LineSidebar,
   MultiSelectionSidebar,
@@ -7,3 +7,4 @@ export {
   SectionSidebar,
   TextSidebar,
 } from './organisms';
+export { FlowNode, FlowSection, FlowText } from './flow-nodes';

--- a/src/features/editor/types/editor.types.ts
+++ b/src/features/editor/types/editor.types.ts
@@ -74,6 +74,38 @@ export interface AIMenuItem {
   icon: React.ReactNode;
 }
 
+// React Flow node types
+export type NodeColorVariant = 'white' | 'black' | 'blue' | 'purple' | 'red' | 'orange';
+export type NodeState = 'default' | 'focus';
+
+/**
+ * React Flow custom node data extending NodeData with visual variants
+ */
+export interface FlowNodeData extends NodeData {
+  variant: NodeColorVariant;
+  state: NodeState;
+  index?: number;
+}
+
+/**
+ * React Flow custom section data extending SectionData with visual variants
+ */
+export interface FlowSectionData extends SectionData {
+  variant: NodeColorVariant;
+  state: NodeState;
+}
+
+/**
+ * React Flow custom text data extending TextData with visual variants
+ */
+export interface FlowTextData extends TextData {
+  variant: NodeColorVariant;
+  state: NodeState;
+}
+
+export type FlowNodeType = 'custom-node' | 'custom-section' | 'custom-text';
+
+
 // Dropdown item type
 export interface ToolbarDropdownItem {
   icon: React.ReactNode;

--- a/src/features/editor/utils/flow-node-colors.ts
+++ b/src/features/editor/utils/flow-node-colors.ts
@@ -1,0 +1,111 @@
+import type { NodeColorVariant, NodeState } from '../types/editor.types';
+
+/**
+ * Color variant mapping for React Flow custom nodes
+ * Provides Tailwind classes for 6 color variants and 2 states (default/focus)
+ */
+export const FLOW_NODE_COLORS = {
+  white: {
+    default: {
+      bg: 'bg-white',
+      border: 'border-border',
+      text: 'text-foreground',
+      badge: 'bg-muted text-muted-foreground',
+      handle: 'bg-primary',
+    },
+    focus: {
+      bg: 'bg-white',
+      border: 'border-blue-400',
+      text: 'text-foreground',
+      badge: 'bg-blue-500 text-white',
+      handle: 'bg-primary',
+    },
+  },
+  black: {
+    default: {
+      bg: 'bg-primary',
+      border: 'border-border',
+      text: 'text-primary-foreground',
+      badge: 'bg-primary text-primary-foreground',
+      handle: 'bg-primary',
+    },
+    focus: {
+      bg: 'bg-primary',
+      border: 'border-blue-400',
+      text: 'text-primary-foreground',
+      badge: 'bg-blue-500 text-white',
+      handle: 'bg-primary',
+    },
+  },
+  blue: {
+    default: {
+      bg: 'bg-blue-600',
+      border: 'border-border',
+      text: 'text-white',
+      badge: 'bg-blue-500 text-white',
+      handle: 'bg-primary',
+    },
+    focus: {
+      bg: 'bg-blue-600',
+      border: 'border-blue-400',
+      text: 'text-white',
+      badge: 'bg-blue-500 text-white',
+      handle: 'bg-primary',
+    },
+  },
+  purple: {
+    default: {
+      bg: 'bg-violet-600',
+      border: 'border-border',
+      text: 'text-white',
+      badge: 'bg-violet-500 text-white',
+      handle: 'bg-primary',
+    },
+    focus: {
+      bg: 'bg-violet-600',
+      border: 'border-blue-400',
+      text: 'text-white',
+      badge: 'bg-violet-500 text-white',
+      handle: 'bg-primary',
+    },
+  },
+  red: {
+    default: {
+      bg: 'bg-rose-600',
+      border: 'border-border',
+      text: 'text-white',
+      badge: 'bg-rose-500 text-white',
+      handle: 'bg-primary',
+    },
+    focus: {
+      bg: 'bg-rose-600',
+      border: 'border-blue-400',
+      text: 'text-white',
+      badge: 'bg-rose-500 text-white',
+      handle: 'bg-primary',
+    },
+  },
+  orange: {
+    default: {
+      bg: 'bg-amber-600',
+      border: 'border-border',
+      text: 'text-white',
+      badge: 'bg-amber-500 text-white',
+      handle: 'bg-primary',
+    },
+    focus: {
+      bg: 'bg-amber-600',
+      border: 'border-blue-400',
+      text: 'text-white',
+      badge: 'bg-amber-500 text-white',
+      handle: 'bg-primary',
+    },
+  },
+} as const;
+
+/**
+ * Get Tailwind class names for a specific color variant and state
+ */
+export function getFlowNodeClasses(variant: NodeColorVariant, state: NodeState) {
+  return FLOW_NODE_COLORS[variant][state];
+}

--- a/src/features/editor/utils/index.ts
+++ b/src/features/editor/utils/index.ts
@@ -1,0 +1,1 @@
+export { FLOW_NODE_COLORS, getFlowNodeClasses } from './flow-node-colors';


### PR DESCRIPTION
## Summary

- Implement FlowNode, FlowSection, FlowText components with React Flow integration
- Add BaseFlowNode for shared styling logic
- Add color variant mapping utility (6 colors × 2 states)
- Migrated from reactflow to @xyflow/react for React 19 compatibility

## Changes

### New Components
- `FlowNode`: Custom node with 4 connection handles
- `FlowSection`: Section container with title badge
- `FlowText`: Text label component
- `BaseFlowNode`: Internal base component for shared styling

### Utilities
- `flow-node-colors.ts`: Color variant mapping utility

### Types
- Extended `editor.types.ts` with Flow-specific types
- `NodeColorVariant`, `NodeState`, `FlowNodeData`, etc.

### Integration
- Merged with PR #50 (AI components)
- All message constants and types coexist

## Test Results

✅ 264 editor tests passed
✅ All lint checks passed
✅ Build successful

## Files Changed

- 16 files changed, 1141 insertions(+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new flow editor components (nodes, sections, text) with six color variants and interactive selection states.
  * Implemented dynamic styling system with focus state support for enhanced visual feedback.

* **Tests**
  * Added comprehensive test coverage for new flow components including rendering, styling, and state behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->