### PR TITLE
feat(#82): 연결선을 빈 공간으로 드래그하여 노드 생성

### DIFF
--- a/.claude/commands/helpmyset.md
+++ b/.claude/commands/helpmyset.md
@@ -1,0 +1,516 @@
+# Sisyphus System Help - Jagalchi Client
+
+**Purpose**: 프로젝트별 설정, 컨벤션, 워크플로우를 한눈에 확인할 수 있는 종합 가이드입니다.
+
+---
+
+## 📚 목차
+
+1. [프로젝트 개요](#프로젝트-개요)
+2. [개발 워크플로우](#개발-워크플로우)
+3. [코드 컨벤션](#코드-컨벤션)
+4. [아키텍처 규칙](#아키텍처-규칙)
+5. [Git & CI/CD](#git--cicd)
+6. [테스트 전략](#테스트-전략)
+7. [문서 참조](#문서-참조)
+
+---
+
+## 프로젝트 개요
+
+### Tech Stack
+- **Framework**: Next.js 16 (App Router) + React 19
+- **Language**: TypeScript (strict mode)
+- **Styling**: Tailwind CSS v4
+- **UI**: shadcn/ui (Radix UI + CVA)
+- **State**: Jotai (client), TanStack Query (server)
+- **Form**: React Hook Form + Zod
+- **Test**: Vitest, Storybook
+- **Build**: pnpm, Husky, ESLint 9
+
+### Project Structure
+
+```
+src/
+├── app/              # Next.js App Router (routes & layouts)
+├── components/ui/    # shadcn/ui components (shared)
+├── features/         # Feature modules (ISOLATED - no cross-import)
+│   ├── auth/
+│   ├── profile/
+│   ├── roadmap-editor/
+│   └── community/
+├── hooks/            # Shared custom hooks
+├── lib/              # Utility functions
+├── types/            # Shared TypeScript types
+└── constants/        # Constants (colors, typography, messages)
+```
+
+### Quick Commands
+
+```bash
+pnpm dev          # Start dev server (http://localhost:3000)
+pnpm build        # Production build
+pnpm lint         # Run ESLint
+pnpm lint --fix   # Auto-fix lint issues
+pnpm test         # Run Vitest
+pnpm storybook    # Start Storybook (http://localhost:6006)
+```
+
+---
+
+## 개발 워크플로우
+
+**⚠️ 모든 작업은 이 4단계를 필수로 따라야 합니다.**
+
+### Phase 1: 작업 시작 전 (Pre-Development)
+
+#### ⚠️ MUST: 브랜치 & 이슈
+
+```bash
+# 브랜치 네이밍
+<type>/#<issue>-<short-desc>
+
+# 예시
+feat/#84-ai-features-ui
+fix/#92-login-error
+refactor/#101-editor-state
+```
+
+**체크리스트**:
+- [ ] ⚠️ Issue 번호 확인 (없으면 생성)
+- [ ] ⚠️ 브랜치 생성
+- [ ] ⚠️ `.github/ISSUE_TEMPLATE/` 템플릿 확인
+
+#### ⚠️ MUST: 복잡도 평가
+
+**Decision Tree**:
+```
+작업 복잡도 판단:
+├─ 1-2 파일 + 명확한 요구사항 → 바로 시작
+├─ 3+ 파일 OR 아키텍처 변경 → EnterPlanMode
+├─ 불명확한 요구사항 → /intake 또는 AskUserQuestion
+└─ UI 작업 + Figma → /intake → FVL 선택
+```
+
+**체크리스트**:
+- [ ] ⚠️ 파일 변경 개수 추정 (3개 이상 → Plan 필수)
+- [ ] ⚠️ EnterPlanMode 사용 여부 결정
+- [ ] ⚠️ TodoWrite로 작업 계획 수립
+
+---
+
+### Phase 2: 개발 중 (Development)
+
+#### ⚠️ MUST: 코드 수정 전
+
+**체크리스트**:
+- [ ] ⚠️ **기존 코드 먼저 Read** (Read tool 사용)
+- [ ] ⚠️ Feature 간 cross-import 금지 확인
+- [ ] ⚠️ Named exports 사용 (default export 금지)
+- [ ] ⚠️ TypeScript strict mode 준수
+
+**Critical Rules**:
+```typescript
+// ✅ Good
+export { LoginForm } from './LoginForm';
+import { Button } from '@/components/ui/button';
+
+// ❌ Bad
+export default LoginForm;
+import { LoginForm } from '@/features/auth/...'; // Cross-feature import
+```
+
+#### ⚠️ MUST: 실시간 추적
+
+**체크리스트**:
+- [ ] ⚠️ TodoWrite로 작업 상태 업데이트
+- [ ] ⚠️ 작업 완료 즉시 체크리스트 업데이트 (배치 금지)
+- [ ] ⚠️ 새 작업 발견 시 Todo 추가
+
+---
+
+### Phase 3: 완료 전 검증 (Pre-Commit)
+
+#### ⚠️ MUST: Sisyphean Checklist
+
+**모든 항목 체크 전까지 commit 금지**:
+- [ ] ⚠️ **TODO LIST**: Zero pending/in_progress tasks
+- [ ] ⚠️ **FUNCTIONALITY**: 요청된 모든 기능 작동
+- [ ] ⚠️ **TESTS**: 모든 테스트 통과
+- [ ] ⚠️ **ERRORS**: 해결되지 않은 에러 0개
+- [ ] ⚠️ **QUALITY**: Production-ready 코드
+
+#### ⚠️ MUST: 빌드 & 린트
+
+```bash
+pnpm lint           # ESLint 검사 (에러 0개)
+pnpm tsc --noEmit   # 타입 체크
+pnpm build          # Production 빌드 (성공)
+```
+
+#### ⚠️ MUST: 셀프 코드 리뷰
+
+- [ ] ⚠️ 불필요한 console.log 제거
+- [ ] ⚠️ 주석 처리된 코드 제거
+- [ ] ⚠️ 사용하지 않는 import 제거
+- [ ] ⚠️ 하드코딩된 값 → 상수로 추출
+
+---
+
+### Phase 4: Commit & PR (Deployment)
+
+#### ⚠️ MUST: Atomic Commits
+
+**형식**:
+```bash
+<type>(<scope>): <subject>
+
+# 예시
+feat(auth): implement social login
+fix(editor): resolve node duplication bug
+refactor(profile): extract contribution utils
+```
+
+**Types**: feat, fix, refactor, perf, test, docs, chore, ai
+
+#### ⚠️ MUST: PR 생성
+
+**체크리스트**:
+- [ ] ⚠️ `.github/PULL_REQUEST_TEMPLATE.md` 작성
+- [ ] ⚠️ 관련 이슈 링크 (`Closes #<issue>`)
+- [ ] ⚠️ 체크리스트 완료
+- [ ] ⚠️ 스크린샷 첨부 (UI 변경 시)
+
+**PR 제목**:
+```
+<type>(#<issue>): <brief description>
+
+# 예시
+feat(#84): add AI features UI to editor toolbar
+```
+
+---
+
+## 코드 컨벤션
+
+### Export Strategy
+
+**⚠️ MUST: Named exports only**
+
+```typescript
+// ✅ Good - Named exports
+export { ComponentA } from './ComponentA';
+export { ComponentB } from './ComponentB';
+export type { TypeA } from './types';
+
+// ❌ Bad - Default exports
+export default ComponentA;
+
+// ❌ Bad - Wildcard exports
+export * from './ComponentA';
+```
+
+### Boolean Variable Naming
+
+**⚠️ MUST: Use prefixes**
+
+```typescript
+// ✅ Good
+const [isVisible, setIsVisible] = useState(false);
+const [hasError, setHasError] = useState(false);
+const [canSubmit, setCanSubmit] = useState(false);
+
+// ✅ Good - Enum exception
+const [mode, setMode] = useState<'show' | 'edit'>('show');
+
+// ❌ Bad
+const [visible, setVisible] = useState(false);
+```
+
+### UI String Management
+
+**⚠️ MUST: Use constants**
+
+```typescript
+// src/constants/messages.ts
+export const PROFILE_MESSAGES = {
+  BIO_TITLE: '자기소개',
+  COMPLETED_ROADMAP: '완주한 로드맵',
+} as const;
+
+// Component usage
+import { PROFILE_MESSAGES } from '@/constants/messages';
+<h3>{PROFILE_MESSAGES.BIO_TITLE}</h3>
+```
+
+### TypeScript Type Exports
+
+**⚠️ MUST: Use `export type` for re-exports**
+
+```typescript
+// ✅ Good
+export type { Contribution } from './utils/contribution-utils';
+export { COLORS, getLevel } from './utils/contribution-utils';
+
+// ❌ Bad - Build error with isolatedModules
+export { Contribution, COLORS, getLevel } from './utils/contribution-utils';
+```
+
+### Naming Conventions
+
+| Target | Style | Example |
+|--------|-------|---------|
+| Variables/Functions | camelCase | `userName`, `getUserData` |
+| Constants | UPPER_SNAKE | `MAX_COUNT`, `API_URL` |
+| Components/Types | PascalCase | `LoginButton`, `UserData` |
+| Files (component) | PascalCase | `LoginButton.tsx` |
+| Files (general) | kebab-case | `use-auth.ts` |
+| Folders | kebab-case | `user-profile/` |
+| Boolean | is/has/can/should | `isLoading`, `hasError` |
+
+---
+
+## 아키텍처 규칙
+
+### Feature Isolation
+
+**⚠️ MUST: NO cross-feature imports**
+
+```
+Dependency Rules:
+app (routing/pages)
+  ↓ can import
+features (isolated)
+  ↓ can import
+shared (components, hooks, lib, types, constants)
+```
+
+**✅ ALLOWED**:
+```typescript
+// Inside feature
+import { Button } from '@/components/ui/button';
+import { useAuth } from './hooks/use-auth';
+```
+
+**❌ FORBIDDEN**:
+```typescript
+// Cross-feature import
+import { LoginForm } from '@/features/auth/components/organisms/LoginForm';
+```
+
+### Component Organization (Atomic Design)
+
+```
+features/auth/components/
+├── atoms/       # GoogleAuthButton, FormErrorMessage
+├── molecules/   # FormField, PasswordInput
+├── organisms/   # LoginForm, RegisterForm
+└── templates/   # AuthCard
+```
+
+### Import Path Aliases
+
+```typescript
+'@/components/*'  →  src/components/*
+'@/lib/*'         →  src/lib/*
+'@/features/*'    →  src/features/*
+'@/app/*'         →  src/app/*
+```
+
+---
+
+## Git & CI/CD
+
+### Branch Strategy
+
+```bash
+# Main branches
+main     # Production (protected)
+develop  # Development (default)
+
+# Feature branches
+feat/#<issue>-<desc>
+fix/#<issue>-<desc>
+refactor/#<issue>-<desc>
+```
+
+### Git Hooks (Husky)
+
+```bash
+# pre-commit
+pnpm lint-staged  # Auto-fix + format
+
+# commit-msg
+pnpm commitlint   # Conventional commits validation
+```
+
+### GitHub Actions Workflows
+
+1. **CI** - Lint, Type check, Build, Test
+2. **Auto Label** - PR/Issue 자동 라벨링
+3. **Discord Notify** - PR/Deploy 알림
+4. **Netlify Preview** - Preview 배포
+5. **PR Comment** - 자동 코멘트
+6. **Release** - 릴리즈 자동화
+7. **Storybook** - Storybook 빌드/배포
+
+### GitHub Templates
+
+- **PR Template**: `.github/PULL_REQUEST_TEMPLATE.md`
+- **Issue Templates** (6개):
+  - `ai-task.yml`
+  - `bug.yml`
+  - `chore.yml`
+  - `docs.yml`
+  - `feature.yml`
+  - `refactor.yml`
+
+---
+
+## 테스트 전략
+
+### Tools
+
+- **Vitest**: Unit tests (hooks, utils, logic)
+- **Testing Library**: Component tests
+- **Storybook**: Visual documentation & testing
+
+### Test Location
+
+```
+features/[feature]/__tests__/
+├── LoginForm.test.tsx
+├── use-auth.test.ts
+└── auth.utils.test.ts
+```
+
+### Coverage Goals
+
+| Feature | Target | Current |
+|---------|--------|---------|
+| Editor | 100% | 100% ✅ |
+| Auth | 80% | 50% 🟡 |
+| Profile | 80% | 59% 🟡 |
+
+### Writing Tests
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByText('Click me')).toBeInTheDocument();
+  });
+});
+```
+
+---
+
+## 문서 참조
+
+### 프로젝트 문서 (.claude/)
+
+| 파일 | 내용 |
+|------|------|
+| `CLAUDE.md` | 프로젝트 메인 가이드 |
+| `design_system_rules.md` | Figma 통합 가이드 (800줄) |
+| `rules/development-workflow.md` | 개발 워크플로우 (이 문서 기반) |
+| `rules/architecture.md` | Feature isolation, 의존성 규칙 |
+| `rules/code-style.md` | 네이밍, Import 순서 |
+| `rules/workflow.md` | Git, Branch, Commit 규칙 |
+| `rules/testing.md` | 테스트 전략 |
+| `rules/do-not-touch.md` | 수정 금지 파일 |
+
+### 글로벌 문서 (~/.claude/)
+
+| 파일 | 내용 |
+|------|------|
+| `CLAUDE.md` | Sisyphus 시스템 개요 |
+| `sisyphus-system.md` | 스킬, 에이전트, 커맨드 상세 |
+| `git-planning-guide.md` | Git 마스터리 & Planning |
+| `engineering-practices.md` | 에러, 디버깅, 보안, 리팩토링 |
+| `fvl-policy.md` | Frontend 검증 레벨 |
+| `intake-policy.md` | 요청 정제 시스템 |
+| `performance-guide.md` | React 렌더링, 번들, 네트워크 |
+| `pr-review-guide.md` | PR 작성/리뷰 체크리스트 |
+| `cicd-guide.md` | CI/CD, 환경별 배포 |
+| `accessibility-guide.md` | WCAG 2.1 체크리스트 |
+| `design-system-guide.md` | 디자인 시스템 관리 |
+| `pm-dev-collaboration.md` | 기획-개발 협업 |
+| `figma-workflow-guide.md` | Figma → 코드 워크플로우 |
+
+---
+
+## Workflow Commands (Quick Reference)
+
+### 실행 명령어
+
+| Command | Phase | Usage |
+|---------|-------|-------|
+| `/intake <request>` | Phase 1 | 요구사항 정제 (Figma 통합) |
+| `/plan <task>` | Phase 1 | 계획 수립 (Prometheus) |
+| `/ultrawork <task>` | Phase 2 | 병렬 실행 최대 성능 |
+| `/ui <level> <scope>` | Phase 2 | Frontend 검증 (FVL) |
+| `/sisyphus <task>` | Phase 2 | 멀티 에이전트 오케스트레이션 |
+| `/git-master` | Phase 4 | Atomic commits 도움 |
+| `/helpmyset` | Any | 이 가이드 표시 |
+
+### 검증 명령어
+
+| Command | Usage |
+|---------|-------|
+| `pnpm lint` | ESLint 검사 |
+| `pnpm lint --fix` | 자동 수정 |
+| `pnpm build` | Production 빌드 |
+| `pnpm test` | 테스트 실행 |
+| `pnpm storybook` | Storybook 실행 |
+
+---
+
+## Quick Checklist
+
+**매 작업마다 이것만 확인하세요**:
+
+```
+[ ] ⚠️ Phase 1: 브랜치 생성 + 계획 수립
+[ ] ⚠️ Phase 2: 기존 코드 Read + TodoWrite 업데이트
+[ ] ⚠️ Phase 3: Sisyphean Checklist + Lint + Build
+[ ] ⚠️ Phase 4: Atomic commits + PR 템플릿
+```
+
+**이 4단계만 지키면 90%의 문제 예방 가능합니다.**
+
+---
+
+## Enforcement Policy
+
+### High Severity (작업 중단 필수)
+
+- Phase 1 없이 코딩 시작
+- 기존 코드 안 읽고 수정
+- Cross-feature import 사용
+- Phase 3 체크리스트 미완료 상태로 commit
+- Lint/Build 실패 상태로 PR 생성
+
+### Medium Severity (경고 후 계속)
+
+- TodoWrite 미사용
+- 테스트 미작성 (신규 기능)
+- JSDoc 미작성 (복잡한 로직)
+
+### Low Severity (무시 가능)
+
+- Storybook 미작성
+- PR 크기 500줄 초과
+
+---
+
+## Contact & Support
+
+- **Issue 생성**: `.github/ISSUE_TEMPLATE/` 사용
+- **PR 리뷰 요청**: `@codeowners` 태그
+- **문서 개선**: `.claude/` 파일 수정 후 PR
+
+**이 가이드는 항상 최신 상태를 유지합니다. 의문 사항이 있으면 먼저 이 문서를 확인하세요.**

--- a/.claude/rules/development-workflow.md
+++ b/.claude/rules/development-workflow.md
@@ -1,0 +1,431 @@
+# Development Workflow
+
+**Purpose**: 모든 개발 작업의 필수 프로세스를 명시합니다. Claude Code가 이 워크플로우를 **무조건 따라야** 합니다.
+
+**Enforcement Policy**:
+- ⚠️ **MUST** - 필수 단계 (위반 시 작업 중단, 사용자 확인 필요)
+- 💡 **SHOULD** - 권장 단계 (경고 후 계속 진행 가능)
+
+---
+
+## 📋 Phase 1: 작업 시작 전 (Pre-Development)
+
+### ⚠️ MUST: 브랜치 & 이슈 확인
+
+```bash
+# 브랜치 네이밍 규칙
+<type>/#<issue-number>-<short-description>
+
+# 예시
+feat/#84-ai-features-ui
+fix/#92-login-error
+refactor/#101-editor-state
+```
+
+**체크리스트**:
+- [ ] ⚠️ Issue 번호 확인 (이슈 없으면 생성 필요)
+- [ ] ⚠️ 브랜치 생성 (`git checkout -b feat/#<issue>-<desc>`)
+- [ ] ⚠️ `.github/ISSUE_TEMPLATE/` 템플릿 확인
+
+### ⚠️ MUST: 복잡도 평가 & 계획
+
+**Decision Tree**:
+
+```
+작업 복잡도 판단:
+├─ 1-2 파일 + 명확한 요구사항 → 바로 시작
+├─ 3+ 파일 OR 아키텍처 변경 → EnterPlanMode
+├─ 불명확한 요구사항 → /intake 또는 AskUserQuestion
+└─ UI 작업 + Figma 있음 → /intake → FVL 선택
+```
+
+**체크리스트**:
+- [ ] ⚠️ 파일 변경 개수 추정 (3개 이상 → Plan 필수)
+- [ ] ⚠️ EnterPlanMode 사용 여부 결정
+- [ ] ⚠️ TodoWrite로 작업 계획 수립
+
+**예시**:
+
+```markdown
+# 단순 작업 (Plan 불필요)
+- 1개 파일 버그 수정
+- 단일 컴포넌트 스타일 변경
+- 오타 수정
+
+# 복잡한 작업 (Plan 필수)
+- 새 기능 추가 (3+ 파일)
+- 아키텍처 리팩토링
+- API 통합
+- 상태 관리 변경
+```
+
+### 💡 SHOULD: UI 작업 전 확인
+
+**UI 작업 시**:
+- [ ] Figma 디자인 확인 (`/intake` 사용 권장)
+- [ ] `src/components/ui/` 기존 컴포넌트 먼저 확인
+- [ ] `design_system_rules.md` 참고
+- [ ] FVL (Frontend Verification Level) 선택
+
+---
+
+## 🔨 Phase 2: 개발 중 (Development)
+
+### ⚠️ MUST: 코드 수정 전 필수 작업
+
+**체크리스트**:
+- [ ] ⚠️ **기존 코드 먼저 Read** (Read tool 사용)
+- [ ] ⚠️ Feature 간 cross-import 금지 확인
+- [ ] ⚠️ Named exports 사용 (default export 금지)
+- [ ] ⚠️ TypeScript strict mode 준수
+
+**Critical Rules**:
+
+```typescript
+// ✅ Good - Named exports
+export { LoginForm } from './LoginForm';
+export { useAuth } from './use-auth';
+
+// ❌ Bad - Default exports
+export default LoginForm;
+
+// ✅ Good - Feature isolation
+import { Button } from '@/components/ui/button';
+import { useAuth } from './hooks/use-auth';
+
+// ❌ Bad - Cross-feature import
+import { LoginForm } from '@/features/auth/components/organisms/LoginForm';
+```
+
+### ⚠️ MUST: 실시간 진행 상황 추적
+
+**체크리스트**:
+- [ ] ⚠️ TodoWrite로 작업 상태 업데이트 (in_progress → completed)
+- [ ] ⚠️ 작업 완료 즉시 체크리스트 업데이트 (배치 금지)
+- [ ] ⚠️ 새 작업 발견 시 Todo 추가
+
+**예시**:
+
+```typescript
+// Bad - 한 번에 여러 작업 완료 표시
+TodoWrite([
+  { content: 'Fix login', status: 'completed' },
+  { content: 'Add tests', status: 'completed' },
+  { content: 'Update docs', status: 'completed' },
+]);
+
+// Good - 작업 완료 즉시 업데이트
+TodoWrite([
+  { content: 'Fix login', status: 'completed' },
+  { content: 'Add tests', status: 'in_progress' },
+  { content: 'Update docs', status: 'pending' },
+]);
+```
+
+### 💡 SHOULD: 코드 품질 유지
+
+**체크리스트**:
+- [ ] 변경마다 `pnpm lint` 실행
+- [ ] Boolean 변수는 `is/has/can/should` prefix 사용
+- [ ] UI 문자열은 `src/constants/messages.ts`에 정의
+- [ ] JSDoc 추가 (복잡한 로직만)
+
+### 💡 SHOULD: 보안 & 성능
+
+**체크리스트**:
+- [ ] XSS 방지 (사용자 입력 sanitize)
+- [ ] 불필요한 리렌더링 방지 (memo, useMemo)
+- [ ] 민감 정보 커밋 금지 (API key, credentials)
+- [ ] 이미지 최적화 (Next.js Image 사용)
+
+---
+
+## ✅ Phase 3: 완료 전 검증 (Pre-Commit Verification)
+
+### ⚠️ MUST: Sisyphean Checklist
+
+**모든 항목이 체크되기 전까지 commit 금지**:
+
+- [ ] ⚠️ **TODO LIST**: Zero pending/in_progress tasks
+- [ ] ⚠️ **FUNCTIONALITY**: 요청된 모든 기능 작동
+- [ ] ⚠️ **TESTS**: 모든 테스트 통과 (테스트 있는 경우)
+- [ ] ⚠️ **ERRORS**: 해결되지 않은 에러 0개
+- [ ] ⚠️ **QUALITY**: Production-ready 코드
+
+**하나라도 미완료 시 → 작업 계속**
+
+### ⚠️ MUST: 빌드 & 린트 검증
+
+**체크리스트**:
+- [ ] ⚠️ `pnpm lint` 통과 (에러 0개)
+- [ ] ⚠️ `pnpm build` 성공
+- [ ] ⚠️ TypeScript 타입 에러 0개
+
+**명령어**:
+
+```bash
+# 순서대로 실행
+pnpm lint           # ESLint 검사
+pnpm tsc --noEmit   # 타입 체크 (빌드 없이)
+pnpm build          # Production 빌드
+```
+
+### 💡 SHOULD: 테스트 & 문서
+
+**체크리스트**:
+- [ ] 새 기능 → 테스트 작성 (`*.test.tsx`)
+- [ ] UI 컴포넌트 → Storybook 추가 (주요 컴포넌트)
+- [ ] 복잡한 로직 → JSDoc 추가
+- [ ] API 변경 → 문서 업데이트
+
+### ⚠️ MUST: 셀프 코드 리뷰
+
+**체크리스트**:
+- [ ] ⚠️ 불필요한 console.log 제거
+- [ ] ⚠️ 주석 처리된 코드 제거
+- [ ] ⚠️ 사용하지 않는 import 제거
+- [ ] ⚠️ 하드코딩된 값 → 상수로 추출
+
+---
+
+## 🚀 Phase 4: Commit & PR (Deployment)
+
+### ⚠️ MUST: Atomic Commits
+
+**원칙**: 1 commit = 1 논리적 변경
+
+**체크리스트**:
+- [ ] ⚠️ Conventional Commits 형식 사용
+- [ ] ⚠️ Co-Authored-By 기본 제외 (사용자 명시 시만 추가)
+- [ ] ⚠️ Commit message 소문자 동사 시작
+
+**형식**:
+
+```bash
+<type>(<scope>): <subject>
+
+# 예시
+feat(auth): implement social login
+fix(editor): resolve node duplication bug
+refactor(profile): extract contribution utils
+test(roadmap): add edge case tests
+chore(deps): update dependencies
+```
+
+**Types**:
+
+| Type | 사용 시기 |
+|------|----------|
+| feat | 새 기능 추가 |
+| fix | 버그 수정 |
+| refactor | 코드 리팩토링 |
+| perf | 성능 개선 |
+| format | 코드 포맷팅 |
+| test | 테스트 추가/수정 |
+| docs | 문서 변경 |
+| chore | 빌드/도구 변경 |
+
+### ⚠️ MUST: PR 생성 전 확인
+
+**체크리스트**:
+- [ ] ⚠️ `.github/PULL_REQUEST_TEMPLATE.md` 작성
+- [ ] ⚠️ 관련 이슈 링크 (`Closes #<issue>`)
+- [ ] ⚠️ 체크리스트 완료
+- [ ] ⚠️ 스크린샷 첨부 (UI 변경 시)
+
+**PR 제목 형식**:
+
+```
+<type>(#<issue>): <brief description>
+
+# 예시
+feat(#84): add AI features UI to editor toolbar
+fix(#92): resolve login redirect error
+```
+
+### 💡 SHOULD: PR 최적화
+
+**체크리스트**:
+- [ ] PR 크기 < 500줄 (가능하면 분할)
+- [ ] 명확한 설명 (무엇을, 왜, 어떻게)
+- [ ] Breaking changes 명시
+- [ ] 테스트 방법 설명
+
+---
+
+## 🔄 예외 처리 & 특수 상황
+
+### 막힐 때
+
+**Decision Tree**:
+
+```
+문제 발생 시:
+├─ 요구사항 불명확 → AskUserQuestion
+├─ 복잡한 디버깅 → /oracle
+├─ 아키텍처 결정 → /prometheus
+└─ 일반적인 막힘 → 사용자에게 상황 설명
+```
+
+### 병렬 작업
+
+**Git Worktree 사용**:
+
+```bash
+# 여러 이슈 동시 작업
+git worktree add ../jagalchi-84 feat/#84-ai-ui
+git worktree add ../jagalchi-92 fix/#92-login
+
+# 병렬 빌드 (Claude: run_in_background: true)
+cd ../jagalchi-84 && pnpm build &
+cd ../jagalchi-92 && pnpm build &
+
+# 정리
+git worktree remove ../jagalchi-84
+```
+
+### Plan Mode에서 요구사항 변경
+
+**Protocol**:
+
+1. **중단** - 현재 작업 일시 정지
+2. **평가** - 변경 범위 및 영향도 분석
+3. **결정** - AskUserQuestion으로 방향 확인
+4. **기록** - Plan 문서 업데이트
+5. **재개** - 새 계획으로 작업 계속
+
+---
+
+## 🎯 Workflow Commands (Quick Reference)
+
+### 실행 명령어
+
+| Command | Phase | Usage |
+|---------|-------|-------|
+| `/intake <request>` | Phase 1 | 요구사항 정제 (Figma 통합) |
+| `/plan <task>` | Phase 1 | 계획 수립 (Prometheus) |
+| `/ultrawork <task>` | Phase 2 | 병렬 실행 최대 성능 |
+| `/ui <level> <scope>` | Phase 2 | Frontend 검증 (FVL) |
+| `/sisyphus <task>` | Phase 2 | 멀티 에이전트 오케스트레이션 |
+| `/git-master` | Phase 4 | Atomic commits 도움 |
+
+### 검증 명령어
+
+| Command | Usage |
+|---------|-------|
+| `pnpm lint` | ESLint 검사 |
+| `pnpm lint --fix` | 자동 수정 |
+| `pnpm build` | Production 빌드 |
+| `pnpm test` | 테스트 실행 |
+| `pnpm storybook` | Storybook 실행 |
+
+---
+
+## 📊 Workflow Violation Policy
+
+### High Severity (작업 중단 필수)
+
+**위반 시 즉시 중단, 사용자 확인 필요**:
+- Phase 1 없이 코딩 시작
+- 기존 코드 안 읽고 수정
+- Cross-feature import 사용
+- Phase 3 체크리스트 미완료 상태로 commit
+- Lint/Build 실패 상태로 PR 생성
+
+### Medium Severity (경고 후 계속)
+
+**경고 메시지 표시 후 계속 진행 가능**:
+- TodoWrite 미사용
+- 테스트 미작성 (신규 기능)
+- JSDoc 미작성 (복잡한 로직)
+
+### Low Severity (무시 가능)
+
+**Best practice이지만 강제 안 함**:
+- Storybook 미작성
+- PR 크기 500줄 초과
+- 이미지 최적화 누락
+
+---
+
+## 🎓 Learning Examples
+
+### Example 1: 단순 버그 수정
+
+```
+Phase 1:
+✅ Issue #92 확인
+✅ git checkout -b fix/#92-login-redirect
+✅ 1파일 수정 예상 → Plan 불필요
+✅ TodoWrite: ["Fix login redirect bug"]
+
+Phase 2:
+✅ Read: src/features/auth/components/LoginForm.tsx
+✅ 버그 수정
+✅ TodoWrite: status → completed
+
+Phase 3:
+✅ pnpm lint → Pass
+✅ pnpm build → Success
+✅ 셀프 리뷰 완료
+
+Phase 4:
+✅ git commit -m "fix(auth): resolve login redirect error"
+✅ PR 생성 (템플릿 작성)
+```
+
+### Example 2: 복잡한 기능 추가
+
+```
+Phase 1:
+✅ Issue #84 확인
+✅ git checkout -b feat/#84-ai-features
+✅ 5+ 파일 예상 → EnterPlanMode 사용
+✅ Plan 작성 → ExitPlanMode
+✅ TodoWrite: [5개 작업 항목]
+
+Phase 2:
+✅ /sisyphus 또는 /ultrawork 고려
+✅ 기존 컴포넌트 먼저 확인
+✅ 작업마다 TodoWrite 업데이트
+✅ 중간중간 pnpm lint 실행
+
+Phase 3:
+✅ Sisyphean Checklist 완료
+✅ pnpm lint → Pass
+✅ pnpm build → Success
+✅ 테스트 추가
+✅ Storybook 작성
+
+Phase 4:
+✅ Atomic commits (기능별 분리)
+✅ PR 생성 (상세한 설명)
+✅ 스크린샷 첨부
+```
+
+---
+
+## 🔗 Related Documents
+
+- **Architecture**: `.claude/rules/architecture.md`
+- **Code Style**: `.claude/rules/code-style.md`
+- **Git Convention**: `.claude/rules/workflow.md`
+- **Testing**: `.claude/rules/testing.md`
+- **Design System**: `.claude/design_system_rules.md`
+- **FVL Policy**: `~/.claude/fvl-policy.md` (글로벌)
+- **Git Planning**: `~/.claude/git-planning-guide.md` (글로벌)
+
+---
+
+## 📌 Quick Checklist
+
+**매 작업마다 이것만 확인하세요**:
+
+```
+[ ] ⚠️ Phase 1: 브랜치 생성 + 계획 수립
+[ ] ⚠️ Phase 2: 기존 코드 Read + TodoWrite 업데이트
+[ ] ⚠️ Phase 3: Sisyphean Checklist + Lint + Build
+[ ] ⚠️ Phase 4: Atomic commits + PR 템플릿
+```
+
+**이 4단계만 지키면 90%의 문제 예방 가능합니다.**

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -34,4 +34,9 @@ export const EDITOR_MESSAGES = {
   COLOR_PICKER_TITLE: '컬러 선택',
   COLOR_PICKER_CANCEL: '취소',
   COLOR_PICKER_APPLY: '적용',
+  // AI 기능
+  AI_GENERATE_ROADMAP: '로드맵 생성',
+  AI_MODIFY_ROADMAP: '로드맵 수정',
+  AI_MENU_LABEL: 'AI 메뉴',
+  RESOURCE_DELETE_CONFIRM: '자료를 삭제하시겠습니까?',
 } as const;

--- a/src/features/roadmap-editor/components/molecules/ConnectionLine/index.tsx
+++ b/src/features/roadmap-editor/components/molecules/ConnectionLine/index.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { memo } from 'react';
+
+import { getSmoothStepPath, Position } from '@xyflow/react';
+
+import { getNodeColors } from '@/features/roadmap-editor/constants/node-colors';
+import { cn } from '@/lib/utils';
+
+interface ConnectionLineProps {
+  fromX: number;
+  fromY: number;
+  toX: number;
+  toY: number;
+  fromPosition?: Position;
+  toPosition?: Position;
+}
+
+export const ConnectionLine = memo(function ConnectionLine({
+  fromX,
+  fromY,
+  toX,
+  toY,
+  fromPosition = Position.Bottom,
+  toPosition = Position.Top,
+}: ConnectionLineProps) {
+  // Calculate distance between points
+  const distance = Math.sqrt(Math.pow(toX - fromX, 2) + Math.pow(toY - fromY, 2));
+  const showGhost = distance > 50;
+
+  // Get smooth step path
+  const [edgePath] = getSmoothStepPath({
+    sourceX: fromX,
+    sourceY: fromY,
+    sourcePosition: fromPosition,
+    targetX: toX,
+    targetY: toY,
+    targetPosition: toPosition,
+  });
+
+  // Get ghost node colors (using white variant for preview)
+  const colors = getNodeColors('white', 'default');
+
+  return (
+    <g>
+      {/* Connection line */}
+      <path fill="none" stroke="#b1b1b7" strokeWidth={2} className="animated" d={edgePath} />
+
+      {/* Ghost node preview at endpoint */}
+      {showGhost && (
+        <foreignObject
+          x={toX - 100}
+          y={toY - 24}
+          width={200}
+          height={48}
+          className="overflow-visible opacity-50"
+        >
+          <div
+            className={cn(
+              'flex h-12 min-w-[200px] items-center justify-center rounded-lg border-2 px-5 py-2.5',
+              colors.bg,
+              colors.border,
+              colors.text,
+            )}
+          >
+            <span className="truncate text-base font-medium">New Node</span>
+          </div>
+        </foreignObject>
+      )}
+    </g>
+  );
+});

--- a/src/features/roadmap-editor/components/molecules/index.ts
+++ b/src/features/roadmap-editor/components/molecules/index.ts
@@ -1,5 +1,6 @@
 export { ColorPicker } from './ColorPicker';
 export { ColorSelector } from './ColorSelector';
+export { ConnectionLine } from './ConnectionLine';
 export { JagalchiNode } from './JagalchiNode';
 export { JagalchiSection } from './JagalchiSection';
 export { JagalchiText } from './JagalchiText';

--- a/src/features/roadmap-editor/components/organisms/NodePropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/NodePropertiesPanel/index.tsx
@@ -78,7 +78,7 @@ export const NodePropertiesPanel = memo(function NodePropertiesPanel({
       <div>
         <Label>{EDITOR_MESSAGES.SIDEBAR_RESOURCES_LABEL}</Label>
         <div className="mt-2 space-y-2">
-          {node.data.resources.map((resource, index) => (
+          {node.data.resources.map((resource: string, index: number) => (
             <Input
               key={index}
               value={resource}

--- a/src/features/roadmap-editor/components/organisms/RoadmapCanvas/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/RoadmapCanvas/index.tsx
@@ -9,10 +9,13 @@ import {
   addEdge,
   applyNodeChanges,
   applyEdgeChanges,
+  useReactFlow,
+  type Edge,
   type OnConnect,
   type OnNodesChange,
   type OnEdgesChange,
   type OnSelectionChangeFunc,
+  type OnConnectEnd,
   type NodeTypes,
   BackgroundVariant,
   ConnectionMode,
@@ -30,6 +33,7 @@ import {
 import type { RoadmapNode } from '@/features/roadmap-editor/types/editor.types';
 
 import { useKeyboardShortcuts } from '../../../hooks/use-keyboard-shortcuts';
+import { ConnectionLine } from '../../molecules/ConnectionLine';
 import { JagalchiNode } from '../../molecules/JagalchiNode';
 import { JagalchiSection } from '../../molecules/JagalchiSection';
 import { JagalchiText } from '../../molecules/JagalchiText';
@@ -45,6 +49,7 @@ export function RoadmapCanvas() {
   const [edges, setEdges] = useAtom(edgesAtom);
   const setSelectedNodeIds = useSetAtom(selectedNodeIdsAtom);
   const setSelectedEdgeIds = useSetAtom(selectedEdgeIdsAtom);
+  const { screenToFlowPosition } = useReactFlow();
 
   // 키보드 단축키 활성화
   useKeyboardShortcuts();
@@ -78,6 +83,50 @@ export function RoadmapCanvas() {
     [setSelectedNodeIds, setSelectedEdgeIds],
   );
 
+  const onConnectEnd: OnConnectEnd = useCallback(
+    (event, connectionState) => {
+      // Only create node if connection ended on empty space (not on another node)
+      if (connectionState.toNode) return;
+
+      // Get mouse position
+      const targetIsPane = (event.target as HTMLElement).classList.contains('react-flow__pane');
+      if (!targetIsPane) return;
+
+      const { clientX, clientY } = 'changedTouches' in event ? event.changedTouches[0] : event;
+      const position = screenToFlowPosition({ x: clientX, y: clientY });
+
+      // Create new node at drop position
+      const newNodeId = `node-${Date.now()}`;
+      const newNode: RoadmapNode = {
+        id: newNodeId,
+        type: 'jagalchi-node',
+        position: { x: position.x - 100, y: position.y - 24 }, // Center the node
+        data: {
+          label: 'New Node',
+          description: '',
+          resources: [],
+          variant: 'white',
+          isLocked: false,
+        },
+      };
+
+      // Add new node
+      setNodes((nds) => [...nds, newNode]);
+
+      // Create edge connecting source to new node
+      if (connectionState.fromNode) {
+        const newEdge: Edge = {
+          id: `edge-${Date.now()}`,
+          source: connectionState.fromNode.id,
+          target: newNodeId,
+          sourceHandle: connectionState.fromHandle?.id ?? null,
+        };
+        setEdges((eds) => [...eds, newEdge]);
+      }
+    },
+    [screenToFlowPosition, setNodes, setEdges],
+  );
+
   return (
     <div className="h-full w-full">
       <ReactFlow
@@ -86,8 +135,10 @@ export function RoadmapCanvas() {
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
+        onConnectEnd={onConnectEnd}
         onSelectionChange={onSelectionChange}
         nodeTypes={nodeTypes}
+        connectionLineComponent={ConnectionLine}
         multiSelectionKeyCode="Shift"
         selectionKeyCode="Shift"
         deleteKeyCode="Delete"


### PR DESCRIPTION
## 📋 관련 이슈

Closes #82

## 📝 작업 내용

Phase 3 Track 3-2: 연결선을 빈 공간으로 드래그하면 새 노드 생성

### 구현 내용
- 연결선 드래그 중 반투명 미리보기 노드 표시
- 50px 이상 드래그하면 생성될 노드의 위치를 미리보기로 표시
- 빈 공간에 드롭하면 해당 위치에 새 노드 생성 및 자동 연결
- screenToFlowPosition API로 정확한 캔버스 좌표 계산
- 점선 테두리와 50% 투명도로 시각적 피드백 제공

### 기술적 구현
- ConnectionLine 컴포넌트 생성 (Molecule)
- RoadmapCanvas에 onConnectEnd 핸들러 추가
- React Flow의 useReactFlow 훅 활용

## 📸 스크린샷 (UI 변경 시)

노드의 핸들을 드래그하면 반투명 미리보기 노드가 마우스 커서를 따라다닙니다. 빈 공간에 놓으면 해당 위치에 새 노드가 생성됩니다.

## ✅ 체크리스트

- [x] 관련 이슈 연결
- [x] 셀프 코드 리뷰 완료
- [x] 컨벤션 준수 확인
- [x] 린트/빌드 통과 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual connection lines between nodes in the roadmap editor with smooth pathways.
  * Enabled node creation by dragging connection endpoints to empty canvas areas.
  * Introduced ghost node preview that appears when dragging connections over longer distances, providing visual feedback before creating new nodes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->