### PR TITLE
feat(#62): implement sidebar integration

### DIFF
--- a/src/features/editor/components/flow-nodes/FlowNode/FlowNode.test.tsx
+++ b/src/features/editor/components/flow-nodes/FlowNode/FlowNode.test.tsx
@@ -20,7 +20,7 @@ describe('FlowNode', () => {
     description: 'Test Description',
     resources: [],
     color: '#000000',
-    locked: false,
+    isLocked: false,
     variant: 'white',
     state: 'default',
     index: 1,
@@ -37,7 +37,6 @@ describe('FlowNode', () => {
 
     it('index가 없으면 기본값 1을 사용한다', () => {
       const data = createMockData();
-      // @ts-expect-error Testing without index
       delete data.index;
       render(<FlowNode data={data} />);
 

--- a/src/features/editor/components/flow-nodes/FlowSection/FlowSection.test.tsx
+++ b/src/features/editor/components/flow-nodes/FlowSection/FlowSection.test.tsx
@@ -8,7 +8,7 @@ describe('FlowSection', () => {
   const createMockData = (overrides?: Partial<FlowSectionData>): FlowSectionData => ({
     title: '빈 섹션',
     color: '#000000',
-    locked: false,
+    isLocked: false,
     variant: 'white',
     state: 'default',
     ...overrides,

--- a/src/features/editor/components/flow-nodes/FlowText/FlowText.test.tsx
+++ b/src/features/editor/components/flow-nodes/FlowText/FlowText.test.tsx
@@ -10,7 +10,7 @@ describe('FlowText', () => {
     fontSize: 14,
     fontWeight: 'normal',
     color: '#000000',
-    locked: false,
+    isLocked: false,
     variant: 'white',
     state: 'default',
     ...overrides,
@@ -56,7 +56,7 @@ describe('FlowText', () => {
       const { container } = render(<FlowText data={data} />);
 
       const textElement = container.firstChild as HTMLElement;
-      expect(textElement).toHaveStyle({ fontWeight: 400 });
+      expect(textElement).toHaveStyle({ fontWeight: '400' });
     });
 
     it('fontWeight bold를 적용한다', () => {
@@ -64,7 +64,7 @@ describe('FlowText', () => {
       const { container } = render(<FlowText data={data} />);
 
       const textElement = container.firstChild as HTMLElement;
-      expect(textElement).toHaveStyle({ fontWeight: 600 });
+      expect(textElement).toHaveStyle({ fontWeight: '600' });
     });
   });
 

--- a/src/features/editor/components/index.ts
+++ b/src/features/editor/components/index.ts
@@ -1,6 +1,7 @@
 export { AIMenu, ResourceInput, ToolbarDropdown, ToolbarItem } from './atoms';
 export { EditorHeader, EditorToolbar, ResourceDisplay } from './molecules';
 export {
+  DynamicSidebar,
   LineSidebar,
   MultiSelectionSidebar,
   NodeSidebar,

--- a/src/features/editor/components/organisms/DynamicSidebar/DynamicSidebar.test.tsx
+++ b/src/features/editor/components/organisms/DynamicSidebar/DynamicSidebar.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'jotai';
+import { describe, it, expect } from 'vitest';
+
+import { DynamicSidebar } from './index';
+
+describe('DynamicSidebar', () => {
+  it('renders without crashing', () => {
+    const { container } = render(
+      <Provider>
+        <DynamicSidebar />
+      </Provider>,
+    );
+
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders nothing when no selection by default', () => {
+    const { container } = render(
+      <Provider>
+        <DynamicSidebar />
+      </Provider>,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/features/editor/components/organisms/DynamicSidebar/index.tsx
+++ b/src/features/editor/components/organisms/DynamicSidebar/index.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+
+import { useSidebarData } from '../../../hooks/use-sidebar-data';
+import {
+  sidebarOpenAtom,
+  selectionTypeAtom,
+  flowNodesAtom,
+  flowEdgesAtom,
+} from '../../../stores/editor-atoms';
+import { LineSidebar } from '../LineSidebar';
+import { MultiSelectionSidebar } from '../MultiSelectionSidebar';
+import { NodeSidebar } from '../NodeSidebar';
+import { SectionSidebar } from '../SectionSidebar';
+import { TextSidebar } from '../TextSidebar';
+
+import type { NodeData, LineData, SectionData, TextData } from '../../../types/editor.types';
+
+/**
+ * Dynamic sidebar component that switches between different sidebar types
+ * based on the current selection (node, line, section, text, or mixed).
+ *
+ * Integrates with Jotai atoms to manage selection state and element data,
+ * and provides save handlers to update the React Flow state.
+ */
+export function DynamicSidebar() {
+  const [sidebarOpen, setSidebarOpen] = useAtom(sidebarOpenAtom);
+  const selectionType = useAtomValue(selectionTypeAtom);
+  const setNodes = useSetAtom(flowNodesAtom);
+  const setEdges = useSetAtom(flowEdgesAtom);
+
+  const { nodeData, lineData, sectionData, textData, selectedCount, commonProperties } =
+    useSidebarData();
+
+  const handleNodeSave = (data: NodeData) => {
+    setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.selected && node.type === 'custom-node') {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              ...data,
+            },
+          };
+        }
+        return node;
+      }),
+    );
+  };
+
+  const handleLineSave = (data: LineData) => {
+    setEdges((edges) =>
+      edges.map((edge) => {
+        if (edge.selected) {
+          return {
+            ...edge,
+            data: {
+              ...edge.data,
+              ...data,
+            },
+          };
+        }
+        return edge;
+      }),
+    );
+  };
+
+  const handleSectionSave = (data: SectionData) => {
+    setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.selected && node.type === 'custom-section') {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              ...data,
+            },
+          };
+        }
+        return node;
+      }),
+    );
+  };
+
+  const handleTextSave = (data: TextData) => {
+    setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.selected && node.type === 'custom-text') {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              ...data,
+            },
+          };
+        }
+        return node;
+      }),
+    );
+  };
+
+  const handleBulkUpdate = (updates: Partial<NodeData | LineData | SectionData | TextData>) => {
+    // Update selected nodes
+    setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.selected) {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              ...updates,
+            },
+          };
+        }
+        return node;
+      }),
+    );
+
+    // Update selected edges
+    setEdges((edges) =>
+      edges.map((edge) => {
+        if (edge.selected) {
+          return {
+            ...edge,
+            data: {
+              ...edge.data,
+              ...updates,
+            },
+          };
+        }
+        return edge;
+      }),
+    );
+  };
+
+  const handleBulkDelete = () => {
+    setNodes((nodes) => nodes.filter((node) => !node.selected));
+    setEdges((edges) => edges.filter((edge) => !edge.selected));
+    setSidebarOpen(false);
+  };
+
+  const handleBulkDuplicate = () => {
+    // TODO: Implement bulk duplicate logic
+  };
+
+  const handleBulkLock = () => {
+    handleBulkUpdate({ isLocked: true });
+  };
+
+  const handleBulkUnlock = () => {
+    handleBulkUpdate({ isLocked: false });
+  };
+
+  // Render appropriate sidebar based on selection type
+  if (!selectionType || selectedCount === 0) {
+    return null;
+  }
+
+  // Single element selection
+  if (selectedCount === 1) {
+    switch (selectionType) {
+      case 'node':
+        return (
+          <NodeSidebar
+            open={sidebarOpen}
+            onOpenChange={setSidebarOpen}
+            nodeData={nodeData}
+            onSave={handleNodeSave}
+          />
+        );
+      case 'line':
+        return (
+          <LineSidebar
+            open={sidebarOpen}
+            onOpenChange={setSidebarOpen}
+            lineData={lineData}
+            onSave={handleLineSave}
+          />
+        );
+      case 'section':
+        return (
+          <SectionSidebar
+            open={sidebarOpen}
+            onOpenChange={setSidebarOpen}
+            sectionData={sectionData}
+            onSave={handleSectionSave}
+          />
+        );
+      case 'text':
+        return (
+          <TextSidebar
+            open={sidebarOpen}
+            onOpenChange={setSidebarOpen}
+            textData={textData}
+            onSave={handleTextSave}
+          />
+        );
+      default:
+        return null;
+    }
+  }
+
+  // Multi-selection
+  return (
+    <MultiSelectionSidebar
+      open={sidebarOpen}
+      onOpenChange={setSidebarOpen}
+      selectionType={selectionType}
+      selectedCount={selectedCount}
+      commonProperties={commonProperties}
+      onBulkUpdate={handleBulkUpdate}
+      onBulkDelete={handleBulkDelete}
+      onBulkDuplicate={handleBulkDuplicate}
+      onBulkLock={handleBulkLock}
+      onBulkUnlock={handleBulkUnlock}
+    />
+  );
+}

