### PR TITLE
feat(#60): implement Jotai atoms and EditorTemplate

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -15,4 +15,6 @@ export const EDITOR_MESSAGES = {
   FLOW_NODE_DEFAULT_TITLE: 'Node',
   FLOW_SECTION_DEFAULT_TITLE: '섹션',
   FLOW_TEXT_DEFAULT_CONTENT: '텍스트',
+  EDITOR_LOADING: '에디터 로딩 중...',
+  ROADMAP_UNTITLED: '새 로드맵',
 } as const;

--- a/src/features/editor/components/flow-nodes/FlowNode/FlowNode.test.tsx
+++ b/src/features/editor/components/flow-nodes/FlowNode/FlowNode.test.tsx
@@ -20,7 +20,7 @@ describe('FlowNode', () => {
     description: 'Test Description',
     resources: [],
     color: '#000000',
-    locked: false,
+    isLocked: false,
     variant: 'white',
     state: 'default',
     index: 1,
@@ -37,7 +37,6 @@ describe('FlowNode', () => {
 
     it('index가 없으면 기본값 1을 사용한다', () => {
       const data = createMockData();
-      // @ts-expect-error Testing without index
       delete data.index;
       render(<FlowNode data={data} />);
 

--- a/src/features/editor/components/flow-nodes/FlowSection/FlowSection.test.tsx
+++ b/src/features/editor/components/flow-nodes/FlowSection/FlowSection.test.tsx
@@ -8,7 +8,7 @@ describe('FlowSection', () => {
   const createMockData = (overrides?: Partial<FlowSectionData>): FlowSectionData => ({
     title: '빈 섹션',
     color: '#000000',
-    locked: false,
+    isLocked: false,
     variant: 'white',
     state: 'default',
     ...overrides,

--- a/src/features/editor/components/flow-nodes/FlowText/FlowText.test.tsx
+++ b/src/features/editor/components/flow-nodes/FlowText/FlowText.test.tsx
@@ -10,7 +10,7 @@ describe('FlowText', () => {
     fontSize: 14,
     fontWeight: 'normal',
     color: '#000000',
-    locked: false,
+    isLocked: false,
     variant: 'white',
     state: 'default',
     ...overrides,
@@ -56,7 +56,7 @@ describe('FlowText', () => {
       const { container } = render(<FlowText data={data} />);
 
       const textElement = container.firstChild as HTMLElement;
-      expect(textElement).toHaveStyle({ fontWeight: 400 });
+      expect(textElement).toHaveStyle({ fontWeight: '400' });
     });
 
     it('fontWeight bold를 적용한다', () => {
@@ -64,7 +64,7 @@ describe('FlowText', () => {
       const { container } = render(<FlowText data={data} />);
 
       const textElement = container.firstChild as HTMLElement;
-      expect(textElement).toHaveStyle({ fontWeight: 600 });
+      expect(textElement).toHaveStyle({ fontWeight: '600' });
     });
   });
 

--- a/src/features/editor/components/index.ts
+++ b/src/features/editor/components/index.ts
@@ -8,3 +8,4 @@ export {
   TextSidebar,
 } from './organisms';
 export { FlowNode, FlowSection, FlowText } from './flow-nodes';
+export { EditorTemplate } from './templates';

--- a/src/features/editor/components/templates/EditorTemplate/EditorTemplate.test.tsx
+++ b/src/features/editor/components/templates/EditorTemplate/EditorTemplate.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { EditorTemplate } from './index';
+
+describe('EditorTemplate', () => {
+  it('children을 렌더링한다', () => {
+    render(
+      <EditorTemplate>
+        <div data-testid="canvas">Canvas Content</div>
+      </EditorTemplate>,
+    );
+
+    expect(screen.getByTestId('canvas')).toBeInTheDocument();
+    expect(screen.getByText('Canvas Content')).toBeInTheDocument();
+  });
+
+  it('header를 렌더링한다', () => {
+    render(
+      <EditorTemplate header={<div data-testid="header">Header</div>}>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+  });
+
+  it('toolbar를 렌더링한다', () => {
+    render(
+      <EditorTemplate toolbar={<div data-testid="toolbar">Toolbar</div>}>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    expect(screen.getByTestId('toolbar')).toBeInTheDocument();
+  });
+
+  it('sidebar를 렌더링한다', () => {
+    render(
+      <EditorTemplate sidebar={<div data-testid="sidebar">Sidebar</div>}>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+  });
+
+  it('모든 섹션을 동시에 렌더링한다', () => {
+    render(
+      <EditorTemplate
+        header={<div data-testid="header">Header</div>}
+        toolbar={<div data-testid="toolbar">Toolbar</div>}
+        sidebar={<div data-testid="sidebar">Sidebar</div>}
+      >
+        <div data-testid="canvas">Canvas</div>
+      </EditorTemplate>,
+    );
+
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+    expect(screen.getByTestId('toolbar')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+    expect(screen.getByTestId('canvas')).toBeInTheDocument();
+  });
+
+  it('header가 fixed positioning을 가진다', () => {
+    render(
+      <EditorTemplate header={<div data-testid="header">Header</div>}>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    const headerContainer = screen.getByTestId('header').parentElement;
+    expect(headerContainer).toHaveClass('fixed');
+    expect(headerContainer).toHaveClass('top-0');
+  });
+
+  it('toolbar가 fixed positioning을 가진다', () => {
+    render(
+      <EditorTemplate toolbar={<div data-testid="toolbar">Toolbar</div>}>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    const toolbarContainer = screen.getByTestId('toolbar').parentElement;
+    expect(toolbarContainer).toHaveClass('fixed');
+    expect(toolbarContainer).toHaveClass('bottom-4');
+  });
+
+  it('canvas가 absolute positioning을 가진다', () => {
+    render(
+      <EditorTemplate>
+        <div data-testid="canvas">Canvas</div>
+      </EditorTemplate>,
+    );
+
+    const canvasContainer = screen.getByTestId('canvas').parentElement;
+    expect(canvasContainer).toHaveClass('absolute');
+    expect(canvasContainer).toHaveClass('inset-0');
+  });
+
+  it('커스텀 className이 적용된다', () => {
+    const { container } = render(
+      <EditorTemplate className="custom-class">
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+
+  it('header가 없으면 렌더링하지 않는다', () => {
+    const { container } = render(
+      <EditorTemplate>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    const headers = container.querySelectorAll('.fixed.top-0');
+    expect(headers).toHaveLength(0);
+  });
+
+  it('toolbar가 없으면 렌더링하지 않는다', () => {
+    const { container } = render(
+      <EditorTemplate>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    const toolbars = container.querySelectorAll('.fixed.bottom-4');
+    expect(toolbars).toHaveLength(0);
+  });
+});

--- a/src/features/editor/components/templates/EditorTemplate/index.tsx
+++ b/src/features/editor/components/templates/EditorTemplate/index.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils';
+
+export interface EditorTemplateProps {
+  children: React.ReactNode; // React Flow canvas
+  header?: React.ReactNode; // EditorHeader
+  toolbar?: React.ReactNode; // EditorToolbar
+  sidebar?: React.ReactNode; // Dynamic sidebar
+  className?: string;
+}
+
+/**
+ * Editor page layout template
+ * Provides fixed positioning for header, toolbar, sidebar, and canvas
+ */
+export function EditorTemplate({
+  children,
+  header,
+  toolbar,
+  sidebar,
+  className,
+}: EditorTemplateProps) {
+  return (
+    <div className={cn('relative h-screen w-screen overflow-hidden', className)}>
+      {/* Header (top, fixed) */}
+      {header && <div className="fixed top-0 right-0 left-0 z-40">{header}</div>}
+
+      {/* Canvas (absolute, full viewport) */}
+      <div className="absolute inset-0">{children}</div>
+
+      {/* Toolbar (bottom center, fixed) */}
+      {toolbar && <div className="fixed bottom-4 left-1/2 z-40 -translate-x-1/2">{toolbar}</div>}
+
+      {/* Sidebar (right, conditional) */}
+      {sidebar}
+    </div>
+  );
+}

--- a/src/features/editor/components/templates/index.ts
+++ b/src/features/editor/components/templates/index.ts
@@ -1,0 +1,1 @@
+export { EditorTemplate } from './EditorTemplate';

--- a/src/features/editor/index.ts
+++ b/src/features/editor/index.ts
@@ -4,12 +4,25 @@ export {
   ToolbarItem,
   EditorHeader,
   EditorToolbar,
+  EditorTemplate,
   LineSidebar,
   MultiSelectionSidebar,
   NodeSidebar,
   SectionSidebar,
   TextSidebar,
 } from './components';
+export {
+  editorToolbarModeAtom,
+  selectedNodeIdsAtom,
+  selectedEdgeIdsAtom,
+  selectionTypeAtom,
+  flowNodesAtom,
+  flowEdgesAtom,
+  sidebarOpenAtom,
+  saveStatusAtom,
+  roadmapTitleAtom,
+  roadmapIsLockedAtom,
+} from './stores/editor-atoms';
 export type {
   Resource,
   EditorToolbarMode,

--- a/src/features/editor/stores/editor-atoms.ts
+++ b/src/features/editor/stores/editor-atoms.ts
@@ -1,0 +1,95 @@
+import { atom } from 'jotai';
+
+import type { EditorToolbarMode, SaveStatus, SelectionType } from '../types/editor.types';
+import type { Node, Edge } from '@xyflow/react';
+
+/**
+ * Toolbar mode state
+ * null indicates no mode is active (default/selection mode)
+ */
+export const editorToolbarModeAtom = atom<EditorToolbarMode | null>(null);
+
+/**
+ * Selected node IDs
+ */
+export const selectedNodeIdsAtom = atom<string[]>([]);
+
+/**
+ * Selected edge IDs
+ */
+export const selectedEdgeIdsAtom = atom<string[]>([]);
+
+/**
+ * Derived atom: current selection type
+ * Determines which sidebar to display based on selection
+ */
+export const selectionTypeAtom = atom<SelectionType | null>((get) => {
+  const nodeIds = get(selectedNodeIdsAtom);
+  const edgeIds = get(selectedEdgeIdsAtom);
+  const nodes = get(flowNodesAtom);
+
+  // No selection
+  if (nodeIds.length === 0 && edgeIds.length === 0) {
+    return null;
+  }
+
+  // Multiple items selected (mixed)
+  if (nodeIds.length + edgeIds.length > 1) {
+    return 'mixed';
+  }
+
+  // Single node selected - determine node type
+  if (nodeIds.length === 1) {
+    const node = nodes.find((n) => n.id === nodeIds[0]);
+    if (!node) return null;
+
+    switch (node.type) {
+      case 'custom-node':
+        return 'node';
+      case 'custom-section':
+        return 'section';
+      case 'custom-text':
+        return 'text';
+      default:
+        return 'node';
+    }
+  }
+
+  // Single edge selected
+  if (edgeIds.length === 1) {
+    return 'line';
+  }
+
+  return null;
+});
+
+/**
+ * React Flow nodes data (synchronized with React Flow state)
+ */
+export const flowNodesAtom = atom<Node[]>([]);
+
+/**
+ * React Flow edges data (synchronized with React Flow state)
+ */
+export const flowEdgesAtom = atom<Edge[]>([]);
+
+/**
+ * Sidebar open/close state
+ */
+export const sidebarOpenAtom = atom<boolean>(false);
+
+/**
+ * Save status for the roadmap
+ */
+export const saveStatusAtom = atom<SaveStatus>('default');
+
+/**
+ * Roadmap title
+ */
+export const roadmapTitleAtom = atom<string>('새 로드맵');
+
+/**
+ * Roadmap lock status
+ * When locked, the roadmap is read-only
+ */
+export const roadmapIsLockedAtom = atom<boolean>(false);

--- a/src/features/editor/types/editor.types.ts
+++ b/src/features/editor/types/editor.types.ts
@@ -105,7 +105,6 @@ export interface FlowTextData extends TextData {
 
 export type FlowNodeType = 'custom-node' | 'custom-section' | 'custom-text';
 
-
 // Dropdown item type
 export interface ToolbarDropdownItem {
   icon: React.ReactNode;


### PR DESCRIPTION
## 📋 관련 이슈

Closes #60

## 📝 작업 내용

- Jotai atoms 구현 (`editor-atoms.ts`)
  - toolbar, selection, sidebar, save status 상태 관리
- EditorTemplate 레이아웃 구현
  - header (fixed top), canvas (absolute), toolbar (fixed bottom center), sidebar (fixed right)
  - z-index 관리로 계층 구조 확립
- 테스트 작성
- Barrel exports 업데이트

**의존성**: #59 (ColorPicker 사용)

## ✅ 체크리스트

- [x] 관련 이슈 연결
- [x] 셀프 코드 리뷰 완료
- [x] 컨벤션 준수 확인
- [x] 린트/빌드 통과 확인