### PR TITLE
feat(#95): add AI modal infrastructure

### DIFF
--- a/src/features/roadmap-editor/components/organisms/RoadmapAiModal/RoadmapAiModal.test.tsx
+++ b/src/features/roadmap-editor/components/organisms/RoadmapAiModal/RoadmapAiModal.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RoadmapAiModal } from './index';
+
+describe('RoadmapAiModal', () => {
+  const mockOnClose = vi.fn();
+
+  it('열려있을 때 모달을 렌더링한다', () => {
+    render(<RoadmapAiModal isOpen={true} onClose={mockOnClose} />);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '로드맵 생성' })).toBeInTheDocument();
+  });
+
+  it('닫혀있을 때 모달을 렌더링하지 않는다', () => {
+    render(<RoadmapAiModal isOpen={false} onClose={mockOnClose} />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('Sparkles 아이콘과 제목을 표시한다', () => {
+    render(<RoadmapAiModal isOpen={true} onClose={mockOnClose} />);
+
+    expect(screen.getByRole('heading', { name: '로드맵 생성' })).toBeInTheDocument();
+  });
+
+  it('Close 버튼 클릭 시 onClose를 호출한다', async () => {
+    const user = userEvent.setup();
+
+    render(<RoadmapAiModal isOpen={true} onClose={mockOnClose} />);
+
+    const closeButton = screen.getByLabelText('Close dialog');
+    await user.click(closeButton);
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it('탭을 전환할 수 있다', async () => {
+    const user = userEvent.setup();
+
+    render(<RoadmapAiModal isOpen={true} onClose={mockOnClose} />);
+
+    // 초기 상태는 "로드맵 생성"
+    expect(screen.getByRole('heading', { name: '로드맵 생성' })).toBeInTheDocument();
+
+    // "로드맵 수정" 탭 클릭
+    const editTab = screen.getByRole('button', { name: '로드맵 수정' });
+    await user.click(editTab);
+
+    // 제목이 변경되었는지 확인
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: '로드맵 수정' })).toBeInTheDocument();
+    });
+  });
+
+  it('활성화된 탭은 aria-pressed가 true이다', async () => {
+    const user = userEvent.setup();
+
+    render(<RoadmapAiModal isOpen={true} onClose={mockOnClose} />);
+
+    const createTab = screen.getByRole('button', { name: '로드맵 생성' });
+    const editTab = screen.getByRole('button', { name: '로드맵 수정' });
+
+    // 초기 상태
+    expect(createTab).toHaveAttribute('aria-pressed', 'true');
+    expect(editTab).toHaveAttribute('aria-pressed', 'false');
+
+    // "로드맵 수정" 탭 클릭
+    await user.click(editTab);
+
+    // 상태 변경 확인
+    await waitFor(() => {
+      expect(createTab).toHaveAttribute('aria-pressed', 'false');
+      expect(editTab).toHaveAttribute('aria-pressed', 'true');
+    });
+  });
+
+  it('각 탭에 맞는 콘텐츠를 표시한다', async () => {
+    const user = userEvent.setup();
+
+    render(<RoadmapAiModal isOpen={true} onClose={mockOnClose} />);
+
+    // "로드맵 생성" 콘텐츠
+    expect(screen.getByText('로드맵 생성 폼이 여기에 표시됩니다.')).toBeInTheDocument();
+
+    // "로드맵 수정" 탭 클릭
+    const editTab = screen.getByRole('button', { name: '로드맵 수정' });
+    await user.click(editTab);
+
+    // "로드맵 수정" 콘텐츠
+    await waitFor(() => {
+      expect(screen.getByText('로드맵 수정 폼이 여기에 표시됩니다.')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/roadmap-editor/components/organisms/RoadmapAiModal/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/RoadmapAiModal/index.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Sparkles, X } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+interface RoadmapAiModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  className?: string;
+}
+
+type TabType = 'create' | 'edit';
+
+export function RoadmapAiModal({ isOpen, onClose, className }: RoadmapAiModalProps) {
+  const [activeTab, setActiveTab] = useState<TabType>('create');
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogContent
+          className={cn(
+            'w-[480px] p-0 shadow-xl',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out',
+            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+            'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+            className,
+          )}
+          showCloseButton={false}
+        >
+          {/* Header */}
+          <div className="flex h-9 items-center justify-between bg-neutral-900 px-4">
+            <div className="flex items-center gap-2">
+              <Sparkles className="text-neutral-0 h-4 w-4" aria-hidden="true" />
+              <DialogTitle className="text-neutral-0 text-sm font-medium">
+                {activeTab === 'create' ? '로드맵 생성' : '로드맵 수정'}
+              </DialogTitle>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-neutral-0 transition-colors hover:text-neutral-300"
+              aria-label="Close dialog"
+            >
+              <X className="h-6 w-6" aria-hidden="true" />
+            </button>
+          </div>
+
+          {/* Tab System */}
+          <div className="border-b border-neutral-200">
+            <div className="flex">
+              <button
+                type="button"
+                onClick={() => setActiveTab('create')}
+                className={cn(
+                  'flex-1 px-4 py-2 text-sm font-medium transition-colors',
+                  'focus:ring-primary-500 focus:ring-2 focus:outline-none',
+                  activeTab === 'create'
+                    ? 'bg-neutral-100 text-neutral-900'
+                    : 'bg-neutral-0 text-neutral-700 hover:bg-neutral-50',
+                )}
+                aria-pressed={activeTab === 'create'}
+              >
+                로드맵 생성
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab('edit')}
+                className={cn(
+                  'flex-1 px-4 py-2 text-sm font-medium transition-colors',
+                  'focus:ring-primary-500 focus:ring-2 focus:outline-none',
+                  activeTab === 'edit'
+                    ? 'bg-neutral-100 text-neutral-900'
+                    : 'bg-neutral-0 text-neutral-700 hover:bg-neutral-50',
+                )}
+                aria-pressed={activeTab === 'edit'}
+              >
+                로드맵 수정
+              </button>
+            </div>
+          </div>
+
+          {/* Content Area */}
+          <div className="min-h-[320px] p-4">
+            {activeTab === 'create' && (
+              <div className="text-sm text-neutral-700">로드맵 생성 폼이 여기에 표시됩니다.</div>
+            )}
+            {activeTab === 'edit' && (
+              <div className="text-sm text-neutral-700">로드맵 수정 폼이 여기에 표시됩니다.</div>
+            )}
+          </div>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  );
+}

--- a/src/stories/roadmap-editor/RoadmapAiModal.stories.tsx
+++ b/src/stories/roadmap-editor/RoadmapAiModal.stories.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+import { RoadmapAiModal } from '@/features/roadmap-editor/components/organisms/RoadmapAiModal';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/Organisms/RoadmapAiModal',
+  component: RoadmapAiModal,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof RoadmapAiModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const InteractiveComponent = () => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <div>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="bg-primary-500 text-neutral-0 rounded-md px-4 py-2 text-sm font-medium"
+      >
+        Open AI Modal
+      </button>
+      <RoadmapAiModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+  },
+  render: InteractiveComponent,
+};