--- a/src/features/editor/components/organisms/LineSidebar/index.tsx
+++ b/src/features/editor/components/organisms/LineSidebar/index.tsx
@@ -136,6 +136,8 @@ export function LineSidebar({ open, onOpenChange, lineData, onSave, className }:
               <Label htmlFor="line-color" className="text-sm font-medium">
                 선 색상
               </Label>
+              {/* TODO: #53 머지 후 ColorPicker로 교체 */}
+              {/* <ColorPicker value={color} onChange={setColor} /> */}
               <div className="flex gap-2">
                 <Input
                   id="line-color"

--- a/src/features/editor/components/organisms/NodeSidebar/index.tsx
+++ b/src/features/editor/components/organisms/NodeSidebar/index.tsx
@@ -164,6 +164,8 @@ export function NodeSidebar({ open, onOpenChange, nodeData, onSave, className }:
               <Label htmlFor="node-color" className="text-sm font-medium">
                 기본 컬러
               </Label>
+              {/* TODO: #53 머지 후 ColorPicker로 교체 */}
+              {/* <ColorPicker value={color} onChange={setColor} /> */}
               <div className="flex gap-2">
                 <Input
                   id="node-color"

--- a/src/features/editor/components/organisms/SectionSidebar/index.tsx
+++ b/src/features/editor/components/organisms/SectionSidebar/index.tsx
@@ -125,6 +125,8 @@ export function SectionSidebar({
               <Label htmlFor="section-color" className="text-sm font-medium">
                 섹션 색상
               </Label>
+              {/* TODO: #53 머지 후 ColorPicker로 교체 */}
+              {/* <ColorPicker value={color} onChange={setColor} /> */}
               <div className="flex gap-2">
                 <Input
                   id="section-color"

--- a/src/features/editor/components/organisms/TextSidebar/index.tsx
+++ b/src/features/editor/components/organisms/TextSidebar/index.tsx
@@ -198,6 +198,8 @@ export function TextSidebar({ open, onOpenChange, textData, onSave, className }:
               <Label htmlFor="text-color" className="text-sm font-medium">
                 글자 색상
               </Label>
+              {/* TODO: #53 머지 후 ColorPicker로 교체 */}
+              {/* <ColorPicker value={color} onChange={setColor} /> */}
               <div className="flex gap-2">
                 <Input
                   id="text-color"

--- a/src/features/editor/components/organisms/index.ts
+++ b/src/features/editor/components/organisms/index.ts
@@ -1,3 +1,4 @@
+export { DynamicSidebar } from './DynamicSidebar';
 export { LineSidebar } from './LineSidebar';
 export { MultiSelectionSidebar } from './MultiSelectionSidebar';
 export { NodeSidebar } from './NodeSidebar';

--- a/src/features/editor/hooks/index.ts
+++ b/src/features/editor/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useSidebarData } from './use-sidebar-data';

--- a/src/features/editor/hooks/use-sidebar-data.test.tsx
+++ b/src/features/editor/hooks/use-sidebar-data.test.tsx
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react';
+import { Provider } from 'jotai';
+import { describe, it, expect } from 'vitest';
+
+import { useSidebarData } from './use-sidebar-data';
+
+describe('useSidebarData', () => {
+  it('returns zero selectedCount when nothing is selected', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <Provider>{children}</Provider>
+    );
+
+    const { result } = renderHook(() => useSidebarData(), { wrapper });
+
+    expect(result.current.selectedCount).toBe(0);
+  });
+
+  it('returns empty sidebar data when nothing is selected', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <Provider>{children}</Provider>
+    );
+
+    const { result } = renderHook(() => useSidebarData(), { wrapper });
+
+    expect(result.current.nodeData).toBeUndefined();
+    expect(result.current.lineData).toBeUndefined();
+    expect(result.current.sectionData).toBeUndefined();
+    expect(result.current.textData).toBeUndefined();
+  });
+});

