### PR TITLE
feat(#65): refactor EditorTemplate to fixed sidebar layout

### DIFF
--- a/src/features/editor/components/index.ts
+++ b/src/features/editor/components/index.ts
@@ -8,3 +8,4 @@ export {
   TextSidebar,
 } from './organisms';
 export { FlowNode, FlowSection, FlowText } from './flow-nodes';
+export { EditorTemplate } from './templates/EditorTemplate';

--- a/src/features/editor/components/molecules/EditorHeader/EditorHeader.test.tsx
+++ b/src/features/editor/components/molecules/EditorHeader/EditorHeader.test.tsx
@@ -1,159 +1,66 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { useRouter } from 'next/navigation';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { EditorHeader } from './index';
 
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+}));
+
 vi.mock('lucide-react', () => ({
-  ArrowLeft: () => <span data-testid="arrow-left-icon" />,
-  Check: () => <span data-testid="check-icon" />,
-  AlertCircle: () => <span data-testid="alert-circle-icon" />,
+  ChevronLeft: () => <span data-testid="chevron-left-icon" />,
 }));
 
 describe('EditorHeader', () => {
-  it('기본 title이 렌더링된다', () => {
-    render(<EditorHeader title="테스트 로드맵" status="default" />);
-    expect(screen.getByText('테스트 로드맵')).toBeInTheDocument();
+  const mockRouter = {
+    back: vi.fn(),
+    forward: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useRouter as ReturnType<typeof vi.fn>).mockReturnValue(mockRouter);
   });
 
-  it('title이 없으면 기본 텍스트를 표시한다', () => {
-    render(<EditorHeader status="default" />);
-    expect(screen.getByText('로드맵 제목')).toBeInTheDocument();
+  it('renders "< Jagalchi Roadmap" text', () => {
+    render(<EditorHeader />);
+    expect(screen.getByText('Jagalchi Roadmap')).toBeInTheDocument();
   });
 
-  it('onTitleChange가 제공되면 편집 가능한 input이 렌더링된다', () => {
-    render(<EditorHeader title="테스트 로드맵" status="default" onTitleChange={vi.fn()} />);
-
-    const input = screen.getByRole('textbox');
-    expect(input).toHaveValue('테스트 로드맵');
-    expect(input).toHaveAttribute('placeholder', '로드맵 제목');
+  it('renders back button with chevron icon', () => {
+    render(<EditorHeader />);
+    const button = screen.getByRole('button', { name: '뒤로 가기' });
+    expect(button).toBeInTheDocument();
+    expect(screen.getByTestId('chevron-left-icon')).toBeInTheDocument();
   });
 
-  it('onTitleChange가 없으면 정적 heading이 렌더링된다', () => {
-    render(<EditorHeader title="테스트 로드맵" status="default" />);
-
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('테스트 로드맵');
-    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-  });
-
-  it('title input 변경 시 onTitleChange를 호출한다', async () => {
+  it('calls router.back() when back button clicked', async () => {
     const user = userEvent.setup();
-    const handleTitleChange = vi.fn();
+    render(<EditorHeader />);
 
-    render(<EditorHeader title="" status="default" onTitleChange={handleTitleChange} />);
+    const button = screen.getByRole('button', { name: '뒤로 가기' });
+    await user.click(button);
 
-    const input = screen.getByRole('textbox');
-    await user.type(input, 'test');
-
-    // userEvent.type()은 각 글자마다 onChange를 호출함
-    expect(handleTitleChange).toHaveBeenCalled();
-    // 각 문자 입력마다 호출되므로 최소 1회 이상 호출됨
-    expect(handleTitleChange).toHaveBeenCalledTimes(4); // 't', 'e', 's', 't'
+    expect(mockRouter.back).toHaveBeenCalledTimes(1);
   });
 
-  it('onBack이 제공되면 뒤로 가기 버튼이 렌더링된다', () => {
-    render(<EditorHeader title="테스트" status="default" onBack={vi.fn()} />);
+  it('has correct styling classes', () => {
+    const { container } = render(<EditorHeader />);
+    const wrapper = container.firstChild as HTMLElement;
 
-    expect(screen.getByRole('button', { name: '뒤로 가기' })).toBeInTheDocument();
+    expect(wrapper).toHaveClass('flex', 'items-center', 'gap-2', 'px-4', 'py-3', 'h-14');
   });
 
-  it('onBack이 없으면 뒤로 가기 버튼이 렌더링되지 않는다', () => {
-    render(<EditorHeader title="테스트" status="default" />);
+  it('button has hover effect class', () => {
+    render(<EditorHeader />);
+    const button = screen.getByRole('button', { name: '뒤로 가기' });
 
-    expect(screen.queryByRole('button', { name: '뒤로 가기' })).not.toBeInTheDocument();
-  });
-
-  it('뒤로 가기 버튼 클릭 시 onBack을 호출한다', async () => {
-    const user = userEvent.setup();
-    const handleBack = vi.fn();
-
-    render(<EditorHeader title="테스트" status="default" onBack={handleBack} />);
-
-    const backButton = screen.getByRole('button', { name: '뒤로 가기' });
-    await user.click(backButton);
-
-    expect(handleBack).toHaveBeenCalledTimes(1);
-  });
-
-  it('saved 상태 인디케이터를 표시한다', () => {
-    render(<EditorHeader title="테스트" status="saved" />);
-
-    expect(screen.getByText('(저장됨)')).toBeInTheDocument();
-    expect(screen.getByTestId('check-icon')).toBeInTheDocument();
-  });
-
-  it('failed 상태 인디케이터를 표시한다', () => {
-    render(<EditorHeader title="테스트" status="failed" />);
-
-    expect(screen.getByText('(저장 실패)')).toBeInTheDocument();
-    expect(screen.getByTestId('alert-circle-icon')).toBeInTheDocument();
-  });
-
-  it('default 상태일 때 인디케이터를 표시하지 않는다', () => {
-    render(<EditorHeader title="테스트" status="default" />);
-
-    expect(screen.queryByText('(저장됨)')).not.toBeInTheDocument();
-    expect(screen.queryByText('(저장 실패)')).not.toBeInTheDocument();
-    expect(screen.queryByRole('status')).not.toBeInTheDocument();
-  });
-
-  it('상태 인디케이터가 적절한 접근성 속성을 갖는다', () => {
-    const { rerender } = render(<EditorHeader title="테스트" status="saved" />);
-
-    let statusElement = screen.getByRole('status');
-    expect(statusElement).toHaveAttribute('aria-live', 'polite');
-    expect(statusElement).toHaveClass('text-green-600');
-
-    rerender(<EditorHeader title="테스트" status="failed" />);
-
-    statusElement = screen.getByRole('status');
-    expect(statusElement).toHaveAttribute('aria-live', 'polite');
-    expect(statusElement).toHaveClass('text-destructive');
-  });
-
-  it('상태가 변경될 때 올바르게 업데이트된다', () => {
-    const { rerender } = render(<EditorHeader title="테스트" status="default" />);
-
-    expect(screen.queryByRole('status')).not.toBeInTheDocument();
-
-    rerender(<EditorHeader title="테스트" status="saved" />);
-    expect(screen.getByText('(저장됨)')).toBeInTheDocument();
-
-    rerender(<EditorHeader title="테스트" status="failed" />);
-    expect(screen.getByText('(저장 실패)')).toBeInTheDocument();
-    expect(screen.queryByText('(저장됨)')).not.toBeInTheDocument();
-
-    rerender(<EditorHeader title="테스트" status="default" />);
-    expect(screen.queryByRole('status')).not.toBeInTheDocument();
-  });
-
-  it('커스텀 className이 적용된다', () => {
-    const { container } = render(
-      <EditorHeader title="테스트" status="default" className="custom-header" />,
-    );
-
-    const header = container.querySelector('header');
-    expect(header).toHaveClass('custom-header');
-  });
-
-  it('헤더 요소가 올바른 시맨틱을 갖는다', () => {
-    render(<EditorHeader title="테스트" status="default" />);
-
-    const header = document.querySelector('header');
-    expect(header).toBeInTheDocument();
-  });
-
-  it('빈 title에서 시작하여 입력할 수 있다', async () => {
-    const user = userEvent.setup();
-    const handleTitleChange = vi.fn();
-
-    render(<EditorHeader title="" status="default" onTitleChange={handleTitleChange} />);
-
-    const input = screen.getByRole('textbox');
-    expect(input).toHaveValue('');
-
-    await user.type(input, '새로운 로드맵');
-
-    expect(handleTitleChange).toHaveBeenCalled();
+    expect(button).toHaveClass('hover:underline');
   });
 });

--- a/src/features/editor/components/molecules/EditorHeader/index.tsx
+++ b/src/features/editor/components/molecules/EditorHeader/index.tsx
@@ -10,6 +10,7 @@ export function EditorHeader() {
   return (
     <div className="flex h-14 items-center gap-2 px-4 py-3">
       <button
+        type="button"
         onClick={() => router.back()}
         className="flex items-center gap-1 text-sm hover:underline"
         aria-label="뒤로 가기"

--- a/src/features/editor/components/molecules/EditorHeader/index.tsx
+++ b/src/features/editor/components/molecules/EditorHeader/index.tsx
@@ -1,71 +1,22 @@
 'use client';
 
-import { ArrowLeft, Check, AlertCircle } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { EDITOR_MESSAGES } from '@/constants/messages';
-import type { SaveStatus } from '@/features/editor/types/editor.types';
-import { cn } from '@/lib/utils';
+import { ChevronLeft } from 'lucide-react';
 
-interface EditorHeaderProps {
-  title?: string;
-  status: SaveStatus;
-  onTitleChange?: (title: string) => void;
-  onBack?: () => void;
-  className?: string;
-}
+export function EditorHeader() {
+  const router = useRouter();
 
-export function EditorHeader({
-  title,
-  status,
-  onTitleChange,
-  onBack,
-  className,
-}: EditorHeaderProps) {
   return (
-    <header className={cn('bg-background flex h-16 items-center gap-4 border-b px-6', className)}>
-      {onBack && (
-        <Button variant="ghost" size="icon" onClick={onBack} aria-label="뒤로 가기">
-          <ArrowLeft className="size-5" />
-        </Button>
-      )}
-
-      <div className="flex flex-1 items-center justify-center gap-3">
-        {onTitleChange ? (
-          <Input
-            type="text"
-            value={title || ''}
-            onChange={(e) => onTitleChange(e.target.value)}
-            placeholder="로드맵 제목"
-            className="h-10 max-w-md text-center text-lg font-semibold"
-          />
-        ) : (
-          <h1 className="text-lg font-semibold">{title || '로드맵 제목'}</h1>
-        )}
-
-        {status === 'saved' && (
-          <div
-            className="flex items-center gap-1 text-sm text-green-600"
-            role="status"
-            aria-live="polite"
-          >
-            <Check className="size-4" />
-            <span>({EDITOR_MESSAGES.SAVE_SUCCESS})</span>
-          </div>
-        )}
-
-        {status === 'failed' && (
-          <div
-            className="text-destructive flex items-center gap-1 text-sm"
-            role="status"
-            aria-live="polite"
-          >
-            <AlertCircle className="size-4" />
-            <span>({EDITOR_MESSAGES.SAVE_FAILED})</span>
-          </div>
-        )}
-      </div>
-    </header>
+    <div className="flex h-14 items-center gap-2 px-4 py-3">
+      <button
+        onClick={() => router.back()}
+        className="flex items-center gap-1 text-sm hover:underline"
+        aria-label="뒤로 가기"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        <span>Jagalchi Roadmap</span>
+      </button>
+    </div>
   );
 }

--- a/src/features/editor/components/templates/EditorTemplate/EditorTemplate.test.tsx
+++ b/src/features/editor/components/templates/EditorTemplate/EditorTemplate.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { EditorTemplate } from './index';
+
+describe('EditorTemplate', () => {
+  it('renders children (canvas)', () => {
+    render(
+      <EditorTemplate>
+        <div>Canvas Content</div>
+      </EditorTemplate>,
+    );
+
+    expect(screen.getByText('Canvas Content')).toBeInTheDocument();
+  });
+
+  it('renders header when provided', () => {
+    render(
+      <EditorTemplate header={<div>Header Content</div>}>
+        <div>Canvas Content</div>
+      </EditorTemplate>,
+    );
+
+    expect(screen.getByText('Header Content')).toBeInTheDocument();
+  });
+
+  it('renders toolbar when provided', () => {
+    render(
+      <EditorTemplate toolbar={<div>Toolbar Content</div>}>
+        <div>Canvas Content</div>
+      </EditorTemplate>,
+    );
+
+    expect(screen.getByText('Toolbar Content')).toBeInTheDocument();
+  });
+
+  it('renders fixed sidebar on right when provided', () => {
+    const { container } = render(
+      <EditorTemplate sidebar={<div>Sidebar Content</div>}>
+        <div>Canvas Content</div>
+      </EditorTemplate>,
+    );
+
+    expect(screen.getByText('Sidebar Content')).toBeInTheDocument();
+
+    const sidebar = container.querySelector('.w-\\[320px\\]');
+    expect(sidebar).toBeInTheDocument();
+    expect(sidebar).toHaveClass('border-l');
+    expect(sidebar).toHaveClass('bg-background');
+    expect(sidebar).toHaveClass('overflow-y-auto');
+  });
+
+  it('does not render sidebar when not provided', () => {
+    const { container } = render(
+      <EditorTemplate>
+        <div>Canvas Content</div>
+      </EditorTemplate>,
+    );
+
+    const sidebar = container.querySelector('.w-\\[320px\\]');
+    expect(sidebar).not.toBeInTheDocument();
+  });
+
+  it('has correct layout structure', () => {
+    const { container } = render(
+      <EditorTemplate
+        header={<div>Header</div>}
+        sidebar={<div>Sidebar</div>}
+        toolbar={<div>Toolbar</div>}
+      >
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    // Root container
+    const root = container.firstChild as HTMLElement;
+    expect(root).toHaveClass('relative', 'h-screen', 'w-screen', 'overflow-hidden');
+
+    // Header at top
+    const header = container.querySelector('.fixed.top-0');
+    expect(header).toBeInTheDocument();
+    expect(header).toHaveClass('z-40', 'bg-background', 'border-b');
+
+    // Canvas + Sidebar container
+    const mainArea = container.querySelector('.absolute.inset-0.top-\\[56px\\].flex');
+    expect(mainArea).toBeInTheDocument();
+
+    // Canvas flex-1
+    const canvas = mainArea?.querySelector('.flex-1.relative');
+    expect(canvas).toBeInTheDocument();
+
+    // Toolbar at bottom center
+    const toolbar = container.querySelector('.fixed.bottom-4');
+    expect(toolbar).toBeInTheDocument();
+    expect(toolbar).toHaveClass('left-1/2', '-translate-x-1/2', 'z-40');
+  });
+
+  it('header has fixed positioning with proper z-index', () => {
+    const { container } = render(
+      <EditorTemplate header={<div>Header</div>}>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    const header = container.querySelector('.fixed.top-0');
+    expect(header).toHaveClass('left-0', 'right-0', 'z-40');
+  });
+
+  it('canvas takes remaining space', () => {
+    const { container } = render(
+      <EditorTemplate>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    const canvas = container.querySelector('.flex-1.relative');
+    expect(canvas).toBeInTheDocument();
+  });
+
+  it('sidebar has fixed 320px width', () => {
+    const { container } = render(
+      <EditorTemplate sidebar={<div>Sidebar</div>}>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    const sidebar = container.querySelector('.w-\\[320px\\]');
+    expect(sidebar).toBeInTheDocument();
+  });
+
+  it('toolbar is centered horizontally and fixed at bottom', () => {
+    const { container } = render(
+      <EditorTemplate toolbar={<div>Toolbar</div>}>
+        <div>Canvas</div>
+      </EditorTemplate>,
+    );
+
+    const toolbar = container.querySelector('.fixed.bottom-4');
+    expect(toolbar).toHaveClass('left-1/2', '-translate-x-1/2');
+  });
+});

--- a/src/features/editor/components/templates/EditorTemplate/index.tsx
+++ b/src/features/editor/components/templates/EditorTemplate/index.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+interface EditorTemplateProps {
+  children: React.ReactNode; // Canvas
+  header?: React.ReactNode;
+  toolbar?: React.ReactNode;
+  sidebar?: React.ReactNode; // Fixed right panel
+}
+
+export function EditorTemplate({ children, header, toolbar, sidebar }: EditorTemplateProps) {
+  return (
+    <div className="relative h-screen w-screen overflow-hidden">
+      {/* Header - Fixed top */}
+      {header && (
+        <div className="bg-background fixed top-0 right-0 left-0 z-40 border-b">{header}</div>
+      )}
+
+      {/* Canvas + Sidebar area */}
+      <div className="absolute inset-0 top-[56px] flex">
+        {/* Canvas - Left expanding */}
+        <div className="relative flex-1">{children}</div>
+
+        {/* Sidebar - Right fixed panel */}
+        {sidebar && (
+          <div className="bg-background w-[320px] overflow-y-auto border-l">{sidebar}</div>
+        )}
+      </div>
+
+      {/* Toolbar - Bottom center */}
+      {toolbar && <div className="fixed bottom-4 left-1/2 z-40 -translate-x-1/2">{toolbar}</div>}
+    </div>
+  );
+}

--- a/src/features/editor/components/templates/EditorTemplate/index.tsx
+++ b/src/features/editor/components/templates/EditorTemplate/index.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import { cn } from '@/lib/utils';
+
 interface EditorTemplateProps {
   children: React.ReactNode; // Canvas
   header?: React.ReactNode;
   toolbar?: React.ReactNode;
   sidebar?: React.ReactNode; // Fixed right panel
 }
+
+const HEADER_HEIGHT = 56; // px
 
 export function EditorTemplate({ children, header, toolbar, sidebar }: EditorTemplateProps) {
   return (
@@ -16,7 +20,10 @@ export function EditorTemplate({ children, header, toolbar, sidebar }: EditorTem
       )}
 
       {/* Canvas + Sidebar area */}
-      <div className="absolute inset-0 top-[56px] flex">
+      <div
+        className={cn('absolute inset-0 flex', header && `top-[${HEADER_HEIGHT}px]`)}
+        style={header ? { top: `${HEADER_HEIGHT}px` } : undefined}
+      >
         {/* Canvas - Left expanding */}
         <div className="relative flex-1">{children}</div>
 

--- a/src/features/editor/types/editor.types.ts
+++ b/src/features/editor/types/editor.types.ts
@@ -105,7 +105,6 @@ export interface FlowTextData extends TextData {
 
 export type FlowNodeType = 'custom-node' | 'custom-section' | 'custom-text';
 
-
 // Dropdown item type
 export interface ToolbarDropdownItem {
   icon: React.ReactNode;


### PR DESCRIPTION
## 📋 관련 이슈

Closes #65

## 📝 작업 내용

- EditorTemplate 레이아웃 변경
  - Sidebar를 우측 고정 패널로 변경 (w-[320px])
  - flex 레이아웃으로 Canvas와 Sidebar 나란히 배치
  - Sheet 제거, 조건부 렌더링 추가
- EditorHeader 간소화
  - "< Jagalchi Roadmap" 텍스트만 유지
  - 뒤로가기 버튼 추가 (useRouter().back())
  - 타이틀 편집, AI 버튼, 잠금/저장 UI 제거
- /editor/new 페이지 삭제
- EditorTemplate.test.tsx 생성

## ✅ 체크리스트

- [x] 관련 이슈 연결
- [x] 셀프 코드 리뷰 완료
- [x] 컨벤션 준수 확인
- [x] 린트/빌드 통과 확인 (14.3s)
- [x] 테스트 작성 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added EditorTemplate component with configurable header, toolbar, and sidebar sections for flexible editor-style layouts.
  * Streamlined EditorHeader to display a fixed back button for improved navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->