### PR DESCRIPTION
## 📋 관련 이슈

Closes #95

## 📝 작업 내용

AI 기능의 기반이 되는 모달 인프라를 구축했습니다.

### RoadmapAiModal 컴포넌트
- **Dialog wrapper**: shadcn/ui Dialog 기반 모달 시스템
- **Modal 크기**: 480px × ~400px (Figma 스펙 준수)
- **Shadow**: xl variant (20px offset, 25px blur)

### 헤더 구현
- **Background**: neutral-900 (#0f172a)
- **Height**: 36px
- **Sparkles 아이콘**: 16px (lucide-react)
- **동적 제목**: 활성 탭에 따라 "로드맵 생성" / "로드맵 수정" 전환
- **Close button**: X icon (24px) with hover effect

### 탭 시스템
- **Tab height**: 32px
- **Active tab**: bg-neutral-100, text-neutral-900
- **Inactive tab**: bg-neutral-0, text-neutral-700
- **Transitions**: smooth color transitions
- **Accessibility**: aria-pressed attributes

### 접근성 (A11y)
- DialogTitle 컴포넌트 사용 (스크린 리더 지원)
- aria-pressed 속성으로 활성 탭 표시
- aria-label로 Close 버튼 설명
- aria-hidden으로 장식용 아이콘 숨김
- Keyboard navigation 지원

### 테스트 & 문서화
- 7개 단위 테스트 작성
  - 모달 렌더링 검증
  - Close 버튼 동작 확인
  - 탭 전환 기능 테스트
  - ARIA 속성 검증
- Storybook 스토리 추가 (인터랙티브 예제)

## ✅ 체크리스트

- [x] 관련 이슈 연결
- [x] 셀프 코드 리뷰 완료
- [x] 컨벤션 준수 확인
- [x] 린트/빌드 통과 확인
- [x] 테스트 통과 확인 (196/196 passed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new modal interface with create and edit tabs for roadmap management, including responsive design and smooth transitions.

* **Tests**
  * Added comprehensive unit tests covering modal rendering, tab switching, state management, and content display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->