### PR TITLE
feat(#96): add AI forms and loading states

### DIFF
--- a/src/features/roadmap-editor/components/atoms/LoadingButton/LoadingButton.test.tsx
+++ b/src/features/roadmap-editor/components/atoms/LoadingButton/LoadingButton.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LoadingButton } from './index';
+
+describe('LoadingButton', () => {
+  it('기본 텍스트를 렌더링한다', () => {
+    render(<LoadingButton>Click me</LoadingButton>);
+
+    expect(screen.getByRole('button')).toHaveTextContent('Click me');
+  });
+
+  it('로딩 상태에서 스피너와 로딩 텍스트를 표시한다', () => {
+    render(
+      <LoadingButton isLoading={true} loadingText="Loading...">
+        Click me
+      </LoadingButton>,
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('Loading...');
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('로딩 상태에서 버튼이 비활성화된다', () => {
+    render(<LoadingButton isLoading={true}>Click me</LoadingButton>);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('disabled prop이 true일 때 버튼이 비활성화된다', () => {
+    render(<LoadingButton disabled={true}>Click me</LoadingButton>);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('클릭 이벤트를 처리한다', async () => {
+    const handleClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(<LoadingButton onClick={handleClick}>Click me</LoadingButton>);
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('로딩 상태에서는 클릭 이벤트가 발생하지 않는다', async () => {
+    const handleClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <LoadingButton isLoading={true} onClick={handleClick}>
+        Click me
+      </LoadingButton>,
+    );
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/roadmap-editor/components/atoms/LoadingButton/index.tsx
+++ b/src/features/roadmap-editor/components/atoms/LoadingButton/index.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { forwardRef } from 'react';
+
+import { Loader2 } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+interface LoadingButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  isLoading?: boolean;
+  loadingText?: string;
+}
+
+export const LoadingButton = forwardRef<HTMLButtonElement, LoadingButtonProps>(
+  ({ isLoading = false, loadingText, children, className, disabled, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        disabled={disabled || isLoading}
+        className={cn(
+          'focus:ring-primary-500 bg-primary-500 text-neutral-0 flex h-9 items-center justify-center gap-2 rounded-md px-4 text-sm font-medium transition-opacity focus:ring-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        {...props}
+      >
+        {isLoading && (
+          <Loader2 className="h-[13.25px] w-[13.25px] animate-spin" aria-hidden="true" />
+        )}
+        <span>{isLoading && loadingText ? loadingText : children}</span>
+      </button>
+    );
+  },
+);
+
+LoadingButton.displayName = 'LoadingButton';

--- a/src/features/roadmap-editor/components/molecules/ResourceCard/ResourceCard.test.tsx
+++ b/src/features/roadmap-editor/components/molecules/ResourceCard/ResourceCard.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ResourceCard } from './index';
+
+describe('ResourceCard', () => {
+  const mockResource = {
+    title: 'React Documentation',
+    url: 'https://react.dev',
+  };
+
+  it('리소스 제목과 URL을 렌더링한다', () => {
+    render(<ResourceCard title={mockResource.title} url={mockResource.url} />);
+
+    expect(screen.getByText(mockResource.title)).toBeInTheDocument();
+    expect(screen.getByText(mockResource.url)).toBeInTheDocument();
+  });
+
+  it('URL은 새 탭에서 열린다', () => {
+    render(<ResourceCard title={mockResource.title} url={mockResource.url} />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', mockResource.url);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('onAdd가 제공되면 Add 버튼을 표시한다', () => {
+    const handleAdd = vi.fn();
+
+    render(<ResourceCard title={mockResource.title} url={mockResource.url} onAdd={handleAdd} />);
+
+    expect(screen.getByRole('button', { name: `Add ${mockResource.title}` })).toBeInTheDocument();
+  });
+
+  it('onAdd가 없으면 Add 버튼을 표시하지 않는다', () => {
+    render(<ResourceCard title={mockResource.title} url={mockResource.url} />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('Add 버튼 클릭 시 onAdd를 호출한다', async () => {
+    const handleAdd = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ResourceCard title={mockResource.title} url={mockResource.url} onAdd={handleAdd} />);
+
+    const addButton = screen.getByRole('button', { name: `Add ${mockResource.title}` });
+    await user.click(addButton);
+
+    expect(handleAdd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/roadmap-editor/components/molecules/ResourceCard/index.tsx
+++ b/src/features/roadmap-editor/components/molecules/ResourceCard/index.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { ExternalLink, Plus } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+interface ResourceCardProps {
+  title: string;
+  url: string;
+  onAdd?: () => void;
+  className?: string;
+}
+
+export function ResourceCard({ title, url, onAdd, className }: ResourceCardProps) {
+  return (
+    <div
+      className={cn(
+        'bg-neutral-0 flex items-center justify-between gap-3 rounded-md border border-neutral-200 p-3',
+        className,
+      )}
+    >
+      {/* Resource Info */}
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <ExternalLink className="h-4 w-4 shrink-0 text-neutral-700" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-neutral-900">{title}</p>
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-500 hover:text-primary-600 truncate text-xs transition-colors"
+          >
+            {url}
+          </a>
+        </div>
+      </div>
+
+      {/* Add Button */}
+      {onAdd && (
+        <button
+          type="button"
+          onClick={onAdd}
+          className="focus:ring-primary-500 bg-primary-500 text-neutral-0 hover:bg-primary-600 flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors focus:ring-2 focus:outline-none"
+          aria-label={`Add ${title}`}
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/features/roadmap-editor/components/molecules/RoadmapGenerationForm/RoadmapGenerationForm.test.tsx
+++ b/src/features/roadmap-editor/components/molecules/RoadmapGenerationForm/RoadmapGenerationForm.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RoadmapGenerationForm } from './index';
+
+describe('RoadmapGenerationForm', () => {
+  it('레이블과 Textarea를 렌더링한다', () => {
+    render(<RoadmapGenerationForm onSubmit={vi.fn()} />);
+
+    expect(screen.getByText('로드맵 설명')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('생성할 로드맵의 정보를 자세히 알려주세요.'),
+    ).toBeInTheDocument();
+  });
+
+  it('제출 버튼을 렌더링한다', () => {
+    render(<RoadmapGenerationForm onSubmit={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: '로드맵 생성하기' })).toBeInTheDocument();
+  });
+
+  it('빈 입력일 때 제출 버튼이 비활성화된다', () => {
+    render(<RoadmapGenerationForm onSubmit={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: '로드맵 생성하기' })).toBeDisabled();
+  });
+
+  it('텍스트 입력 시 제출 버튼이 활성화된다', async () => {
+    const user = userEvent.setup();
+
+    render(<RoadmapGenerationForm onSubmit={vi.fn()} />);
+
+    const textarea = screen.getByPlaceholderText('생성할 로드맵의 정보를 자세히 알려주세요.');
+    await user.type(textarea, 'React 학습 로드맵');
+
+    expect(screen.getByRole('button', { name: '로드맵 생성하기' })).not.toBeDisabled();
+  });
+
+  it('폼 제출 시 onSubmit을 호출한다', async () => {
+    const handleSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(<RoadmapGenerationForm onSubmit={handleSubmit} />);
+
+    const textarea = screen.getByPlaceholderText('생성할 로드맵의 정보를 자세히 알려주세요.');
+    await user.type(textarea, 'React 학습 로드맵');
+
+    const submitButton = screen.getByRole('button', { name: '로드맵 생성하기' });
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith('React 학습 로드맵');
+    });
+  });
+
+  it('로딩 상태에서 버튼과 텍스트 필드가 비활성화된다', () => {
+    render(<RoadmapGenerationForm onSubmit={vi.fn()} isLoading={true} />);
+
+    expect(screen.getByRole('button', { name: '생성중' })).toBeDisabled();
+    expect(screen.getByPlaceholderText('생성할 로드맵의 정보를 자세히 알려주세요.')).toBeDisabled();
+  });
+
+  it('로딩 상태에서 버튼 텍스트가 "생성중"으로 변경된다', () => {
+    render(<RoadmapGenerationForm onSubmit={vi.fn()} isLoading={true} />);
+
+    expect(screen.getByRole('button', { name: '생성중' })).toBeInTheDocument();
+  });
+});

--- a/src/features/roadmap-editor/components/molecules/RoadmapGenerationForm/index.tsx
+++ b/src/features/roadmap-editor/components/molecules/RoadmapGenerationForm/index.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+import { LoadingButton } from '../../atoms/LoadingButton';
+
+interface RoadmapGenerationFormProps {
+  onSubmit: (prompt: string) => void | Promise<void>;
+  isLoading?: boolean;
+  className?: string;
+}
+
+export function RoadmapGenerationForm({
+  onSubmit,
+  isLoading = false,
+  className,
+}: RoadmapGenerationFormProps) {
+  const [prompt, setPrompt] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (prompt.trim() && !isLoading) {
+      await onSubmit(prompt);
+    }
+  };
+
+  const isSubmitDisabled = !prompt.trim() || isLoading;
+
+  return (
+    <form onSubmit={handleSubmit} className={cn('flex flex-col gap-4', className)}>
+      <div className="flex flex-col gap-2">
+        <label htmlFor="roadmap-prompt" className="text-xs font-medium text-neutral-700">
+          로드맵 설명
+        </label>
+        <Textarea
+          id="roadmap-prompt"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="생성할 로드맵의 정보를 자세히 알려주세요."
+          className="h-[120px] resize-y"
+          disabled={isLoading}
+        />
+      </div>
+
+      <LoadingButton
+        type="submit"
+        isLoading={isLoading}
+        loadingText="생성중"
+        disabled={isSubmitDisabled}
+        className="w-full"
+      >
+        로드맵 생성하기
+      </LoadingButton>
+    </form>
+  );
+}

--- a/src/features/roadmap-editor/components/molecules/RoadmapModificationForm/index.tsx
+++ b/src/features/roadmap-editor/components/molecules/RoadmapModificationForm/index.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+import { LoadingButton } from '../../atoms/LoadingButton';
+
+interface RoadmapModificationFormProps {
+  onSubmit: (prompt: string) => void | Promise<void>;
+  isLoading?: boolean;
+  className?: string;
+}
+
+export function RoadmapModificationForm({
+  onSubmit,
+  isLoading = false,
+  className,
+}: RoadmapModificationFormProps) {
+  const [prompt, setPrompt] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (prompt.trim() && !isLoading) {
+      await onSubmit(prompt);
+    }
+  };
+
+  const isSubmitDisabled = !prompt.trim() || isLoading;
+
+  return (
+    <form onSubmit={handleSubmit} className={cn('flex flex-col gap-4', className)}>
+      <div className="flex flex-col gap-2">
+        <label htmlFor="modification-prompt" className="text-xs font-medium text-neutral-700">
+          수정 내용
+        </label>
+        <Textarea
+          id="modification-prompt"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="수정할 내용을 자세히 알려주세요."
+          className="h-[120px] resize-y"
+          disabled={isLoading}
+        />
+      </div>
+
+      <LoadingButton
+        type="submit"
+        isLoading={isLoading}
+        loadingText="수정중"
+        disabled={isSubmitDisabled}
+        className="w-full"
+      >
+        로드맵 수정하기
+      </LoadingButton>
+    </form>
+  );
+}

--- a/src/features/roadmap-editor/components/organisms/ResourceRecommendationModal/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/ResourceRecommendationModal/index.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { Sparkles, X } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+
+import { ResourceCard } from '../../molecules/ResourceCard';
+
+interface Resource {
+  id: string;
+  title: string;
+  url: string;
+}
+
+interface ResourceRecommendationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  resources: Resource[];
+  onAddResource?: (resource: Resource) => void;
+  isLoading?: boolean;
+  className?: string;
+}
+
+export function ResourceRecommendationModal({
+  isOpen,
+  onClose,
+  resources,
+  onAddResource,
+  isLoading = false,
+  className,
+}: ResourceRecommendationModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogContent
+          className={cn(
+            'w-[480px] p-0 shadow-xl',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out',
+            'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+            'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+            className,
+          )}
+          showCloseButton={false}
+        >
+          {/* Header */}
+          <div className="flex h-9 items-center justify-between bg-neutral-900 px-4">
+            <div className="flex items-center gap-2">
+              <Sparkles className="text-neutral-0 h-4 w-4" aria-hidden="true" />
+              <DialogTitle className="text-neutral-0 text-sm font-medium">자료 추천</DialogTitle>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-neutral-0 transition-colors hover:text-neutral-300"
+              aria-label="Close dialog"
+            >
+              <X className="h-6 w-6" aria-hidden="true" />
+            </button>
+          </div>
+
+          {/* Content Area */}
+          <div className="max-h-[400px] overflow-y-auto p-4">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-8">
+                <p className="text-sm text-neutral-700">자료를 불러오는 중...</p>
+              </div>
+            ) : resources.length === 0 ? (
+              <div className="flex items-center justify-center py-8">
+                <p className="text-sm text-neutral-700">추천할 자료가 없습니다.</p>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-3">
+                {resources.map((resource) => (
+                  <ResourceCard
+                    key={resource.id}
+                    title={resource.title}
+                    url={resource.url}
+                    onAdd={onAddResource ? () => onAddResource(resource) : undefined}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  );
+}

--- a/src/stories/roadmap-editor/LoadingButton.stories.tsx
+++ b/src/stories/roadmap-editor/LoadingButton.stories.tsx
@@ -1,0 +1,36 @@
+import { LoadingButton } from '@/features/roadmap-editor/components/atoms/LoadingButton';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/Atoms/LoadingButton',
+  component: LoadingButton,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof LoadingButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: '로드맵 생성하기',
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+    loadingText: '생성중',
+    children: '로드맵 생성하기',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    children: '로드맵 생성하기',
+  },
+};

--- a/src/stories/roadmap-editor/ResourceCard.stories.tsx
+++ b/src/stories/roadmap-editor/ResourceCard.stories.tsx
@@ -1,0 +1,38 @@
+import { ResourceCard } from '@/features/roadmap-editor/components/molecules/ResourceCard';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/Molecules/ResourceCard',
+  component: ResourceCard,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ResourceCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: 'React Official Documentation',
+    url: 'https://react.dev',
+    onAdd: () => alert('Resource added!'),
+  },
+};
+
+export const WithoutAddButton: Story = {
+  args: {
+    title: 'React Official Documentation',
+    url: 'https://react.dev',
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    title: 'Complete Guide to React Hooks and Modern React Development Patterns',
+    url: 'https://react.dev/learn/hooks',
+    onAdd: () => alert('Resource added!'),
+  },
+};

--- a/src/stories/roadmap-editor/RoadmapGenerationForm.stories.tsx
+++ b/src/stories/roadmap-editor/RoadmapGenerationForm.stories.tsx
@@ -1,0 +1,28 @@
+import { RoadmapGenerationForm } from '@/features/roadmap-editor/components/molecules/RoadmapGenerationForm';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/Molecules/RoadmapGenerationForm',
+  component: RoadmapGenerationForm,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof RoadmapGenerationForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onSubmit: (prompt: string) => alert(`Submitted: ${prompt}`),
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+    onSubmit: (prompt: string) => alert(`Submitted: ${prompt}`),
+  },
+};


### PR DESCRIPTION
## 📋 관련 이슈

Closes #96

## 📝 작업 내용

AI 모달의 폼과 로딩 상태를 구현했습니다.

### 새로 추가된 컴포넌트

#### LoadingButton (Atom)
- **Height**: 36px (Figma 스펙)
- **Loading state**: Opacity 50%, Loader icon (13.25px) + "생성중"/"수정중"
- **Disabled state**: cursor-not-allowed
- **Features**: Spinner animation, dynamic text

#### ResourceCard (Molecule)
- **URL/Title display**: Truncate 처리
- **External link icon**: 4px size
- **Add button**: + icon with primary background
- **Target**: Opens in new tab with security attributes

#### RoadmapGenerationForm (Molecule)
- **Textarea**: 120px height, resizable
- **Placeholder**: "생성할 로드맵의 정보를 자세히 알려주세요."
- **Validation**: 빈 입력 시 제출 버튼 비활성화
- **Loading state**: 폼 전체 비활성화

#### RoadmapModificationForm (Molecule)
- RoadmapGenerationForm과 유사하나 텍스트/플레이스홀더 변경
- **Placeholder**: "수정할 내용을 자세히 알려주세요."
- **Button text**: "로드맵 수정하기" / "수정중"

#### ResourceRecommendationModal (Organism)
- **Header**: Sparkles icon + "자료 추천" 제목
- **Content area**: Max height 400px, overflow-y scroll
- **Resource list**: ResourceCard 컴포넌트 배열
- **Empty state**: "추천할 자료가 없습니다."
- **Loading state**: "자료를 불러오는 중..."

### 테스트 & 문서화
- **18개 단위 테스트** 작성
  - LoadingButton: 6 tests
  - ResourceCard: 5 tests
  - RoadmapGenerationForm: 7 tests
- **3개 Storybook 스토리** 추가
  - LoadingButton: Default, Loading, Disabled
  - ResourceCard: Default, WithoutAddButton, LongTitle
  - RoadmapGenerationForm: Default, Loading

### 기술적 구현
- **Form validation**: Empty input 체크
- **Accessibility**: aria-label, aria-hidden 적용
- **Responsive**: Truncate long text, flexible widths
- **Type safety**: TypeScript strict mode

## ✅ 체크리스트

- [x] 관련 이슈 연결
- [x] 셀프 코드 리뷰 완료
- [x] 컨벤션 준수 확인
- [x] 린트/빌드 통과 확인
- [x] 테스트 통과 확인 (214/214 passed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)