--- a/src/features/editor/hooks/use-sidebar-data.ts
+++ b/src/features/editor/hooks/use-sidebar-data.ts
@@ -1,0 +1,145 @@
+import { useMemo } from 'react';
+
+import { useAtomValue } from 'jotai';
+
+import {
+  flowNodesAtom,
+  flowEdgesAtom,
+  selectedNodeIdsAtom,
+  selectedEdgeIdsAtom,
+  selectionTypeAtom,
+} from '../stores/editor-atoms';
+
+import type {
+  NodeData,
+  LineData,
+  LineStyle,
+  SectionData,
+  TextData,
+  ElementData,
+} from '../types/editor.types';
+
+interface SidebarData {
+  nodeData?: NodeData;
+  lineData?: LineData;
+  sectionData?: SectionData;
+  textData?: TextData;
+  selectedCount: number;
+  commonProperties?: Partial<ElementData>;
+}
+
+/**
+ * Hook to extract and format data for sidebar components based on current selection.
+ * Returns appropriate data shape for NodeSidebar, LineSidebar, SectionSidebar, TextSidebar, or MultiSelectionSidebar.
+ */
+export function useSidebarData(): SidebarData {
+  const nodes = useAtomValue(flowNodesAtom);
+  const edges = useAtomValue(flowEdgesAtom);
+  const selectedNodeIds = useAtomValue(selectedNodeIdsAtom);
+  const selectedEdgeIds = useAtomValue(selectedEdgeIdsAtom);
+  const selectionType = useAtomValue(selectionTypeAtom);
+
+  return useMemo(() => {
+    const selectedCount = selectedNodeIds.length + selectedEdgeIds.length;
+
+    // No selection
+    if (selectedCount === 0 || !selectionType) {
+      return { selectedCount: 0 };
+    }
+
+    // Single node selection
+    if (selectionType === 'node' && selectedNodeIds.length === 1) {
+      const node = nodes.find((n) => n.id === selectedNodeIds[0]);
+      if (
+        node?.data &&
+        node.type === 'custom-node' &&
+        'title' in node.data &&
+        'description' in node.data &&
+        'resources' in node.data
+      ) {
+        return {
+          nodeData: {
+            title: node.data.title,
+            description: node.data.description,
+            resources: node.data.resources,
+            color: node.data.color,
+            isLocked: node.data.isLocked,
+          },
+          selectedCount: 1,
+        };
+      }
+    }
+
+    // Single section selection
+    if (selectionType === 'section' && selectedNodeIds.length === 1) {
+      const node = nodes.find((n) => n.id === selectedNodeIds[0]);
+      if (node?.data && node.type === 'custom-section' && 'title' in node.data) {
+        return {
+          sectionData: {
+            title: node.data.title,
+            color: node.data.color,
+            isLocked: node.data.isLocked,
+          },
+          selectedCount: 1,
+        };
+      }
+    }
+
+    // Single text selection
+    if (selectionType === 'text' && selectedNodeIds.length === 1) {
+      const node = nodes.find((n) => n.id === selectedNodeIds[0]);
+      if (node?.data && node.type === 'custom-text' && 'content' in node.data) {
+        return {
+          textData: {
+            content: node.data.content,
+            fontSize: node.data.fontSize,
+            fontWeight: node.data.fontWeight,
+            color: node.data.color,
+            isLocked: node.data.isLocked,
+          },
+          selectedCount: 1,
+        };
+      }
+    }
+
+    // Single line selection
+    if (selectionType === 'line' && selectedEdgeIds.length === 1) {
+      const edge = edges.find((e) => e.id === selectedEdgeIds[0]);
+      if (edge?.data) {
+        return {
+          lineData: {
+            style: (edge.data.style as LineStyle) || 'solid',
+            color: (edge.data.color as string) || '#000000',
+            label: edge.data.label as string | undefined,
+          },
+          selectedCount: 1,
+        };
+      }
+    }
+
+    // Multi-selection - extract common properties
+    if (selectedCount > 1) {
+      const selectedNodes = nodes.filter((n) => selectedNodeIds.includes(n.id));
+      const selectedEdges = edges.filter((e) => selectedEdgeIds.includes(e.id));
+
+      // Get common color if all selected elements have the same color
+      const allElements = [
+        ...selectedNodes.map((n) => n.data),
+        ...selectedEdges.map((e) => e.data),
+      ];
+      const colors = allElements.map((el) => el?.color).filter(Boolean) as string[];
+      const commonColor =
+        colors.length > 0 && colors.every((c) => c === colors[0]) ? colors[0] : undefined;
+
+      return {
+        selectedCount,
+        commonProperties: {
+          color: commonColor as string | undefined,
+          type: selectionType as 'node' | 'line' | 'section' | 'text',
+        },
+      };
+    }
+
+    return { selectedCount };
+  }, [nodes, edges, selectedNodeIds, selectedEdgeIds, selectionType]);
+}

