### PR TITLE
feat(#66): implement 2D gradient ColorPicker with react-colorful

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@sentry/nextjs": "^10.32.1",
     "@tanstack/react-query": "^5.90.12",
+    "@xyflow/react": "^12.3.5",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.19",
@@ -44,9 +45,9 @@
     "next": "16.1.0",
     "next-seo": "^7.0.1",
     "react": "19.2.3",
+    "react-colorful": "^5.6.1",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.69.0",
-    "@xyflow/react": "^12.3.5",
     "tailwind-merge": "^3.4.0",
     "zod": "^3.25.76"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       react:
         specifier: 19.2.3
         version: 19.2.3
+      react-colorful:
+        specifier: ^5.6.1
+        version: 5.6.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
@@ -4743,6 +4746,12 @@ packages:
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  react-colorful@5.6.1:
+    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
@@ -10310,6 +10319,11 @@ snapshots:
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  react-colorful@5.6.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
     dependencies:

--- a/src/features/editor/components/atoms/ColorPicker/ColorPicker.test.tsx
+++ b/src/features/editor/components/atoms/ColorPicker/ColorPicker.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ColorPicker } from './index';
+
+describe('ColorPicker', () => {
+  it('renders preset colors', () => {
+    render(<ColorPicker value="#000000" onChange={vi.fn()} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBe(5);
+  });
+
+  it('calls onChange when preset color clicked', () => {
+    const onChange = vi.fn();
+    render(<ColorPicker value="#000000" onChange={onChange} />);
+
+    const blueButton = screen.getByLabelText('Select color #3B82F6');
+    fireEvent.click(blueButton);
+
+    expect(onChange).toHaveBeenCalledWith('#3B82F6');
+  });
+
+  it('renders HexColorPicker from react-colorful', () => {
+    const { container } = render(<ColorPicker value="#000000" onChange={vi.fn()} />);
+
+    expect(container.querySelector('.react-colorful')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <ColorPicker value="#000000" onChange={vi.fn()} className="custom-class" />,
+    );
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveClass('custom-class');
+  });
+
+  it('uses custom preset colors when provided', () => {
+    const customColors = ['#FF6B6B', '#4ECDC4', '#45B7D1'];
+    render(<ColorPicker value="#FF6B6B" onChange={vi.fn()} presetColors={customColors} />);
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBe(3);
+  });
+
+  it('highlights selected preset color', () => {
+    render(<ColorPicker value="#3B82F6" onChange={vi.fn()} />);
+
+    const blueButton = screen.getByLabelText('Select color #3B82F6');
+    expect(blueButton).toHaveClass('ring-2', 'ring-primary', 'ring-offset-2');
+  });
+});

--- a/src/features/editor/components/atoms/ColorPicker/index.tsx
+++ b/src/features/editor/components/atoms/ColorPicker/index.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import { HexColorPicker } from 'react-colorful';
+import 'react-colorful/dist/index.css';
 
 import { cn } from '@/lib/utils';
 
@@ -21,6 +22,11 @@ export function ColorPicker({
 }: ColorPickerProps) {
   const [currentColor, setCurrentColor] = useState(value);
 
+  // Sync internal state with external value prop
+  useEffect(() => {
+    setCurrentColor(value);
+  }, [value]);
+
   const handleChange = (newColor: string) => {
     setCurrentColor(newColor);
     onChange(newColor);
@@ -33,10 +39,11 @@ export function ColorPicker({
         {presetColors.map((color) => (
           <button
             key={color}
+            type="button"
             onClick={() => handleChange(color)}
             className={cn(
               'h-8 w-8 rounded-full border-2 transition-all',
-              currentColor === color
+              currentColor.toLowerCase() === color.toLowerCase()
                 ? 'ring-primary ring-2 ring-offset-2'
                 : 'border-gray-300 hover:scale-110',
             )}

--- a/src/features/editor/components/atoms/ColorPicker/index.tsx
+++ b/src/features/editor/components/atoms/ColorPicker/index.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+import { HexColorPicker } from 'react-colorful';
+
+import { cn } from '@/lib/utils';
+
+interface ColorPickerProps {
+  value: string;
+  onChange: (color: string) => void;
+  presetColors?: string[];
+  className?: string;
+}
+
+const DEFAULT_COLORS = ['#000000', '#3B82F6', '#8B5CF6', '#EF4444', '#F97316'];
+
+export function ColorPicker({
+  value,
+  onChange,
+  presetColors = DEFAULT_COLORS,
+  className,
+}: ColorPickerProps) {
+  const [currentColor, setCurrentColor] = useState(value);
+
+  const handleChange = (newColor: string) => {
+    setCurrentColor(newColor);
+    onChange(newColor);
+  };
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      {/* 5색 프리셋 */}
+      <div className="flex gap-2">
+        {presetColors.map((color) => (
+          <button
+            key={color}
+            onClick={() => handleChange(color)}
+            className={cn(
+              'h-8 w-8 rounded-full border-2 transition-all',
+              currentColor === color
+                ? 'ring-primary ring-2 ring-offset-2'
+                : 'border-gray-300 hover:scale-110',
+            )}
+            style={{ backgroundColor: color }}
+            aria-label={`Select color ${color}`}
+          />
+        ))}
+      </div>
+
+      {/* 2D 그라디언트 피커 */}
+      <div className="space-y-2">
+        <p className="text-sm font-medium">커스텀</p>
+        <HexColorPicker color={currentColor} onChange={handleChange} />
+      </div>
+    </div>
+  );
+}

--- a/src/features/editor/components/atoms/index.ts
+++ b/src/features/editor/components/atoms/index.ts
@@ -1,4 +1,5 @@
 export { AIMenu } from './AIMenu';
+export { ColorPicker } from './ColorPicker';
 export { ResourceInput } from './ResourceInput';
 export { ToolbarDropdown } from './ToolbarDropdown';
 export { ToolbarItem } from './ToolbarItem';

--- a/src/features/editor/types/editor.types.ts
+++ b/src/features/editor/types/editor.types.ts
@@ -105,7 +105,6 @@ export interface FlowTextData extends TextData {
 
 export type FlowNodeType = 'custom-node' | 'custom-section' | 'custom-text';
 
-
 // Dropdown item type
 export interface ToolbarDropdownItem {
   icon: React.ReactNode;

--- a/src/stories/editor/ColorPicker.stories.tsx
+++ b/src/stories/editor/ColorPicker.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ColorPicker } from '@/features/editor/components/atoms/ColorPicker';
+
+const meta = {
+  title: 'Editor/ColorPicker',
+  component: ColorPicker,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ColorPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: '#3B82F6',
+    onChange: (color) => console.log(color),
+  },
+};
+
+export const CustomPresets: Story = {
+  args: {
+    value: '#FF6B6B',
+    onChange: (color) => console.log(color),
+    presetColors: ['#FF6B6B', '#4ECDC4', '#45B7D1', '#FFA07A', '#98D8C8'],
+  },
+};
+
+export const BlackSelected: Story = {
+  args: {
+    value: '#000000',
+    onChange: (color) => console.log(color),
+  },
+};
+
+export const PurpleSelected: Story = {
+  args: {
+    value: '#8B5CF6',
+    onChange: (color) => console.log(color),
+  },
+};


### PR DESCRIPTION
## 📋 관련 이슈

Closes #66

## 📝 작업 내용

- react-colorful 라이브러리 설치
- ColorPicker 재작성 (2D 그라디언트 + HEX 슬라이더)
- 5색 프리셋 유지 (Black, Blue, Purple, Red, Orange)
- HEX input 제거
- 테스트 작성 (3개 테스트)
- Storybook 업데이트

## ✅ 체크리스트

- [x] 관련 이슈 연결
- [x] 셀프 코드 리뷰 완료
- [x] 컨벤션 준수 확인
- [x] 린트/빌드 통과 확인 (14.3s)
- [x] 테스트 작성 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a color picker component featuring preset color buttons and a hex color gradient selector, with customizable preset colors.

* **Tests**
  * Added comprehensive test suite for the color picker component covering rendering, interaction, and customization.

* **Chores**
  * Updated project dependencies.
  * Added Storybook stories for the color picker component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->