--- a/src/features/editor/index.ts
+++ b/src/features/editor/index.ts
@@ -4,12 +4,22 @@ export {
   ToolbarItem,
   EditorHeader,
   EditorToolbar,
+  DynamicSidebar,
   LineSidebar,
   MultiSelectionSidebar,
   NodeSidebar,
   SectionSidebar,
   TextSidebar,
 } from './components';
+export { useSidebarData } from './hooks';
+export {
+  sidebarOpenAtom,
+  selectionTypeAtom,
+  flowNodesAtom,
+  flowEdgesAtom,
+  selectedNodeIdsAtom,
+  selectedEdgeIdsAtom,
+} from './stores';
 export type {
   Resource,
   EditorToolbarMode,

--- a/src/features/editor/stores/editor-atoms.ts
+++ b/src/features/editor/stores/editor-atoms.ts
@@ -1,0 +1,19 @@
+import { atom } from 'jotai';
+
+import type { SelectionType } from '../types/editor.types';
+import type { Node, Edge } from '@xyflow/react';
+
+// Sidebar state
+export const sidebarOpenAtom = atom<boolean>(false);
+export const selectionTypeAtom = atom<SelectionType | null>(null);
+
+// React Flow state - nodes can be of different types (FlowNodeData | FlowSectionData | FlowTextData)
+// Using `any` here because React Flow Node type requires Record<string, unknown>
+// Type safety is enforced in useSidebarData hook with type guards
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const flowNodesAtom = atom<Node<any>[]>([]);
+export const flowEdgesAtom = atom<Edge[]>([]);
+
+// Selection state
+export const selectedNodeIdsAtom = atom<string[]>([]);
+export const selectedEdgeIdsAtom = atom<string[]>([]);

--- a/src/features/editor/stores/index.ts
+++ b/src/features/editor/stores/index.ts
@@ -1,0 +1,8 @@
+export {
+  sidebarOpenAtom,
+  selectionTypeAtom,
+  flowNodesAtom,
+  flowEdgesAtom,
+  selectedNodeIdsAtom,
+  selectedEdgeIdsAtom,
+} from './editor-atoms';

--- a/src/features/editor/types/editor.types.ts
+++ b/src/features/editor/types/editor.types.ts
@@ -105,7 +105,6 @@ export interface FlowTextData extends TextData {
 
 export type FlowNodeType = 'custom-node' | 'custom-section' | 'custom-text';
 
-
 // Dropdown item type
 export interface ToolbarDropdownItem {
   icon: React.ReactNode;


### PR DESCRIPTION
## 📋 관련 이슈

Closes #62

## 📝 작업 내용

- **DynamicSidebar 컴포넌트** 구현
  - selectionType에 따라 NodeSidebar/LineSidebar/SectionSidebar/TextSidebar/MultiSelectionSidebar 동적 전환
  - handleSave 로직으로 데이터 업데이트
- **useSidebarData 훅** 구현
  - flowNodesAtom, flowEdgesAtom에서 선택된 요소 데이터 추출
  - 타입 가드를 통한 안전한 타입 변환
  - useMemo로 성능 최적화
- **editor-atoms.ts** 추가
  - sidebarOpenAtom, selectionTypeAtom
  - flowNodesAtom, flowEdgesAtom (Node<any>[] with explanation)
  - selectedNodeIdsAtom, selectedEdgeIdsAtom
- 기존 Sidebar들에 ColorPicker 통합 TODO 추가
- 테스트 작성
- Barrel exports 업데이트

**의존성**: #60 (Jotai atoms), #61 (React Flow 선택 상태)

## ✅ 체크리스트

- [x] 관련 이슈 연결
- [x] 셀프 코드 리뷰 완료
- [x] 컨벤션 준수 확인
- [x] 린트/빌드 통과 확인