### PR TITLE
feat(#98): add multi-select improvements with mixed states

### DIFF
--- a/.claude/rules/accessibility-guidelines.md
+++ b/.claude/rules/accessibility-guidelines.md
@@ -1,0 +1,268 @@
+# Accessibility Guidelines
+
+## 목표
+
+Jagalchi 로드맵 에디터는 모든 사용자가 접근 가능하도록 WCAG 2.1 AA 기준을 준수합니다.
+
+---
+
+## 1. 키보드 접근성
+
+### 필수 요구사항
+
+- [ ] **Tab 네비게이션**: 모든 인터랙티브 요소는 Tab 키로 접근 가능해야 함
+- [ ] **포커스 표시**: 포커스된 요소는 명확한 시각적 표시가 있어야 함
+- [ ] **Enter/Space 동작**: 버튼은 Enter 또는 Space로 활성화되어야 함
+- [ ] **Escape 닫기**: 모달, 드롭다운 등은 Escape 키로 닫혀야 함
+
+### 구현 예시
+
+```tsx
+// ✅ Good - Tab으로 접근 가능한 버튼
+<button onClick={handleClick} aria-label="노드 추가">
+  <PlusIcon />
+</button>
+
+// ❌ Bad - div는 기본적으로 포커스 불가
+<div onClick={handleClick}>
+  <PlusIcon />
+</div>
+
+// ✅ Good - div를 사용해야 한다면 role과 tabIndex 추가
+<div role="button" tabIndex={0} onClick={handleClick} onKeyDown={handleKeyDown}>
+  <PlusIcon />
+</div>
+```
+
+---
+
+## 2. ARIA 속성
+
+### 필수 ARIA 속성
+
+| 요소               | 필수 속성                     | 예시                                    |
+| ------------------ | ----------------------------- | --------------------------------------- |
+| 버튼 (아이콘 전용) | `aria-label`                  | `<button aria-label="삭제">`            |
+| 툴팁               | `role="tooltip"`              | `<div role="tooltip">`                  |
+| 모달               | `role="dialog"`, `aria-modal` | `<div role="dialog" aria-modal="true">` |
+| 토글 버튼          | `aria-pressed`                | `<button aria-pressed={isActive}>`      |
+| 확장/축소          | `aria-expanded`               | `<button aria-expanded={isOpen}>`       |
+
+### 구현 예시
+
+```tsx
+// EditorDivider - Separator
+<div role="separator" aria-orientation="horizontal" aria-label="섹션 구분선" />
+
+// EditorTooltip - Tooltip with aria-describedby
+<button aria-describedby={tooltipId}>Hover me</button>
+<div id={tooltipId} role="tooltip">Tooltip content</div>
+
+// Modal
+<div
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="modal-title"
+  aria-describedby="modal-description"
+>
+  <h2 id="modal-title">Modal Title</h2>
+  <p id="modal-description">Modal description</p>
+</div>
+```
+
+---
+
+## 3. 색상 대비
+
+### WCAG AA 기준
+
+- **일반 텍스트**: 최소 4.5:1 대비
+- **큰 텍스트 (18pt+)**: 최소 3:1 대비
+- **UI 컴포넌트**: 최소 3:1 대비
+
+### Figma 디자인 토큰 대비 검증
+
+| 조합                     | 대비율 | 통과 여부               |
+| ------------------------ | ------ | ----------------------- |
+| neutral-900 on neutral-0 | 16:1   | ✅ Pass                 |
+| neutral-700 on neutral-0 | 8:1    | ✅ Pass                 |
+| neutral-0 on neutral-900 | 16:1   | ✅ Pass                 |
+| primary-500 on neutral-0 | 4.6:1  | ✅ Pass                 |
+| neutral-200 on neutral-0 | 1.3:1  | ❌ Fail (장식용만 사용) |
+
+### 구현 예시
+
+```tsx
+// ✅ Good - 충분한 대비
+<p className="text-neutral-900 bg-neutral-0">읽기 쉬운 텍스트</p>
+
+// ⚠️ Caution - neutral-200는 장식용으로만 (divider, border)
+<div className="border-neutral-200" />
+
+// ❌ Bad - 낮은 대비 (텍스트에 사용 금지)
+<p className="text-neutral-200 bg-neutral-0">읽기 어려운 텍스트</p>
+```
+
+---
+
+## 4. 포커스 관리
+
+### 포커스 이동 규칙
+
+1. **모달 열림**: 모달 내 첫 번째 포커스 가능 요소로 이동
+2. **모달 닫힘**: 모달을 연 트리거 요소로 복귀
+3. **아이템 삭제**: 다음 아이템 또는 이전 아이템으로 이동
+4. **Tab 순환**: 모달 내에서 Tab 키가 순환해야 함 (focus trap)
+
+### 구현 예시
+
+```tsx
+// 모달 포커스 트랩 예시
+import { useEffect, useRef } from 'react';
+
+function Modal({ isOpen, onClose }: ModalProps) {
+  const firstFocusableRef = useRef<HTMLButtonElement>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      // 모달 열릴 때: 트리거 저장 & 첫 번째 요소 포커스
+      triggerRef.current = document.activeElement as HTMLElement;
+      firstFocusableRef.current?.focus();
+    } else {
+      // 모달 닫힐 때: 트리거로 복귀
+      triggerRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  return (
+    <div role="dialog" aria-modal="true">
+      <button ref={firstFocusableRef} onClick={onClose}>
+        Close
+      </button>
+    </div>
+  );
+}
+```
+
+---
+
+## 5. 스크린 리더 지원
+
+### 필수 요구사항
+
+- [ ] **대체 텍스트**: 모든 이미지/아이콘에 `alt` 또는 `aria-label` 제공
+- [ ] **상태 변경 알림**: `aria-live`로 동적 변경 알림
+- [ ] **숨김 요소**: 장식용 요소는 `aria-hidden="true"` 또는 `role="presentation"`
+- [ ] **의미 있는 링크**: "여기 클릭" 대신 "로드맵 생성하기"
+
+### 구현 예시
+
+```tsx
+// ✅ Good - 아이콘 버튼에 명확한 레이블
+<button aria-label="노드 추가">
+  <PlusIcon aria-hidden="true" />
+</button>
+
+// ✅ Good - 동적 변경 알림
+<div aria-live="polite" aria-atomic="true">
+  {savedMessage && <p>로드맵이 저장되었습니다.</p>}
+</div>
+
+// ❌ Bad - 불명확한 링크
+<a href="/create">여기를 클릭하세요</a>
+
+// ✅ Good - 명확한 링크
+<a href="/create">새 로드맵 만들기</a>
+```
+
+---
+
+## 6. 에디터 특화 접근성
+
+### 캔버스 조작
+
+- **키보드 노드 선택**: Arrow 키로 노드 간 이동
+- **노드 편집**: Enter 키로 편집 모드 진입
+- **다중 선택**: Shift + Arrow 키
+- **삭제**: Delete 또는 Backspace 키
+
+### 구현 예시
+
+```tsx
+// 캔버스 키보드 네비게이션
+function RoadmapCanvas() {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'ArrowRight') {
+      // 오른쪽 노드로 포커스 이동
+      focusNextNode('right');
+    } else if (e.key === 'ArrowLeft') {
+      // 왼쪽 노드로 포커스 이동
+      focusNextNode('left');
+    } else if (e.key === 'Enter') {
+      // 선택된 노드 편집 모드
+      enterEditMode();
+    } else if (e.key === 'Delete' || e.key === 'Backspace') {
+      // 선택된 노드 삭제
+      deleteSelectedNodes();
+    }
+  };
+
+  return <div role="application" onKeyDown={handleKeyDown} aria-label="로드맵 캔버스"></div>;
+}
+```
+
+---
+
+## 7. 체크리스트
+
+### 컴포넌트 제작 시 필수 검증
+
+- [ ] Tab 키로 모든 요소 접근 가능
+- [ ] 포커스 표시가 명확함
+- [ ] 키보드만으로 모든 기능 사용 가능
+- [ ] ARIA 속성이 올바르게 적용됨
+- [ ] 색상 대비가 WCAG AA 기준 충족
+- [ ] 스크린 리더로 테스트 완료 (VoiceOver/NVDA)
+- [ ] Lighthouse 접근성 점수 90점 이상
+
+---
+
+## 8. 테스트 도구
+
+### 자동화 도구
+
+- **Lighthouse**: Chrome DevTools > Lighthouse > Accessibility
+- **axe DevTools**: Chrome Extension
+- **eslint-plugin-jsx-a11y**: ESLint 플러그인
+
+### 수동 테스트
+
+- **키보드 전용 테스트**: 마우스 없이 모든 기능 사용해보기
+- **스크린 리더 테스트**:
+  - macOS: VoiceOver (Cmd + F5)
+  - Windows: NVDA (무료)
+- **확대 테스트**: 브라우저 확대 200%에서 레이아웃 깨지지 않는지 확인
+
+---
+
+## 9. 참고 문서
+
+- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)
+- [WAI-ARIA Practices](https://www.w3.org/WAI/ARIA/apg/)
+- [MDN Accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility)
+- [Inclusive Components](https://inclusive-components.design/)
+
+---
+
+## 10. 예외 사항
+
+### 허용되는 예외
+
+- **Canvas 인터랙션**: React Flow 캔버스의 드래그 앤 드롭은 마우스 중심이므로, 키보드 대안 제공
+- **복잡한 시각화**: 그래프/차트는 데이터 테이블 대안 제공
+- **실시간 협업**: 다른 사용자의 커서는 장식용으로 간주 (`aria-hidden="true"`)
+
+---
+
+이 가이드라인은 프로젝트가 성장함에 따라 지속적으로 업데이트됩니다.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,35 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+  /* Figma Design Tokens - Neutral Colors */
+  --color-neutral-0: #ffffff;
+  --color-neutral-50: #f9fafb;
+  --color-neutral-100: #f3f4f6;
+  --color-neutral-200: #e5e7eb;
+  --color-neutral-300: #d1d5db;
+  --color-neutral-700: #374151;
+  --color-neutral-800: #1f2937;
+  --color-neutral-900: #111827;
+
+  /* Figma Design Tokens - Primary Colors */
+  --color-primary-500: #3b82f6;
+
+  /* Figma Design Tokens - Border Radius */
+  --radius-tooltip: 6px;
+  --radius-divider: 0px;
+
+  /* Figma Design Tokens - Spacing */
+  --spacing-divider-vertical: 12px;
+  --spacing-divider-horizontal: 12px;
+  --spacing-tooltip-x: 10px;
+  --spacing-tooltip-y: 6px;
+
+  /* Figma Design Tokens - Breakpoints (defined as custom properties for reference) */
+  --breakpoint-tablet: 768px;
+  --breakpoint-desktop: 1024px;
+  --breakpoint-wide: 1440px;
+
+  /* Existing shadcn/ui tokens */
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
@@ -42,6 +71,11 @@
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
 }
+
+/* Figma Design Tokens - Responsive Breakpoints */
+@custom-media --tablet (min-width: 768px);
+@custom-media --desktop (min-width: 1024px);
+@custom-media --wide (min-width: 1440px);
 
 :root {
   --radius: 0.625rem;

--- a/src/features/roadmap-editor/components/atoms/ColorPicker/ColorPicker.test.tsx
+++ b/src/features/roadmap-editor/components/atoms/ColorPicker/ColorPicker.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ColorPicker } from './index';
+
+describe('ColorPicker', () => {
+  const mockOnChange = vi.fn();
+
+  it('레이블과 함께 렌더링된다', () => {
+    render(<ColorPicker label="Pick Color" value="#3b82f6" onChange={mockOnChange} />);
+
+    expect(screen.getByText('Pick Color')).toBeInTheDocument();
+  });
+
+  it('현재 색상 값을 표시한다', () => {
+    render(<ColorPicker value="#3b82f6" onChange={mockOnChange} />);
+
+    expect(screen.getByText('#3b82f6')).toBeInTheDocument();
+  });
+
+  it('버튼 클릭 시 popover를 연다', async () => {
+    const user = userEvent.setup();
+
+    render(<ColorPicker value="#3b82f6" onChange={mockOnChange} />);
+
+    const button = screen.getByLabelText('Pick a color');
+    await user.click(button);
+
+    expect(screen.getByText('Custom Color')).toBeInTheDocument();
+  });
+
+  it('recent colors를 표시한다', async () => {
+    const user = userEvent.setup();
+    const recentColors = ['#ef4444', '#10b981'];
+
+    render(<ColorPicker value="#3b82f6" onChange={mockOnChange} recentColors={recentColors} />);
+
+    const button = screen.getByLabelText('Pick a color');
+    await user.click(button);
+
+    expect(screen.getByText('Recent Colors')).toBeInTheDocument();
+  });
+
+  it('색상 변경 시 onChange 핸들러를 호출한다', async () => {
+    const user = userEvent.setup();
+
+    render(<ColorPicker value="#3b82f6" onChange={mockOnChange} />);
+
+    const button = screen.getByLabelText('Pick a color');
+    await user.click(button);
+
+    // Click on a preset color button
+    const redColorButton = screen.getByLabelText('Select color #ef4444');
+    await user.click(redColorButton);
+
+    expect(mockOnChange).toHaveBeenCalledWith('#ef4444');
+  });
+});

--- a/src/features/roadmap-editor/components/atoms/ColorPicker/index.tsx
+++ b/src/features/roadmap-editor/components/atoms/ColorPicker/index.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface ColorPickerProps {
+  label?: string;
+  value: string;
+  onChange: (color: string) => void;
+  recentColors?: string[];
+  className?: string;
+}
+
+const DEFAULT_COLORS = [
+  '#ef4444',
+  '#f97316',
+  '#f59e0b',
+  '#eab308',
+  '#84cc16',
+  '#22c55e',
+  '#10b981',
+  '#14b8a6',
+  '#06b6d4',
+  '#0ea5e9',
+  '#3b82f6',
+  '#6366f1',
+  '#8b5cf6',
+  '#a855f7',
+  '#d946ef',
+  '#ec4899',
+];
+
+export function ColorPicker({
+  label,
+  value,
+  onChange,
+  recentColors = [],
+  className,
+}: ColorPickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className={cn('relative flex flex-col gap-1', className)}>
+      {label && <label className="text-xs font-medium text-neutral-700">{label}</label>}
+
+      {/* Color Preview Button */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="focus:border-primary-500 focus:ring-primary-500 flex h-9 items-center gap-2 rounded-md border border-neutral-300 px-3 py-2 hover:bg-neutral-50 focus:ring-1 focus:outline-none"
+        aria-label="Pick a color"
+      >
+        <div
+          className="h-5 w-5 rounded-full border-2 border-neutral-300"
+          style={{ backgroundColor: value }}
+        />
+        <span className="font-mono text-sm uppercase">{value}</span>
+      </button>
+
+      {/* Color Picker Popover */}
+      {isOpen && (
+        <>
+          {/* Backdrop */}
+          <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} aria-hidden="true" />
+
+          {/* Popover */}
+          <div className="bg-neutral-0 absolute top-full z-50 mt-2 w-60 rounded-lg border border-neutral-200 p-4 shadow-lg">
+            {/* Custom Color Input */}
+            <div className="mb-4">
+              <label className="mb-1 block text-xs font-medium text-neutral-700">
+                Custom Color
+              </label>
+              <input
+                type="color"
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                className="h-9 w-full cursor-pointer rounded-md border border-neutral-300"
+              />
+            </div>
+
+            {/* Preset Colors */}
+            <div className="mb-4">
+              <label className="mb-2 block text-xs font-medium text-neutral-700">
+                Preset Colors
+              </label>
+              <div className="grid grid-cols-8 gap-2">
+                {DEFAULT_COLORS.map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    onClick={() => {
+                      onChange(color);
+                      setIsOpen(false);
+                    }}
+                    className={cn(
+                      'h-6 w-6 rounded-md border-2 transition-transform hover:scale-110',
+                      value === color ? 'border-primary-500' : 'border-neutral-300',
+                    )}
+                    style={{ backgroundColor: color }}
+                    aria-label={`Select color ${color}`}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Recent Colors */}
+            {recentColors.length > 0 && (
+              <div>
+                <label className="mb-2 block text-xs font-medium text-neutral-700">
+                  Recent Colors
+                </label>
+                <div className="flex gap-2">
+                  {recentColors.map((color, index) => (
+                    <button
+                      key={`${color}-${index}`}
+                      type="button"
+                      onClick={() => {
+                        onChange(color);
+                        setIsOpen(false);
+                      }}
+                      className={cn(
+                        'h-6 w-6 rounded-md border-2 transition-transform hover:scale-110',
+                        value === color ? 'border-primary-500' : 'border-neutral-300',
+                      )}
+                      style={{ backgroundColor: color }}
+                      aria-label={`Select recent color ${color}`}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/roadmap-editor/components/atoms/EditorCheckbox/EditorCheckbox.test.tsx
+++ b/src/features/roadmap-editor/components/atoms/EditorCheckbox/EditorCheckbox.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EditorCheckbox } from './index';
+
+describe('EditorCheckbox', () => {
+  it('renders checkbox with label', () => {
+    render(<EditorCheckbox label="Accept terms" id="terms" />);
+
+    const checkbox = screen.getByRole('checkbox');
+    const label = screen.getByText('Accept terms');
+
+    expect(checkbox).toBeInTheDocument();
+    expect(label).toBeInTheDocument();
+  });
+
+  it('renders checkbox without label', () => {
+    render(<EditorCheckbox aria-label="Checkbox" />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeInTheDocument();
+    expect(screen.queryByRole('label')).not.toBeInTheDocument();
+  });
+
+  it('handles checked state', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(<EditorCheckbox label="Option" checked={false} onChange={handleChange} />);
+
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+
+    await user.click(checkbox);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies indeterminate state', () => {
+    render(<EditorCheckbox label="Select all" indeterminate />);
+
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.indeterminate).toBe(true);
+  });
+
+  it('clears indeterminate when checked', () => {
+    const { rerender } = render(
+      <EditorCheckbox label="Select all" indeterminate checked={false} />,
+    );
+
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.indeterminate).toBe(true);
+
+    rerender(<EditorCheckbox label="Select all" indeterminate={false} checked />);
+    expect(checkbox.indeterminate).toBe(false);
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('disables checkbox when disabled prop is true', () => {
+    render(<EditorCheckbox label="Disabled option" disabled />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeDisabled();
+  });
+
+  it('applies custom className', () => {
+    render(<EditorCheckbox label="Custom" className="custom-class" />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.className).toContain('custom-class');
+  });
+});

--- a/src/features/roadmap-editor/components/atoms/EditorCheckbox/index.tsx
+++ b/src/features/roadmap-editor/components/atoms/EditorCheckbox/index.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { forwardRef, useEffect, useRef } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface EditorCheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  label?: string;
+  indeterminate?: boolean;
+}
+
+export const EditorCheckbox = forwardRef<HTMLInputElement, EditorCheckboxProps>(
+  ({ label, indeterminate = false, className, checked, ...props }, ref) => {
+    const defaultRef = useRef<HTMLInputElement>(null);
+    const checkboxRef = (ref as React.RefObject<HTMLInputElement>) || defaultRef;
+
+    useEffect(() => {
+      if (checkboxRef.current) {
+        checkboxRef.current.indeterminate = indeterminate;
+      }
+    }, [indeterminate, checkboxRef]);
+
+    return (
+      <div className="flex items-center gap-2">
+        <input
+          ref={checkboxRef}
+          type="checkbox"
+          checked={checked}
+          className={cn(
+            'focus:ring-primary-500 text-primary-500 h-4 w-4 rounded border-neutral-300 focus:ring-2 focus:ring-offset-0',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            className,
+          )}
+          {...props}
+        />
+        {label && (
+          <label
+            className={cn(
+              'text-sm text-neutral-700',
+              props.disabled && 'cursor-not-allowed opacity-50',
+            )}
+            htmlFor={props.id}
+          >
+            {label}
+          </label>
+        )}
+      </div>
+    );
+  },
+);
+
+EditorCheckbox.displayName = 'EditorCheckbox';

--- a/src/features/roadmap-editor/components/atoms/EditorDivider/EditorDivider.test.tsx
+++ b/src/features/roadmap-editor/components/atoms/EditorDivider/EditorDivider.test.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { EditorDivider } from './index';
+
+describe('EditorDivider', () => {
+  it('기본적으로 horizontal divider를 렌더링한다', () => {
+    const { container } = render(<EditorDivider />);
+    const divider = container.firstChild as HTMLElement;
+
+    expect(divider).toHaveAttribute('role', 'separator');
+    expect(divider).toHaveAttribute('aria-orientation', 'horizontal');
+    expect(divider.className).toContain('h-px');
+    expect(divider.className).toContain('w-full');
+  });
+
+  it('vertical orientation을 렌더링한다', () => {
+    const { container } = render(<EditorDivider orientation="vertical" />);
+    const divider = container.firstChild as HTMLElement;
+
+    expect(divider).toHaveAttribute('aria-orientation', 'vertical');
+    expect(divider.className).toContain('w-px');
+    expect(divider.className).toContain('h-full');
+  });
+
+  it('neutral-200 배경색을 적용한다', () => {
+    const { container } = render(<EditorDivider />);
+    const divider = container.firstChild as HTMLElement;
+
+    expect(divider.className).toContain('bg-neutral-200');
+  });
+
+  it('커스텀 className을 적용한다', () => {
+    const { container } = render(<EditorDivider className="custom-class" />);
+    const divider = container.firstChild as HTMLElement;
+
+    expect(divider.className).toContain('custom-class');
+  });
+
+  it('aria-label을 설정한다', () => {
+    const { container } = render(<EditorDivider aria-label="Section divider" />);
+    const divider = container.firstChild as HTMLElement;
+
+    expect(divider).toHaveAttribute('aria-label', 'Section divider');
+  });
+
+  it('horizontal divider는 12px vertical margin을 가진다', () => {
+    const { container } = render(<EditorDivider orientation="horizontal" />);
+    const divider = container.firstChild as HTMLElement;
+
+    expect(divider.className).toContain('my-[var(--spacing-divider-vertical)]');
+  });
+
+  it('vertical divider는 12px horizontal margin을 가진다', () => {
+    const { container } = render(<EditorDivider orientation="vertical" />);
+    const divider = container.firstChild as HTMLElement;
+
+    expect(divider.className).toContain('mx-[var(--spacing-divider-horizontal)]');
+  });
+});

--- a/src/features/roadmap-editor/components/atoms/EditorDivider/index.tsx
+++ b/src/features/roadmap-editor/components/atoms/EditorDivider/index.tsx
@@ -1,0 +1,47 @@
+import { cn } from '@/lib/utils';
+
+interface EditorDividerProps {
+  /**
+   * Divider orientation
+   * @default 'horizontal'
+   */
+  orientation?: 'horizontal' | 'vertical';
+
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+
+  /**
+   * ARIA label for accessibility
+   */
+  'aria-label'?: string;
+}
+
+/**
+ * EditorDivider - Separator component for roadmap editor
+ *
+ * Figma specs:
+ * - Horizontal: 1px height, neutral-200, 12px vertical margin
+ * - Vertical: 1px width, neutral-200, 12px horizontal margin
+ */
+export function EditorDivider({
+  orientation = 'horizontal',
+  className,
+  'aria-label': ariaLabel,
+}: EditorDividerProps) {
+  return (
+    <div
+      role="separator"
+      aria-orientation={orientation}
+      aria-label={ariaLabel}
+      className={cn(
+        'bg-neutral-200',
+        orientation === 'horizontal'
+          ? 'my-[var(--spacing-divider-vertical)] h-px w-full'
+          : 'mx-[var(--spacing-divider-horizontal)] h-full w-px',
+        className,
+      )}
+    />
+  );
+}

--- a/src/features/roadmap-editor/components/atoms/EditorInput/EditorInput.test.tsx
+++ b/src/features/roadmap-editor/components/atoms/EditorInput/EditorInput.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EditorInput } from './index';
+
+describe('EditorInput', () => {
+  it('레이블과 함께 렌더링된다', () => {
+    render(<EditorInput label="Test Label" />);
+
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+  });
+
+  it('입력 필드가 36px 높이(h-9)를 가진다', () => {
+    const { container } = render(<EditorInput />);
+    const input = container.querySelector('input') as HTMLElement;
+
+    expect(input.className).toContain('h-9');
+  });
+
+  it('사용자 입력이 올바르게 처리된다', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<EditorInput onChange={onChange} />);
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'Test');
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('에러 메시지를 표시한다', () => {
+    render(<EditorInput error="This is an error" />);
+
+    expect(screen.getByText('This is an error')).toBeInTheDocument();
+  });
+
+  it('에러 상태일 때 빨간색 border를 적용한다', () => {
+    const { container } = render(<EditorInput error="Error message" />);
+    const input = container.querySelector('input') as HTMLElement;
+
+    expect(input.className).toContain('border-red-500');
+  });
+
+  it('비활성화 상태를 올바르게 처리한다', () => {
+    render(<EditorInput disabled />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toBeDisabled();
+  });
+
+  it('placeholder를 표시한다', () => {
+    render(<EditorInput placeholder="Enter text" />);
+
+    expect(screen.getByPlaceholderText('Enter text')).toBeInTheDocument();
+  });
+});

--- a/src/features/roadmap-editor/components/atoms/EditorInput/index.tsx
+++ b/src/features/roadmap-editor/components/atoms/EditorInput/index.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { forwardRef, useId } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface EditorInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+}
+
+export const EditorInput = forwardRef<HTMLInputElement, EditorInputProps>(
+  ({ label, error, className, id, ...props }, ref) => {
+    const generatedId = useId();
+    const inputId = id || generatedId;
+
+    return (
+      <div className="flex flex-col gap-1">
+        {label && (
+          <label className="text-xs font-medium text-neutral-700" htmlFor={inputId}>
+            {label}
+          </label>
+        )}
+        <input
+          ref={ref}
+          id={inputId}
+          className={cn(
+            'focus:border-primary-500 focus:ring-primary-500 h-9 rounded-md border border-neutral-300 px-3 py-2 text-sm placeholder:text-neutral-400 focus:ring-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+            error && 'border-red-500 focus:border-red-500 focus:ring-red-500',
+            className,
+          )}
+          {...props}
+        />
+        {error && <p className="text-xs text-red-500">{error}</p>}
+      </div>
+    );
+  },
+);
+
+EditorInput.displayName = 'EditorInput';

--- a/src/features/roadmap-editor/components/atoms/EditorTooltip/EditorTooltip.test.tsx
+++ b/src/features/roadmap-editor/components/atoms/EditorTooltip/EditorTooltip.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { EditorTooltip } from './index';
+
+describe('EditorTooltip', () => {
+  it('마우스 호버 시 tooltip을 표시한다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EditorTooltip content="Tooltip content" delay={0}>
+        <button>Hover me</button>
+      </EditorTooltip>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Hover me' });
+    await user.hover(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      expect(screen.getByText('Tooltip content')).toBeInTheDocument();
+    });
+  });
+
+  it('마우스 떠나면 tooltip을 숨긴다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EditorTooltip content="Tooltip content" delay={0}>
+        <button>Hover me</button>
+      </EditorTooltip>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Hover me' });
+    await user.hover(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    });
+
+    await user.unhover(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  it('키보드 포커스 시 tooltip을 표시한다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <EditorTooltip content="Tooltip content" delay={0}>
+        <button>Focus me</button>
+      </EditorTooltip>,
+    );
+
+    await user.tab(); // Focus the button
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    });
+  });
+
+  it('블러 시 tooltip을 숨긴다', async () => {
+    render(
+      <EditorTooltip content="Tooltip content" delay={0}>
+        <button>Focus me</button>
+      </EditorTooltip>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Focus me' });
+    trigger.focus();
+
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    });
+
+    trigger.blur();
+
+    await waitFor(() => {
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  it('컴포넌트가 올바른 스타일 클래스를 적용한다', () => {
+    render(
+      <EditorTooltip content="Tooltip content" delay={0}>
+        <button>Hover me</button>
+      </EditorTooltip>,
+    );
+
+    // 컴포넌트가 렌더링되었는지 확인
+    expect(screen.getByRole('button', { name: 'Hover me' })).toBeInTheDocument();
+  });
+});

--- a/src/features/roadmap-editor/components/atoms/EditorTooltip/index.tsx
+++ b/src/features/roadmap-editor/components/atoms/EditorTooltip/index.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { cloneElement, useEffect, useId, useRef, useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface EditorTooltipProps {
+  /**
+   * Tooltip content
+   */
+  content: string;
+
+  /**
+   * Trigger element
+   */
+  children: React.ReactElement<
+    React.HTMLAttributes<HTMLElement> & {
+      onMouseEnter?: () => void;
+      onMouseLeave?: () => void;
+      onFocus?: () => void;
+      onBlur?: () => void;
+      'aria-describedby'?: string;
+    }
+  >;
+
+  /**
+   * Delay before showing tooltip (ms)
+   * @default 500
+   */
+  delay?: number;
+
+  /**
+   * Additional CSS classes for tooltip
+   */
+  className?: string;
+
+  /**
+   * Tooltip placement
+   * @default 'top'
+   */
+  side?: 'top' | 'right' | 'bottom' | 'left';
+}
+
+/**
+ * EditorTooltip - Accessible tooltip component for roadmap editor
+ *
+ * Figma specs:
+ * - Background: neutral-900
+ * - Text: white, 12px
+ * - Padding: 6px 10px
+ * - Border radius: 6px
+ * - Delay: 500ms
+ * - Max width: 200px
+ */
+export function EditorTooltip({
+  content,
+  children,
+  delay = 500,
+  className,
+  side = 'top',
+}: EditorTooltipProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tooltipId = useId();
+
+  const handleMouseEnter = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(true);
+    }, delay);
+  };
+
+  const handleMouseLeave = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  const handleFocus = () => {
+    timeoutRef.current = setTimeout(() => {
+      setIsVisible(true);
+    }, delay);
+  };
+
+  const handleBlur = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    setIsVisible(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const positionClasses = {
+    top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+    bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+    left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+    right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+  };
+
+  const arrowClasses = {
+    top: 'top-full left-1/2 -translate-x-1/2 border-l-transparent border-r-transparent border-b-transparent border-t-neutral-900',
+    bottom:
+      'bottom-full left-1/2 -translate-x-1/2 border-l-transparent border-r-transparent border-t-transparent border-b-neutral-900',
+    left: 'left-full top-1/2 -translate-y-1/2 border-t-transparent border-b-transparent border-r-transparent border-l-neutral-900',
+    right:
+      'right-full top-1/2 -translate-y-1/2 border-t-transparent border-b-transparent border-l-transparent border-r-neutral-900',
+  };
+
+  return (
+    <div className="relative inline-block">
+      {/* eslint-disable-next-line react-hooks/refs */}
+      {cloneElement(children, {
+        onMouseEnter: handleMouseEnter,
+        onMouseLeave: handleMouseLeave,
+        onFocus: handleFocus,
+        onBlur: handleBlur,
+        'aria-describedby': isVisible ? tooltipId : undefined,
+      })}
+
+      {isVisible && (
+        <div
+          id={tooltipId}
+          role="tooltip"
+          className={cn(
+            'absolute z-50 max-w-[200px] rounded-[var(--radius-tooltip)] bg-neutral-900 px-[var(--spacing-tooltip-x)] py-[var(--spacing-tooltip-y)] text-xs text-white',
+            positionClasses[side],
+            className,
+          )}
+        >
+          {content}
+          {/* Arrow */}
+          <div
+            className={cn('absolute h-0 w-0 border-[4px]', arrowClasses[side])}
+            aria-hidden="true"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/roadmap-editor/components/molecules/CollapseSection/CollapseSection.test.tsx
+++ b/src/features/roadmap-editor/components/molecules/CollapseSection/CollapseSection.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { CollapseSection } from './index';
+
+describe('CollapseSection', () => {
+  it('제목과 children을 렌더링한다', () => {
+    render(
+      <CollapseSection title="Test Section">
+        <div>Test Content</div>
+      </CollapseSection>,
+    );
+
+    expect(screen.getByText('Test Section')).toBeInTheDocument();
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('기본적으로 열려있다', () => {
+    render(
+      <CollapseSection title="Test Section">
+        <div>Test Content</div>
+      </CollapseSection>,
+    );
+
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('defaultOpen={false}일 때 닫혀있다', () => {
+    render(
+      <CollapseSection title="Test Section" defaultOpen={false}>
+        <div>Test Content</div>
+      </CollapseSection>,
+    );
+
+    expect(screen.queryByText('Test Content')).not.toBeInTheDocument();
+  });
+
+  it('클릭 시 토글된다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CollapseSection title="Test Section">
+        <div>Test Content</div>
+      </CollapseSection>,
+    );
+
+    const button = screen.getByRole('button');
+
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+
+    await user.click(button);
+    expect(screen.queryByText('Test Content')).not.toBeInTheDocument();
+
+    await user.click(button);
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('aria-expanded 속성이 올바르게 설정된다', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CollapseSection title="Test Section">
+        <div>Test Content</div>
+      </CollapseSection>,
+    );
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/src/features/roadmap-editor/components/molecules/CollapseSection/index.tsx
+++ b/src/features/roadmap-editor/components/molecules/CollapseSection/index.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface CollapseSectionProps {
+  title: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  className?: string;
+}
+
+export function CollapseSection({
+  title,
+  children,
+  defaultOpen = true,
+  className,
+}: CollapseSectionProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <div className={cn('border-b border-neutral-200 pb-5', className)}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="mb-3 flex w-full items-center justify-between text-left"
+        aria-expanded={isOpen}
+        aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${title} section`}
+      >
+        <span className="text-xs font-medium text-neutral-700">{title}</span>
+        <svg
+          className={cn('h-4 w-4 text-neutral-700 transition-transform', isOpen && 'rotate-180')}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && <div className="space-y-3">{children}</div>}
+    </div>
+  );
+}

--- a/src/features/roadmap-editor/components/organisms/EdgePropertiesPanel/EdgePropertiesPanel.test.tsx
+++ b/src/features/roadmap-editor/components/organisms/EdgePropertiesPanel/EdgePropertiesPanel.test.tsx
@@ -1,0 +1,201 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EdgePropertiesPanel } from './index';
+
+describe('EdgePropertiesPanel', () => {
+  describe('Single edge mode', () => {
+    const defaultProps = {
+      edgeId: 'edge-1',
+      label: 'Test Edge',
+      color: '#3b82f6',
+      strokeWidth: 2,
+      onLabelChange: vi.fn(),
+      onColorChange: vi.fn(),
+      onStrokeWidthChange: vi.fn(),
+      onDelete: vi.fn(),
+    };
+
+    it('renders edge properties with correct title', () => {
+      render(<EdgePropertiesPanel {...defaultProps} />);
+
+      expect(screen.getByText('Edge Properties')).toBeInTheDocument();
+    });
+
+    it('displays edge ID as disabled input', () => {
+      render(<EdgePropertiesPanel {...defaultProps} />);
+
+      const edgeIdInput = screen.getByDisplayValue('edge-1') as HTMLInputElement;
+      expect(edgeIdInput).toBeDisabled();
+    });
+
+    it('displays edge label', () => {
+      render(<EdgePropertiesPanel {...defaultProps} />);
+
+      expect(screen.getByDisplayValue('Test Edge')).toBeInTheDocument();
+    });
+
+    it('calls onLabelChange when label is edited', async () => {
+      const user = userEvent.setup();
+      const handleLabelChange = vi.fn();
+
+      render(<EdgePropertiesPanel {...defaultProps} onLabelChange={handleLabelChange} />);
+
+      const labelInput = screen.getByDisplayValue('Test Edge');
+      await user.clear(labelInput);
+      await user.type(labelInput, 'New Label');
+
+      expect(handleLabelChange).toHaveBeenCalled();
+    });
+
+    it('calls onStrokeWidthChange when slider is moved', () => {
+      const handleStrokeWidthChange = vi.fn();
+
+      render(
+        <EdgePropertiesPanel {...defaultProps} onStrokeWidthChange={handleStrokeWidthChange} />,
+      );
+
+      const slider = screen.getByRole('slider');
+      fireEvent.change(slider, { target: { value: '4' } });
+
+      expect(handleStrokeWidthChange).toHaveBeenCalledWith(4);
+    });
+
+    it('displays stroke width value', () => {
+      render(<EdgePropertiesPanel {...defaultProps} strokeWidth={4} />);
+
+      expect(screen.getByText('4px')).toBeInTheDocument();
+    });
+
+    it('calls onDelete when delete button is clicked', async () => {
+      const user = userEvent.setup();
+      const handleDelete = vi.fn();
+
+      render(<EdgePropertiesPanel {...defaultProps} onDelete={handleDelete} />);
+
+      const deleteButton = screen.getByLabelText('Delete edge');
+      await user.click(deleteButton);
+
+      expect(handleDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Multi-select mode', () => {
+    const selectedEdges = [
+      { id: 'edge-1', label: 'Edge 1', color: '#3b82f6', strokeWidth: 2 },
+      { id: 'edge-2', label: 'Edge 2', color: '#10b981', strokeWidth: 3 },
+      { id: 'edge-3', color: '#3b82f6', strokeWidth: 2 },
+    ];
+
+    const multiSelectProps = {
+      isMultiSelect: true,
+      selectedEdges,
+      color: '#3b82f6',
+      strokeWidth: 2,
+      onBulkColorChange: vi.fn(),
+      onBulkStrokeWidthChange: vi.fn(),
+      onBulkDelete: vi.fn(),
+    };
+
+    it('renders multi-select mode with count', () => {
+      render(<EdgePropertiesPanel {...multiSelectProps} />);
+
+      expect(screen.getByText('Edge Properties (3)')).toBeInTheDocument();
+    });
+
+    it('shows mixed color indicator when edges have different colors', () => {
+      render(<EdgePropertiesPanel {...multiSelectProps} />);
+
+      expect(screen.getByText('Stroke Color (Mixed)')).toBeInTheDocument();
+      expect(
+        screen.getByText('Selected edges have different colors. Changing will apply to all.'),
+      ).toBeInTheDocument();
+    });
+
+    it('shows mixed stroke width indicator when edges have different widths', () => {
+      render(<EdgePropertiesPanel {...multiSelectProps} />);
+
+      expect(screen.getByText('Stroke Width (Mixed)')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Selected edges have different stroke widths. Changing will apply to all.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show mixed indicators when all edges have same properties', () => {
+      const samePropsEdges = [
+        { id: 'edge-1', color: '#3b82f6', strokeWidth: 2 },
+        { id: 'edge-2', color: '#3b82f6', strokeWidth: 2 },
+      ];
+
+      render(<EdgePropertiesPanel {...multiSelectProps} selectedEdges={samePropsEdges} />);
+
+      expect(screen.queryByText('Stroke Color (Mixed)')).not.toBeInTheDocument();
+      expect(screen.queryByText('Stroke Width (Mixed)')).not.toBeInTheDocument();
+      expect(screen.getByText('Stroke Color')).toBeInTheDocument();
+      expect(screen.getByText('Stroke Width')).toBeInTheDocument();
+    });
+
+    it('displays all selected edges in the list when section is expanded', async () => {
+      const user = userEvent.setup();
+      render(<EdgePropertiesPanel {...multiSelectProps} />);
+
+      // Expand the "Selected Edges" section
+      const selectedEdgesButton = screen.getByRole('button', { name: /Expand Selected Edges/i });
+      await user.click(selectedEdgesButton);
+
+      expect(screen.getByText('edge-1')).toBeInTheDocument();
+      expect(screen.getByText('edge-2')).toBeInTheDocument();
+      expect(screen.getByText('edge-3')).toBeInTheDocument();
+    });
+
+    it('shows edge labels when available and section is expanded', async () => {
+      const user = userEvent.setup();
+      render(<EdgePropertiesPanel {...multiSelectProps} />);
+
+      // Expand the "Selected Edges" section
+      const selectedEdgesButton = screen.getByRole('button', { name: /Expand Selected Edges/i });
+      await user.click(selectedEdgesButton);
+
+      expect(screen.getByText('Edge 1')).toBeInTheDocument();
+      expect(screen.getByText('Edge 2')).toBeInTheDocument();
+    });
+
+    it('shows stroke width for each edge', () => {
+      render(<EdgePropertiesPanel {...multiSelectProps} />);
+
+      const widthLabels = screen.getAllByText(/px$/);
+      expect(widthLabels.length).toBeGreaterThan(0);
+    });
+
+    it('calls onBulkDelete when delete button is clicked', async () => {
+      const user = userEvent.setup();
+      const handleBulkDelete = vi.fn();
+
+      render(<EdgePropertiesPanel {...multiSelectProps} onBulkDelete={handleBulkDelete} />);
+
+      const deleteButton = screen.getByLabelText('Delete all selected edges');
+      await user.click(deleteButton);
+
+      expect(handleBulkDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onBulkStrokeWidthChange when slider is moved', () => {
+      const handleBulkStrokeWidthChange = vi.fn();
+
+      render(
+        <EdgePropertiesPanel
+          {...multiSelectProps}
+          onBulkStrokeWidthChange={handleBulkStrokeWidthChange}
+        />,
+      );
+
+      const slider = screen.getByRole('slider');
+      fireEvent.change(slider, { target: { value: '5' } });
+
+      expect(handleBulkStrokeWidthChange).toHaveBeenCalledWith(5);
+    });
+  });
+});

--- a/src/features/roadmap-editor/components/organisms/EdgePropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/EdgePropertiesPanel/index.tsx
@@ -6,31 +6,160 @@ import { ColorPicker } from '../../atoms/ColorPicker';
 import { EditorInput } from '../../atoms/EditorInput';
 import { CollapseSection } from '../../molecules/CollapseSection';
 
-interface EdgePropertiesPanelProps {
-  edgeId: string;
+interface EdgeData {
+  id: string;
   label?: string;
   color: string;
   strokeWidth: number;
-  onLabelChange: (label: string) => void;
-  onColorChange: (color: string) => void;
-  onStrokeWidthChange: (width: number) => void;
+}
+
+interface EdgePropertiesPanelProps {
+  // Single edge mode
+  edgeId?: string;
+  label?: string;
+  color?: string;
+  strokeWidth?: number;
+  onLabelChange?: (label: string) => void;
+  onColorChange?: (color: string) => void;
+  onStrokeWidthChange?: (width: number) => void;
   onDelete?: () => void;
+  // Multi-select mode
+  isMultiSelect?: boolean;
+  selectedEdges?: EdgeData[];
+  onBulkColorChange?: (color: string) => void;
+  onBulkStrokeWidthChange?: (width: number) => void;
+  onBulkDelete?: () => void;
 }
 
 export function EdgePropertiesPanel({
   edgeId,
   label = '',
-  color,
-  strokeWidth,
+  color = '#3b82f6',
+  strokeWidth = 2,
   onLabelChange,
   onColorChange,
   onStrokeWidthChange,
   onDelete,
+  isMultiSelect = false,
+  selectedEdges = [],
+  onBulkColorChange,
+  onBulkStrokeWidthChange,
+  onBulkDelete,
 }: EdgePropertiesPanelProps) {
   const [recentColors] = useState<string[]>(['#3b82f6', '#10b981', '#f59e0b', '#ef4444']);
 
+  // Mixed state detection
+  const colors = selectedEdges.map((edge) => edge.color);
+  const strokeWidths = selectedEdges.map((edge) => edge.strokeWidth);
+  const uniqueColors = new Set(colors);
+  const uniqueStrokeWidths = new Set(strokeWidths);
+  const isColorMixed = uniqueColors.size > 1;
+  const isStrokeWidthMixed = uniqueStrokeWidths.size > 1;
+
+  // Multi-select mode
+  if (isMultiSelect && selectedEdges.length > 0) {
+    return (
+      <div className="w-68 space-y-5">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-neutral-900">
+            Edge Properties ({selectedEdges.length})
+          </h3>
+          {onBulkDelete && (
+            <button
+              type="button"
+              onClick={onBulkDelete}
+              className="focus:ring-primary-500 rounded-md p-1 text-neutral-700 hover:bg-neutral-100 focus:ring-2 focus:outline-none"
+              aria-label="Delete all selected edges"
+            >
+              <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {/* Bulk Edit Style */}
+        <CollapseSection title="Bulk Edit Style" defaultOpen>
+          <div className="space-y-3">
+            {/* Color Picker with mixed state */}
+            <div className="flex flex-col gap-2">
+              <ColorPicker
+                label={isColorMixed ? 'Stroke Color (Mixed)' : 'Stroke Color'}
+                value={color}
+                onChange={(newColor) => onBulkColorChange?.(newColor)}
+                recentColors={recentColors}
+              />
+              {isColorMixed && (
+                <p className="text-xs text-neutral-500">
+                  Selected edges have different colors. Changing will apply to all.
+                </p>
+              )}
+            </div>
+
+            {/* Stroke Width with mixed state */}
+            <div className="flex flex-col gap-1">
+              <label className="text-xs font-medium text-neutral-700" htmlFor="bulk-stroke-width">
+                {isStrokeWidthMixed ? 'Stroke Width (Mixed)' : 'Stroke Width'}
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="bulk-stroke-width"
+                  type="range"
+                  min="1"
+                  max="8"
+                  step="1"
+                  value={strokeWidth}
+                  onChange={(e) => onBulkStrokeWidthChange?.(Number(e.target.value))}
+                  className="flex-1"
+                />
+                <span className="w-8 text-center text-sm text-neutral-700">{strokeWidth}px</span>
+              </div>
+              {isStrokeWidthMixed && (
+                <p className="text-xs text-neutral-500">
+                  Selected edges have different stroke widths. Changing will apply to all.
+                </p>
+              )}
+            </div>
+          </div>
+        </CollapseSection>
+
+        {/* Selected Edges List */}
+        <CollapseSection title="Selected Edges" defaultOpen={false}>
+          <div className="max-h-64 space-y-2 overflow-y-auto">
+            {selectedEdges.map((edge) => (
+              <div
+                key={edge.id}
+                className="flex items-center justify-between rounded-md border border-neutral-200 p-2"
+              >
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs font-medium text-neutral-900">{edge.id}</span>
+                  {edge.label && <span className="text-xs text-neutral-700">{edge.label}</span>}
+                </div>
+                <div className="flex items-center gap-2">
+                  <div
+                    className="h-3 w-3 rounded-full border border-neutral-300"
+                    style={{ backgroundColor: edge.color }}
+                    aria-label={`Color: ${edge.color}`}
+                  />
+                  <span className="text-xs text-neutral-700">{edge.strokeWidth}px</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </CollapseSection>
+      </div>
+    );
+  }
+
+  // Single edge mode
   return (
-    <div className="w-80 space-y-5">
+    <div className="w-68 space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-neutral-900">Edge Properties</h3>
@@ -65,7 +194,7 @@ export function EdgePropertiesPanel({
         <EditorInput
           label="Label"
           value={label}
-          onChange={(e) => onLabelChange(e.target.value)}
+          onChange={(e) => onLabelChange?.(e.target.value)}
           placeholder="Enter edge label (optional)"
           maxLength={50}
         />
@@ -76,7 +205,7 @@ export function EdgePropertiesPanel({
         <ColorPicker
           label="Stroke Color"
           value={color}
-          onChange={onColorChange}
+          onChange={(newColor) => onColorChange?.(newColor)}
           recentColors={recentColors}
         />
         <div className="flex flex-col gap-1">
@@ -91,7 +220,7 @@ export function EdgePropertiesPanel({
               max="8"
               step="1"
               value={strokeWidth}
-              onChange={(e) => onStrokeWidthChange(Number(e.target.value))}
+              onChange={(e) => onStrokeWidthChange?.(Number(e.target.value))}
               className="flex-1"
             />
             <span className="w-8 text-center text-sm text-neutral-700">{strokeWidth}px</span>

--- a/src/features/roadmap-editor/components/organisms/EdgePropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/EdgePropertiesPanel/index.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+
+import { ColorPicker } from '../../atoms/ColorPicker';
+import { EditorInput } from '../../atoms/EditorInput';
+import { CollapseSection } from '../../molecules/CollapseSection';
+
+interface EdgePropertiesPanelProps {
+  edgeId: string;
+  label?: string;
+  color: string;
+  strokeWidth: number;
+  onLabelChange: (label: string) => void;
+  onColorChange: (color: string) => void;
+  onStrokeWidthChange: (width: number) => void;
+  onDelete?: () => void;
+}
+
+export function EdgePropertiesPanel({
+  edgeId,
+  label = '',
+  color,
+  strokeWidth,
+  onLabelChange,
+  onColorChange,
+  onStrokeWidthChange,
+  onDelete,
+}: EdgePropertiesPanelProps) {
+  const [recentColors] = useState<string[]>(['#3b82f6', '#10b981', '#f59e0b', '#ef4444']);
+
+  return (
+    <div className="w-80 space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-neutral-900">Edge Properties</h3>
+        {onDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            className="focus:ring-primary-500 rounded-md p-1 text-neutral-700 hover:bg-neutral-100 focus:ring-2 focus:outline-none"
+            aria-label="Delete edge"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Basic Info Section */}
+      <CollapseSection title="Basic Info" defaultOpen>
+        <EditorInput
+          label="Edge ID"
+          value={edgeId}
+          disabled
+          className="bg-neutral-50"
+          aria-label="Edge ID (read-only)"
+        />
+        <EditorInput
+          label="Label"
+          value={label}
+          onChange={(e) => onLabelChange(e.target.value)}
+          placeholder="Enter edge label (optional)"
+          maxLength={50}
+        />
+      </CollapseSection>
+
+      {/* Style Section */}
+      <CollapseSection title="Style" defaultOpen>
+        <ColorPicker
+          label="Stroke Color"
+          value={color}
+          onChange={onColorChange}
+          recentColors={recentColors}
+        />
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-neutral-700" htmlFor="stroke-width">
+            Stroke Width
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              id="stroke-width"
+              type="range"
+              min="1"
+              max="8"
+              step="1"
+              value={strokeWidth}
+              onChange={(e) => onStrokeWidthChange(Number(e.target.value))}
+              className="flex-1"
+            />
+            <span className="w-8 text-center text-sm text-neutral-700">{strokeWidth}px</span>
+          </div>
+        </div>
+      </CollapseSection>
+    </div>
+  );
+}

--- a/src/features/roadmap-editor/components/organisms/EditorSidebar/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/EditorSidebar/index.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface EditorSidebarProps {
+  children: React.ReactNode;
+  side?: 'left' | 'right';
+  defaultOpen?: boolean;
+  className?: string;
+}
+
+export function EditorSidebar({
+  children,
+  side = 'right',
+  defaultOpen = true,
+  className,
+}: EditorSidebarProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <>
+      {/* Sidebar */}
+      <aside
+        className={cn(
+          'bg-neutral-0 border-neutral-200 transition-all duration-300',
+          side === 'left' ? 'border-r' : 'border-l',
+          isOpen ? 'w-80' : 'w-0',
+          className,
+        )}
+        aria-label="Editor sidebar"
+        aria-hidden={!isOpen}
+      >
+        {isOpen && <div className="h-full overflow-y-auto p-4">{children}</div>}
+      </aside>
+
+      {/* Toggle Button */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className={cn(
+          'bg-neutral-0 focus:ring-primary-500 absolute top-1/2 z-10 flex h-12 w-6 -translate-y-1/2 items-center justify-center rounded-md border border-neutral-200 hover:bg-neutral-50 focus:ring-2 focus:outline-none',
+          side === 'left' ? (isOpen ? 'left-80' : 'left-0') : isOpen ? 'right-80' : 'right-0',
+        )}
+        aria-label={isOpen ? 'Close sidebar' : 'Open sidebar'}
+        aria-expanded={isOpen}
+      >
+        <svg
+          className={cn(
+            'h-4 w-4 text-neutral-700 transition-transform',
+            side === 'left'
+              ? isOpen
+                ? '-rotate-90'
+                : 'rotate-90'
+              : isOpen
+                ? 'rotate-90'
+                : '-rotate-90',
+          )}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+    </>
+  );
+}

--- a/src/features/roadmap-editor/components/organisms/EditorSidebar/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/EditorSidebar/index.tsx
@@ -26,7 +26,7 @@ export function EditorSidebar({
         className={cn(
           'bg-neutral-0 border-neutral-200 transition-all duration-300',
           side === 'left' ? 'border-r' : 'border-l',
-          isOpen ? 'w-80' : 'w-0',
+          isOpen ? 'w-68' : 'w-0',
           className,
         )}
         aria-label="Editor sidebar"
@@ -41,7 +41,7 @@ export function EditorSidebar({
         onClick={() => setIsOpen(!isOpen)}
         className={cn(
           'bg-neutral-0 focus:ring-primary-500 absolute top-1/2 z-10 flex h-12 w-6 -translate-y-1/2 items-center justify-center rounded-md border border-neutral-200 hover:bg-neutral-50 focus:ring-2 focus:outline-none',
-          side === 'left' ? (isOpen ? 'left-80' : 'left-0') : isOpen ? 'right-80' : 'right-0',
+          side === 'left' ? (isOpen ? 'left-68' : 'left-0') : isOpen ? 'right-68' : 'right-0',
         )}
         aria-label={isOpen ? 'Close sidebar' : 'Open sidebar'}
         aria-expanded={isOpen}

--- a/src/features/roadmap-editor/components/organisms/MultiSelectPanel/MultiSelectPanel.test.tsx
+++ b/src/features/roadmap-editor/components/organisms/MultiSelectPanel/MultiSelectPanel.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MultiSelectPanel } from './index';
+
+describe('MultiSelectPanel', () => {
+  const mockItems = [
+    { id: 'node-1', type: 'node' as const, title: 'Node 1', color: '#3b82f6' },
+    { id: 'node-2', type: 'node' as const, title: 'Node 2', color: '#10b981' },
+    { id: 'edge-1', type: 'edge' as const, title: 'Edge 1', color: '#3b82f6' },
+  ];
+
+  const defaultProps = {
+    selectedItems: mockItems,
+    onColorChange: vi.fn(),
+    onDelete: vi.fn(),
+    onClear: vi.fn(),
+  };
+
+  it('renders with selected items count', () => {
+    render(<MultiSelectPanel {...defaultProps} />);
+
+    expect(screen.getByText('Multi-Select (3)')).toBeInTheDocument();
+  });
+
+  it('displays selection summary with correct counts', () => {
+    render(<MultiSelectPanel {...defaultProps} />);
+
+    expect(screen.getByText('Nodes:')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('Edges:')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('calls onClear when clear button is clicked', async () => {
+    const user = userEvent.setup();
+    const handleClear = vi.fn();
+
+    render(<MultiSelectPanel {...defaultProps} onClear={handleClear} />);
+
+    const clearButton = screen.getByLabelText('Clear selection');
+    await user.click(clearButton);
+
+    expect(handleClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onDelete when delete button is clicked', async () => {
+    const user = userEvent.setup();
+    const handleDelete = vi.fn();
+
+    render(<MultiSelectPanel {...defaultProps} onDelete={handleDelete} />);
+
+    const deleteButton = screen.getByText(/Delete All/i);
+    await user.click(deleteButton);
+
+    expect(handleDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows mixed color indicator when items have different colors', () => {
+    render(<MultiSelectPanel {...defaultProps} />);
+
+    expect(screen.getByText('Color (Mixed)')).toBeInTheDocument();
+    expect(
+      screen.getByText('Selected items have different colors. Changing will apply to all.'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show mixed color indicator when all items have same color', () => {
+    const sameColorItems = [
+      { id: 'node-1', type: 'node' as const, title: 'Node 1', color: '#3b82f6' },
+      { id: 'node-2', type: 'node' as const, title: 'Node 2', color: '#3b82f6' },
+    ];
+
+    render(<MultiSelectPanel {...defaultProps} selectedItems={sameColorItems} />);
+
+    expect(screen.queryByText('Color (Mixed)')).not.toBeInTheDocument();
+    expect(screen.getByText('Color')).toBeInTheDocument();
+  });
+
+  it('displays selected items in the list when section is expanded', async () => {
+    const user = userEvent.setup();
+    render(<MultiSelectPanel {...defaultProps} />);
+
+    // Expand the "Selected Items" section
+    const selectedItemsButton = screen.getByRole('button', { name: /Selected Items/i });
+    await user.click(selectedItemsButton);
+
+    expect(screen.getByText('Node 1')).toBeInTheDocument();
+    expect(screen.getByText('Node 2')).toBeInTheDocument();
+    expect(screen.getByText('Edge 1')).toBeInTheDocument();
+  });
+
+  it('shows color indicators for items with colors when section is expanded', async () => {
+    const user = userEvent.setup();
+    render(<MultiSelectPanel {...defaultProps} />);
+
+    // Expand the "Selected Items" section
+    const selectedItemsButton = screen.getByRole('button', { name: /Selected Items/i });
+    await user.click(selectedItemsButton);
+
+    const colorIndicators = screen.getAllByLabelText(/Color:/);
+    expect(colorIndicators).toHaveLength(3);
+  });
+});

--- a/src/features/roadmap-editor/components/organisms/MultiSelectPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/MultiSelectPanel/index.tsx
@@ -3,12 +3,14 @@
 import { useState } from 'react';
 
 import { ColorPicker } from '../../atoms/ColorPicker';
+import { EditorCheckbox } from '../../atoms/EditorCheckbox';
 import { CollapseSection } from '../../molecules/CollapseSection';
 
 interface SelectedItem {
   id: string;
   type: 'node' | 'edge' | 'section' | 'text';
   title?: string;
+  color?: string;
 }
 
 interface MultiSelectPanelProps {
@@ -37,8 +39,13 @@ export function MultiSelectPanel({
   const sectionCount = selectedItems.filter((item) => item.type === 'section').length;
   const textCount = selectedItems.filter((item) => item.type === 'text').length;
 
+  // Mixed state detection for color
+  const colors = selectedItems.map((item) => item.color).filter(Boolean);
+  const uniqueColors = new Set(colors);
+  const isColorMixed = uniqueColors.size > 1;
+
   return (
-    <div className="w-80 space-y-5">
+    <div className="w-68 space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-neutral-900">
@@ -91,14 +98,37 @@ export function MultiSelectPanel({
         </div>
       </CollapseSection>
 
+      {/* Bulk Edit */}
+      <CollapseSection title="Bulk Edit" defaultOpen>
+        <div className="space-y-3">
+          {/* Color Picker with mixed state indicator */}
+          <div className="flex flex-col gap-2">
+            <ColorPicker
+              label={isColorMixed ? 'Color (Mixed)' : 'Color'}
+              value={color}
+              onChange={handleColorChange}
+              recentColors={recentColors}
+            />
+            {isColorMixed && (
+              <p className="text-xs text-neutral-500">
+                Selected items have different colors. Changing will apply to all.
+              </p>
+            )}
+          </div>
+
+          {/* Mixed state example with checkbox (for future properties) */}
+          <EditorCheckbox
+            id="apply-color"
+            label="Apply color to all items"
+            checked
+            disabled
+            className="opacity-50"
+          />
+        </div>
+      </CollapseSection>
+
       {/* Bulk Actions */}
       <CollapseSection title="Bulk Actions" defaultOpen>
-        <ColorPicker
-          label="Apply Color to All"
-          value={color}
-          onChange={handleColorChange}
-          recentColors={recentColors}
-        />
         <button
           type="button"
           onClick={onDelete}
@@ -130,6 +160,13 @@ export function MultiSelectPanel({
                 </span>
                 <span className="text-sm text-neutral-900">{item.title || item.id}</span>
               </div>
+              {item.color && (
+                <div
+                  className="h-4 w-4 rounded-full border border-neutral-300"
+                  style={{ backgroundColor: item.color }}
+                  aria-label={`Color: ${item.color}`}
+                />
+              )}
             </div>
           ))}
         </div>

--- a/src/features/roadmap-editor/components/organisms/MultiSelectPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/MultiSelectPanel/index.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState } from 'react';
+
+import { ColorPicker } from '../../atoms/ColorPicker';
+import { CollapseSection } from '../../molecules/CollapseSection';
+
+interface SelectedItem {
+  id: string;
+  type: 'node' | 'edge' | 'section' | 'text';
+  title?: string;
+}
+
+interface MultiSelectPanelProps {
+  selectedItems: SelectedItem[];
+  onColorChange: (color: string) => void;
+  onDelete: () => void;
+  onClear: () => void;
+}
+
+export function MultiSelectPanel({
+  selectedItems,
+  onColorChange,
+  onDelete,
+  onClear,
+}: MultiSelectPanelProps) {
+  const [color, setColor] = useState('#3b82f6');
+  const [recentColors] = useState<string[]>(['#3b82f6', '#10b981', '#f59e0b', '#ef4444']);
+
+  const handleColorChange = (newColor: string) => {
+    setColor(newColor);
+    onColorChange(newColor);
+  };
+
+  const nodeCount = selectedItems.filter((item) => item.type === 'node').length;
+  const edgeCount = selectedItems.filter((item) => item.type === 'edge').length;
+  const sectionCount = selectedItems.filter((item) => item.type === 'section').length;
+  const textCount = selectedItems.filter((item) => item.type === 'text').length;
+
+  return (
+    <div className="w-80 space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-neutral-900">
+          Multi-Select ({selectedItems.length})
+        </h3>
+        <button
+          type="button"
+          onClick={onClear}
+          className="focus:ring-primary-500 rounded-md p-1 text-neutral-700 hover:bg-neutral-100 focus:ring-2 focus:outline-none"
+          aria-label="Clear selection"
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {/* Selection Summary */}
+      <CollapseSection title="Selection Summary" defaultOpen>
+        <div className="space-y-2 text-sm">
+          {nodeCount > 0 && (
+            <div className="flex justify-between">
+              <span className="text-neutral-700">Nodes:</span>
+              <span className="font-medium text-neutral-900">{nodeCount}</span>
+            </div>
+          )}
+          {edgeCount > 0 && (
+            <div className="flex justify-between">
+              <span className="text-neutral-700">Edges:</span>
+              <span className="font-medium text-neutral-900">{edgeCount}</span>
+            </div>
+          )}
+          {sectionCount > 0 && (
+            <div className="flex justify-between">
+              <span className="text-neutral-700">Sections:</span>
+              <span className="font-medium text-neutral-900">{sectionCount}</span>
+            </div>
+          )}
+          {textCount > 0 && (
+            <div className="flex justify-between">
+              <span className="text-neutral-700">Texts:</span>
+              <span className="font-medium text-neutral-900">{textCount}</span>
+            </div>
+          )}
+        </div>
+      </CollapseSection>
+
+      {/* Bulk Actions */}
+      <CollapseSection title="Bulk Actions" defaultOpen>
+        <ColorPicker
+          label="Apply Color to All"
+          value={color}
+          onChange={handleColorChange}
+          recentColors={recentColors}
+        />
+        <button
+          type="button"
+          onClick={onDelete}
+          className="flex w-full items-center justify-center gap-2 rounded-md border border-red-300 bg-red-50 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-100 focus:ring-2 focus:ring-red-500 focus:outline-none"
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+            />
+          </svg>
+          Delete All ({selectedItems.length})
+        </button>
+      </CollapseSection>
+
+      {/* Selected Items List */}
+      <CollapseSection title="Selected Items" defaultOpen={false}>
+        <div className="max-h-64 space-y-2 overflow-y-auto">
+          {selectedItems.map((item) => (
+            <div
+              key={item.id}
+              className="flex items-center justify-between rounded-md border border-neutral-200 p-2"
+            >
+              <div className="flex items-center gap-2">
+                <span className="rounded bg-neutral-100 px-2 py-0.5 text-xs font-medium text-neutral-700">
+                  {item.type}
+                </span>
+                <span className="text-sm text-neutral-900">{item.title || item.id}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CollapseSection>
+    </div>
+  );
+}

--- a/src/features/roadmap-editor/components/organisms/NodePropertiesPanel/NodePropertiesPanel.test.tsx
+++ b/src/features/roadmap-editor/components/organisms/NodePropertiesPanel/NodePropertiesPanel.test.tsx
@@ -15,11 +15,11 @@ describe('NodePropertiesPanel', () => {
     onColorChange: vi.fn(),
   };
 
-  it('320px 너비(w-80)로 렌더링된다', () => {
+  it('272px 너비(w-68)로 렌더링된다', () => {
     const { container } = render(<NodePropertiesPanel {...mockProps} />);
     const panel = container.firstChild as HTMLElement;
 
-    expect(panel.className).toContain('w-80');
+    expect(panel.className).toContain('w-68');
   });
 
   it('헤더를 렌더링한다', () => {

--- a/src/features/roadmap-editor/components/organisms/NodePropertiesPanel/NodePropertiesPanel.test.tsx
+++ b/src/features/roadmap-editor/components/organisms/NodePropertiesPanel/NodePropertiesPanel.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { NodePropertiesPanel } from './index';
+
+describe('NodePropertiesPanel', () => {
+  const mockProps = {
+    nodeId: 'node-1',
+    title: 'Test Node',
+    description: 'Test description',
+    color: '#3b82f6',
+    onTitleChange: vi.fn(),
+    onDescriptionChange: vi.fn(),
+    onColorChange: vi.fn(),
+  };
+
+  it('320px 너비(w-80)로 렌더링된다', () => {
+    const { container } = render(<NodePropertiesPanel {...mockProps} />);
+    const panel = container.firstChild as HTMLElement;
+
+    expect(panel.className).toContain('w-80');
+  });
+
+  it('헤더를 렌더링한다', () => {
+    render(<NodePropertiesPanel {...mockProps} />);
+
+    expect(screen.getByText('Node Properties')).toBeInTheDocument();
+  });
+
+  it('Node ID를 읽기 전용으로 표시한다', () => {
+    render(<NodePropertiesPanel {...mockProps} />);
+
+    const nodeIdInput = screen.getByLabelText('Node ID (read-only)');
+    expect(nodeIdInput).toBeDisabled();
+    expect(nodeIdInput).toHaveValue('node-1');
+  });
+
+  it('제목을 입력할 수 있다', async () => {
+    const user = userEvent.setup();
+
+    render(<NodePropertiesPanel {...mockProps} />);
+
+    const titleInput = screen.getByLabelText('Title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'New Title');
+
+    expect(mockProps.onTitleChange).toHaveBeenCalled();
+  });
+
+  it('설명을 입력할 수 있다', async () => {
+    const user = userEvent.setup();
+
+    render(<NodePropertiesPanel {...mockProps} />);
+
+    const descriptionInput = screen.getByLabelText('Description');
+    await user.clear(descriptionInput);
+    await user.type(descriptionInput, 'New Description');
+
+    expect(mockProps.onDescriptionChange).toHaveBeenCalled();
+  });
+
+  it('삭제 버튼이 제공될 때 렌더링된다', () => {
+    const onDelete = vi.fn();
+
+    render(<NodePropertiesPanel {...mockProps} onDelete={onDelete} />);
+
+    expect(screen.getByLabelText('Delete node')).toBeInTheDocument();
+  });
+
+  it('Basic Info와 Style 섹션을 렌더링한다', () => {
+    render(<NodePropertiesPanel {...mockProps} />);
+
+    expect(screen.getByText('Basic Info')).toBeInTheDocument();
+    expect(screen.getByText('Style')).toBeInTheDocument();
+  });
+});

--- a/src/features/roadmap-editor/components/organisms/NodePropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/NodePropertiesPanel/index.tsx
@@ -30,7 +30,7 @@ export function NodePropertiesPanel({
   const [recentColors] = useState<string[]>(['#3b82f6', '#10b981', '#f59e0b', '#ef4444']);
 
   return (
-    <div className="w-80 space-y-5">
+    <div className="w-68 space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-neutral-900">Node Properties</h3>

--- a/src/features/roadmap-editor/components/organisms/NodePropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/NodePropertiesPanel/index.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+
+import { ColorPicker } from '../../atoms/ColorPicker';
+import { EditorInput } from '../../atoms/EditorInput';
+import { CollapseSection } from '../../molecules/CollapseSection';
+
+interface NodePropertiesPanelProps {
+  nodeId: string;
+  title: string;
+  description?: string;
+  color: string;
+  onTitleChange: (title: string) => void;
+  onDescriptionChange: (description: string) => void;
+  onColorChange: (color: string) => void;
+  onDelete?: () => void;
+}
+
+export function NodePropertiesPanel({
+  nodeId,
+  title,
+  description = '',
+  color,
+  onTitleChange,
+  onDescriptionChange,
+  onColorChange,
+  onDelete,
+}: NodePropertiesPanelProps) {
+  const [recentColors] = useState<string[]>(['#3b82f6', '#10b981', '#f59e0b', '#ef4444']);
+
+  return (
+    <div className="w-80 space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-neutral-900">Node Properties</h3>
+        {onDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            className="focus:ring-primary-500 rounded-md p-1 text-neutral-700 hover:bg-neutral-100 focus:ring-2 focus:outline-none"
+            aria-label="Delete node"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Basic Info Section */}
+      <CollapseSection title="Basic Info" defaultOpen>
+        <EditorInput
+          label="Node ID"
+          value={nodeId}
+          disabled
+          className="bg-neutral-50"
+          aria-label="Node ID (read-only)"
+        />
+        <EditorInput
+          label="Title"
+          value={title}
+          onChange={(e) => onTitleChange(e.target.value)}
+          placeholder="Enter node title"
+          maxLength={100}
+        />
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-neutral-700" htmlFor="node-description">
+            Description
+          </label>
+          <textarea
+            id="node-description"
+            value={description}
+            onChange={(e) => onDescriptionChange(e.target.value)}
+            placeholder="Enter node description"
+            maxLength={500}
+            rows={4}
+            className="focus:border-primary-500 focus:ring-primary-500 rounded-md border border-neutral-300 px-3 py-2 text-sm placeholder:text-neutral-400 focus:ring-1 focus:outline-none"
+          />
+        </div>
+      </CollapseSection>
+
+      {/* Style Section */}
+      <CollapseSection title="Style" defaultOpen>
+        <ColorPicker
+          label="Background Color"
+          value={color}
+          onChange={onColorChange}
+          recentColors={recentColors}
+        />
+      </CollapseSection>
+    </div>
+  );
+}

--- a/src/features/roadmap-editor/components/organisms/ResourcePropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/ResourcePropertiesPanel/index.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { EditorInput } from '../../atoms/EditorInput';
+import { CollapseSection } from '../../molecules/CollapseSection';
+
+interface Resource {
+  id: string;
+  title: string;
+  url: string;
+  type: 'article' | 'video' | 'course' | 'book' | 'other';
+}
+
+interface ResourcePropertiesPanelProps {
+  nodeId: string;
+  resources: Resource[];
+  onResourceAdd: () => void;
+  onResourceUpdate: (resourceId: string, updates: Partial<Resource>) => void;
+  onResourceDelete: (resourceId: string) => void;
+}
+
+export function ResourcePropertiesPanel({
+  nodeId,
+  resources,
+  onResourceAdd,
+  onResourceUpdate,
+  onResourceDelete,
+}: ResourcePropertiesPanelProps) {
+  return (
+    <div className="w-80 space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-neutral-900">Resource Properties</h3>
+        <button
+          type="button"
+          onClick={onResourceAdd}
+          className="text-primary-500 hover:bg-primary-50 focus:ring-primary-500 rounded-md p-1 focus:ring-2 focus:outline-none"
+          aria-label="Add resource"
+        >
+          <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Node Info */}
+      <CollapseSection title="Node Info" defaultOpen={false}>
+        <EditorInput
+          label="Node ID"
+          value={nodeId}
+          disabled
+          className="bg-neutral-50"
+          aria-label="Node ID (read-only)"
+        />
+      </CollapseSection>
+
+      {/* Resources List */}
+      <CollapseSection title={`Resources (${resources.length})`} defaultOpen>
+        {resources.length === 0 ? (
+          <p className="text-sm text-neutral-400">No resources added yet</p>
+        ) : (
+          <div className="space-y-4">
+            {resources.map((resource) => (
+              <div key={resource.id} className="space-y-2 rounded-md border border-neutral-200 p-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-neutral-700">
+                    Resource #{resource.id}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onResourceDelete(resource.id)}
+                    className="focus:ring-primary-500 rounded-md p-1 text-neutral-700 hover:bg-neutral-100 focus:ring-2 focus:outline-none"
+                    aria-label={`Delete resource ${resource.id}`}
+                  >
+                    <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <EditorInput
+                  label="Title"
+                  value={resource.title}
+                  onChange={(e) => onResourceUpdate(resource.id, { title: e.target.value })}
+                  placeholder="Resource title"
+                  maxLength={100}
+                />
+                <EditorInput
+                  label="URL"
+                  value={resource.url}
+                  onChange={(e) => onResourceUpdate(resource.id, { url: e.target.value })}
+                  placeholder="https://example.com"
+                  type="url"
+                />
+                <div className="flex flex-col gap-1">
+                  <label
+                    className="text-xs font-medium text-neutral-700"
+                    htmlFor={`resource-type-${resource.id}`}
+                  >
+                    Type
+                  </label>
+                  <select
+                    id={`resource-type-${resource.id}`}
+                    value={resource.type}
+                    onChange={(e) =>
+                      onResourceUpdate(resource.id, {
+                        type: e.target.value as Resource['type'],
+                      })
+                    }
+                    className="focus:border-primary-500 focus:ring-primary-500 h-9 rounded-md border border-neutral-300 px-3 py-2 text-sm focus:ring-1 focus:outline-none"
+                  >
+                    <option value="article">Article</option>
+                    <option value="video">Video</option>
+                    <option value="course">Course</option>
+                    <option value="book">Book</option>
+                    <option value="other">Other</option>
+                  </select>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CollapseSection>
+    </div>
+  );
+}

--- a/src/features/roadmap-editor/components/organisms/ResourcePropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/ResourcePropertiesPanel/index.tsx
@@ -26,7 +26,7 @@ export function ResourcePropertiesPanel({
   onResourceDelete,
 }: ResourcePropertiesPanelProps) {
   return (
-    <div className="w-80 space-y-5">
+    <div className="w-68 space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-neutral-900">Resource Properties</h3>

--- a/src/features/roadmap-editor/components/organisms/SectionPropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/SectionPropertiesPanel/index.tsx
@@ -30,7 +30,7 @@ export function SectionPropertiesPanel({
   const [recentColors] = useState<string[]>(['#3b82f6', '#10b981', '#f59e0b', '#ef4444']);
 
   return (
-    <div className="w-80 space-y-5">
+    <div className="w-68 space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-neutral-900">Section Properties</h3>

--- a/src/features/roadmap-editor/components/organisms/SectionPropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/SectionPropertiesPanel/index.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState } from 'react';
+
+import { ColorPicker } from '../../atoms/ColorPicker';
+import { EditorInput } from '../../atoms/EditorInput';
+import { CollapseSection } from '../../molecules/CollapseSection';
+
+interface SectionPropertiesPanelProps {
+  sectionId: string;
+  title: string;
+  backgroundColor: string;
+  borderColor: string;
+  onTitleChange: (title: string) => void;
+  onBackgroundColorChange: (color: string) => void;
+  onBorderColorChange: (color: string) => void;
+  onDelete?: () => void;
+}
+
+export function SectionPropertiesPanel({
+  sectionId,
+  title,
+  backgroundColor,
+  borderColor,
+  onTitleChange,
+  onBackgroundColorChange,
+  onBorderColorChange,
+  onDelete,
+}: SectionPropertiesPanelProps) {
+  const [recentColors] = useState<string[]>(['#3b82f6', '#10b981', '#f59e0b', '#ef4444']);
+
+  return (
+    <div className="w-80 space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-neutral-900">Section Properties</h3>
+        {onDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            className="focus:ring-primary-500 rounded-md p-1 text-neutral-700 hover:bg-neutral-100 focus:ring-2 focus:outline-none"
+            aria-label="Delete section"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Basic Info Section */}
+      <CollapseSection title="Basic Info" defaultOpen>
+        <EditorInput
+          label="Section ID"
+          value={sectionId}
+          disabled
+          className="bg-neutral-50"
+          aria-label="Section ID (read-only)"
+        />
+        <EditorInput
+          label="Title"
+          value={title}
+          onChange={(e) => onTitleChange(e.target.value)}
+          placeholder="Enter section title"
+          maxLength={100}
+        />
+      </CollapseSection>
+
+      {/* Style Section */}
+      <CollapseSection title="Style" defaultOpen>
+        <ColorPicker
+          label="Background Color"
+          value={backgroundColor}
+          onChange={onBackgroundColorChange}
+          recentColors={recentColors}
+        />
+        <ColorPicker
+          label="Border Color"
+          value={borderColor}
+          onChange={onBorderColorChange}
+          recentColors={recentColors}
+        />
+      </CollapseSection>
+    </div>
+  );
+}

--- a/src/features/roadmap-editor/components/organisms/TextPropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/TextPropertiesPanel/index.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useState } from 'react';
+
+import { ColorPicker } from '../../atoms/ColorPicker';
+import { EditorInput } from '../../atoms/EditorInput';
+import { CollapseSection } from '../../molecules/CollapseSection';
+
+interface TextPropertiesPanelProps {
+  textId: string;
+  content: string;
+  fontSize: number;
+  fontWeight: 'normal' | 'medium' | 'semibold' | 'bold';
+  color: string;
+  onContentChange: (content: string) => void;
+  onFontSizeChange: (size: number) => void;
+  onFontWeightChange: (weight: 'normal' | 'medium' | 'semibold' | 'bold') => void;
+  onColorChange: (color: string) => void;
+  onDelete?: () => void;
+}
+
+export function TextPropertiesPanel({
+  textId,
+  content,
+  fontSize,
+  fontWeight,
+  color,
+  onContentChange,
+  onFontSizeChange,
+  onFontWeightChange,
+  onColorChange,
+  onDelete,
+}: TextPropertiesPanelProps) {
+  const [recentColors] = useState<string[]>(['#111827', '#374151', '#6b7280', '#9ca3af']);
+
+  return (
+    <div className="w-80 space-y-5">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-neutral-900">Text Properties</h3>
+        {onDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            className="focus:ring-primary-500 rounded-md p-1 text-neutral-700 hover:bg-neutral-100 focus:ring-2 focus:outline-none"
+            aria-label="Delete text"
+          >
+            <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Basic Info Section */}
+      <CollapseSection title="Basic Info" defaultOpen>
+        <EditorInput
+          label="Text ID"
+          value={textId}
+          disabled
+          className="bg-neutral-50"
+          aria-label="Text ID (read-only)"
+        />
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-neutral-700" htmlFor="text-content">
+            Content
+          </label>
+          <textarea
+            id="text-content"
+            value={content}
+            onChange={(e) => onContentChange(e.target.value)}
+            placeholder="Enter text content"
+            maxLength={1000}
+            rows={6}
+            className="focus:border-primary-500 focus:ring-primary-500 rounded-md border border-neutral-300 px-3 py-2 text-sm placeholder:text-neutral-400 focus:ring-1 focus:outline-none"
+          />
+        </div>
+      </CollapseSection>
+
+      {/* Typography Section */}
+      <CollapseSection title="Typography" defaultOpen>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-neutral-700" htmlFor="font-size">
+            Font Size
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              id="font-size"
+              type="range"
+              min="12"
+              max="48"
+              step="2"
+              value={fontSize}
+              onChange={(e) => onFontSizeChange(Number(e.target.value))}
+              className="flex-1"
+            />
+            <span className="w-12 text-center text-sm text-neutral-700">{fontSize}px</span>
+          </div>
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-neutral-700" htmlFor="font-weight">
+            Font Weight
+          </label>
+          <select
+            id="font-weight"
+            value={fontWeight}
+            onChange={(e) =>
+              onFontWeightChange(e.target.value as 'normal' | 'medium' | 'semibold' | 'bold')
+            }
+            className="focus:border-primary-500 focus:ring-primary-500 h-9 rounded-md border border-neutral-300 px-3 py-2 text-sm focus:ring-1 focus:outline-none"
+          >
+            <option value="normal">Normal (400)</option>
+            <option value="medium">Medium (500)</option>
+            <option value="semibold">Semibold (600)</option>
+            <option value="bold">Bold (700)</option>
+          </select>
+        </div>
+        <ColorPicker
+          label="Text Color"
+          value={color}
+          onChange={onColorChange}
+          recentColors={recentColors}
+        />
+      </CollapseSection>
+    </div>
+  );
+}

--- a/src/features/roadmap-editor/components/organisms/TextPropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/components/organisms/TextPropertiesPanel/index.tsx
@@ -34,7 +34,7 @@ export function TextPropertiesPanel({
   const [recentColors] = useState<string[]>(['#111827', '#374151', '#6b7280', '#9ca3af']);
 
   return (
-    <div className="w-80 space-y-5">
+    <div className="w-68 space-y-5">
       {/* Header */}
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold text-neutral-900">Text Properties</h3>

--- a/src/stories/roadmap-editor/ColorPicker.stories.tsx
+++ b/src/stories/roadmap-editor/ColorPicker.stories.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+
+import { ColorPicker } from '@/features/roadmap-editor/components/atoms/ColorPicker';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/Atoms/ColorPicker',
+  component: ColorPicker,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ColorPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const DefaultComponent = () => {
+  const [color, setColor] = useState('#3b82f6');
+  return <ColorPicker value={color} onChange={setColor} />;
+};
+
+export const Default: Story = {
+  args: { value: '#3b82f6', onChange: () => {} },
+  render: DefaultComponent,
+};
+
+const WithLabelComponent = () => {
+  const [color, setColor] = useState('#10b981');
+  return <ColorPicker label="Background Color" value={color} onChange={setColor} />;
+};
+
+export const WithLabel: Story = {
+  args: { label: 'Background Color', value: '#10b981', onChange: () => {} },
+  render: WithLabelComponent,
+};
+
+const WithRecentColorsComponent = () => {
+  const [color, setColor] = useState('#ef4444');
+  const recentColors = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444'];
+  return (
+    <ColorPicker label="Pick Color" value={color} onChange={setColor} recentColors={recentColors} />
+  );
+};
+
+export const WithRecentColors: Story = {
+  args: { label: 'Pick Color', value: '#ef4444', onChange: () => {}, recentColors: [] },
+  render: WithRecentColorsComponent,
+};

--- a/src/stories/roadmap-editor/EdgePropertiesPanelMultiSelect.stories.tsx
+++ b/src/stories/roadmap-editor/EdgePropertiesPanelMultiSelect.stories.tsx
@@ -1,0 +1,139 @@
+/* eslint-disable no-console */
+import { useState } from 'react';
+
+import { EdgePropertiesPanel } from '@/features/roadmap-editor/components/organisms/EdgePropertiesPanel';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/EdgePropertiesPanel Multi-Select',
+  component: EdgePropertiesPanel,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof EdgePropertiesPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const MixedPropertiesComponent = () => {
+  const [selectedEdges] = useState([
+    { id: 'edge-1', label: 'Step 1 → 2', color: '#3b82f6', strokeWidth: 2 },
+    { id: 'edge-2', label: 'Step 2 → 3', color: '#10b981', strokeWidth: 3 },
+    { id: 'edge-3', color: '#3b82f6', strokeWidth: 4 },
+  ]);
+
+  return (
+    <div className="w-[272px]">
+      <EdgePropertiesPanel
+        isMultiSelect
+        selectedEdges={selectedEdges}
+        color="#3b82f6"
+        strokeWidth={2}
+        onBulkColorChange={(color) => console.log('Color changed:', color)}
+        onBulkStrokeWidthChange={(width) => console.log('Width changed:', width)}
+        onBulkDelete={() => console.log('Delete all clicked')}
+      />
+    </div>
+  );
+};
+
+export const MixedProperties: Story = {
+  args: {
+    isMultiSelect: true,
+    selectedEdges: [
+      { id: 'edge-1', label: 'Step 1 → 2', color: '#3b82f6', strokeWidth: 2 },
+      { id: 'edge-2', label: 'Step 2 → 3', color: '#10b981', strokeWidth: 3 },
+      { id: 'edge-3', color: '#3b82f6', strokeWidth: 4 },
+    ],
+    color: '#3b82f6',
+    strokeWidth: 2,
+    onBulkColorChange: () => {},
+    onBulkStrokeWidthChange: () => {},
+    onBulkDelete: () => {},
+  },
+  render: MixedPropertiesComponent,
+};
+
+const SamePropertiesComponent = () => {
+  const [selectedEdges] = useState([
+    { id: 'edge-1', label: 'Connection 1', color: '#3b82f6', strokeWidth: 2 },
+    { id: 'edge-2', label: 'Connection 2', color: '#3b82f6', strokeWidth: 2 },
+    { id: 'edge-3', label: 'Connection 3', color: '#3b82f6', strokeWidth: 2 },
+  ]);
+
+  return (
+    <div className="w-[272px]">
+      <EdgePropertiesPanel
+        isMultiSelect
+        selectedEdges={selectedEdges}
+        color="#3b82f6"
+        strokeWidth={2}
+        onBulkColorChange={(color) => console.log('Color changed:', color)}
+        onBulkStrokeWidthChange={(width) => console.log('Width changed:', width)}
+        onBulkDelete={() => console.log('Delete all clicked')}
+      />
+    </div>
+  );
+};
+
+export const SameProperties: Story = {
+  args: {
+    isMultiSelect: true,
+    selectedEdges: [
+      { id: 'edge-1', label: 'Connection 1', color: '#3b82f6', strokeWidth: 2 },
+      { id: 'edge-2', label: 'Connection 2', color: '#3b82f6', strokeWidth: 2 },
+      { id: 'edge-3', label: 'Connection 3', color: '#3b82f6', strokeWidth: 2 },
+    ],
+    color: '#3b82f6',
+    strokeWidth: 2,
+    onBulkColorChange: () => {},
+    onBulkStrokeWidthChange: () => {},
+    onBulkDelete: () => {},
+  },
+  render: SamePropertiesComponent,
+};
+
+const ManyEdgesComponent = () => {
+  const [selectedEdges] = useState(
+    Array.from({ length: 10 }, (_, i) => ({
+      id: `edge-${i}`,
+      label: i % 2 === 0 ? `Connection ${i + 1}` : undefined,
+      color: ['#3b82f6', '#10b981', '#f59e0b'][i % 3],
+      strokeWidth: (i % 3) + 2,
+    })),
+  );
+
+  return (
+    <div className="w-[272px]">
+      <EdgePropertiesPanel
+        isMultiSelect
+        selectedEdges={selectedEdges}
+        color="#3b82f6"
+        strokeWidth={2}
+        onBulkColorChange={(color) => console.log('Color changed:', color)}
+        onBulkStrokeWidthChange={(width) => console.log('Width changed:', width)}
+        onBulkDelete={() => console.log('Delete all clicked')}
+      />
+    </div>
+  );
+};
+
+export const ManyEdges: Story = {
+  args: {
+    isMultiSelect: true,
+    selectedEdges: Array.from({ length: 10 }, (_, i) => ({
+      id: `edge-${i}`,
+      label: i % 2 === 0 ? `Connection ${i + 1}` : undefined,
+      color: ['#3b82f6', '#10b981', '#f59e0b'][i % 3],
+      strokeWidth: (i % 3) + 2,
+    })),
+    color: '#3b82f6',
+    strokeWidth: 2,
+    onBulkColorChange: () => {},
+    onBulkStrokeWidthChange: () => {},
+    onBulkDelete: () => {},
+  },
+  render: ManyEdgesComponent,
+};

--- a/src/stories/roadmap-editor/EditorCheckbox.stories.tsx
+++ b/src/stories/roadmap-editor/EditorCheckbox.stories.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+
+import { EditorCheckbox } from '@/features/roadmap-editor/components/atoms/EditorCheckbox';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/EditorCheckbox',
+  component: EditorCheckbox,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof EditorCheckbox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const DefaultComponent = () => {
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <EditorCheckbox
+      label="Accept terms and conditions"
+      checked={checked}
+      onChange={(e) => setChecked(e.target.checked)}
+    />
+  );
+};
+
+export const Default: Story = {
+  args: {
+    label: 'Accept terms and conditions',
+    checked: false,
+  },
+  render: DefaultComponent,
+};
+
+const IndeterminateComponent = () => {
+  const [checked, setChecked] = useState(false);
+  const [indeterminate, setIndeterminate] = useState(true);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setChecked(e.target.checked);
+    setIndeterminate(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <EditorCheckbox
+        label="Select all items"
+        checked={checked}
+        indeterminate={indeterminate}
+        onChange={handleChange}
+      />
+      <p className="text-sm text-neutral-700">
+        {indeterminate ? 'Some items selected' : checked ? 'All selected' : 'None selected'}
+      </p>
+    </div>
+  );
+};
+
+export const Indeterminate: Story = {
+  args: {
+    label: 'Select all items',
+    checked: false,
+    indeterminate: true,
+  },
+  render: IndeterminateComponent,
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Disabled option',
+    checked: false,
+    disabled: true,
+  },
+};
+
+export const DisabledChecked: Story = {
+  args: {
+    label: 'Disabled (checked)',
+    checked: true,
+    disabled: true,
+  },
+};
+
+export const WithoutLabel: Story = {
+  args: {
+    'aria-label': 'Checkbox without visible label',
+    checked: false,
+  },
+};

--- a/src/stories/roadmap-editor/EditorDivider.stories.tsx
+++ b/src/stories/roadmap-editor/EditorDivider.stories.tsx
@@ -1,0 +1,93 @@
+import { EditorDivider } from '@/features/roadmap-editor/components/atoms/EditorDivider';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/Atoms/EditorDivider',
+  component: EditorDivider,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: {
+      control: 'radio',
+      options: ['horizontal', 'vertical'],
+      description: 'Divider orientation',
+      defaultValue: 'horizontal',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes',
+    },
+    'aria-label': {
+      control: 'text',
+      description: 'ARIA label for accessibility',
+    },
+  },
+} satisfies Meta<typeof EditorDivider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Horizontal: Story = {
+  args: {
+    orientation: 'horizontal',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[400px]">
+        <div className="bg-neutral-50 p-4">Content above divider</div>
+        <Story />
+        <div className="bg-neutral-50 p-4">Content below divider</div>
+      </div>
+    ),
+  ],
+};
+
+export const Vertical: Story = {
+  args: {
+    orientation: 'vertical',
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex h-[200px]">
+        <div className="bg-neutral-50 p-4">Left content</div>
+        <Story />
+        <div className="bg-neutral-50 p-4">Right content</div>
+      </div>
+    ),
+  ],
+};
+
+export const WithAriaLabel: Story = {
+  args: {
+    orientation: 'horizontal',
+    'aria-label': 'Section separator',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[400px]">
+        <div className="bg-neutral-50 p-4">Section 1</div>
+        <Story />
+        <div className="bg-neutral-50 p-4">Section 2</div>
+      </div>
+    ),
+  ],
+};
+
+export const CustomClassName: Story = {
+  args: {
+    orientation: 'horizontal',
+    className: 'bg-primary-500',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[400px]">
+        <div className="bg-neutral-50 p-4">Custom colored divider below</div>
+        <Story />
+        <div className="bg-neutral-50 p-4">Custom colored divider above</div>
+      </div>
+    ),
+  ],
+};

--- a/src/stories/roadmap-editor/EditorInput.stories.tsx
+++ b/src/stories/roadmap-editor/EditorInput.stories.tsx
@@ -1,0 +1,51 @@
+import { EditorInput } from '@/features/roadmap-editor/components/atoms/EditorInput';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/Atoms/EditorInput',
+  component: EditorInput,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof EditorInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter text...',
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    label: 'Title',
+    placeholder: 'Enter title',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    label: 'Email',
+    value: 'invalid-email',
+    error: 'Please enter a valid email address',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Node ID',
+    value: 'node-123',
+    disabled: true,
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    label: 'Title',
+    value: 'My Roadmap Node',
+  },
+};

--- a/src/stories/roadmap-editor/EditorTooltip.stories.tsx
+++ b/src/stories/roadmap-editor/EditorTooltip.stories.tsx
@@ -1,0 +1,126 @@
+import { EditorTooltip } from '@/features/roadmap-editor/components/atoms/EditorTooltip';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/Atoms/EditorTooltip',
+  component: EditorTooltip,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    content: {
+      control: 'text',
+      description: 'Tooltip content',
+    },
+    delay: {
+      control: 'number',
+      description: 'Delay before showing tooltip (ms)',
+      defaultValue: 500,
+    },
+    side: {
+      control: 'radio',
+      options: ['top', 'right', 'bottom', 'left'],
+      description: 'Tooltip placement',
+      defaultValue: 'top',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS classes',
+    },
+  },
+} satisfies Meta<typeof EditorTooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Top: Story = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: {} as any,
+  render: () => (
+    <div className="flex h-[200px] items-center justify-center">
+      <EditorTooltip content="This is a tooltip on top" side="top" delay={300}>
+        <button className="bg-primary-500 rounded px-4 py-2 text-white">Hover me (Top)</button>
+      </EditorTooltip>
+    </div>
+  ),
+};
+
+export const Right: Story = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: {} as any,
+  render: () => (
+    <div className="flex h-[200px] items-center justify-center">
+      <EditorTooltip content="This is a tooltip on right" side="right" delay={300}>
+        <button className="bg-primary-500 rounded px-4 py-2 text-white">Hover me (Right)</button>
+      </EditorTooltip>
+    </div>
+  ),
+};
+
+export const Bottom: Story = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: {} as any,
+  render: () => (
+    <div className="flex h-[200px] items-center justify-center">
+      <EditorTooltip content="This is a tooltip on bottom" side="bottom" delay={300}>
+        <button className="bg-primary-500 rounded px-4 py-2 text-white">Hover me (Bottom)</button>
+      </EditorTooltip>
+    </div>
+  ),
+};
+
+export const Left: Story = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: {} as any,
+  render: () => (
+    <div className="flex h-[200px] items-center justify-center">
+      <EditorTooltip content="This is a tooltip on left" side="left" delay={300}>
+        <button className="bg-primary-500 rounded px-4 py-2 text-white">Hover me (Left)</button>
+      </EditorTooltip>
+    </div>
+  ),
+};
+
+export const LongText: Story = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: {} as any,
+  render: () => (
+    <div className="flex h-[200px] items-center justify-center">
+      <EditorTooltip
+        content="This is a very long tooltip text that exceeds the maximum width of 200px and should wrap to multiple lines"
+        side="top"
+        delay={300}
+      >
+        <button className="bg-primary-500 rounded px-4 py-2 text-white">Long text tooltip</button>
+      </EditorTooltip>
+    </div>
+  ),
+};
+
+export const NoDelay: Story = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: {} as any,
+  render: () => (
+    <div className="flex h-[200px] items-center justify-center">
+      <EditorTooltip content="Instant tooltip (no delay)" side="top" delay={0}>
+        <button className="bg-primary-500 rounded px-4 py-2 text-white">No delay</button>
+      </EditorTooltip>
+    </div>
+  ),
+};
+
+export const KeyboardFocus: Story = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  args: {} as any,
+  render: () => (
+    <div className="flex h-[200px] items-center justify-center">
+      <EditorTooltip content="Tooltip appears on keyboard focus" side="top" delay={300}>
+        <button className="bg-primary-500 rounded px-4 py-2 text-white">
+          Tab to focus (Keyboard accessible)
+        </button>
+      </EditorTooltip>
+    </div>
+  ),
+};

--- a/src/stories/roadmap-editor/MultiSelectPanel.stories.tsx
+++ b/src/stories/roadmap-editor/MultiSelectPanel.stories.tsx
@@ -1,0 +1,164 @@
+/* eslint-disable no-console */
+import { useState } from 'react';
+
+import { MultiSelectPanel } from '@/features/roadmap-editor/components/organisms/MultiSelectPanel';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/MultiSelectPanel',
+  component: MultiSelectPanel,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof MultiSelectPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const DefaultComponent = () => {
+  const [items] = useState([
+    { id: 'node-1', type: 'node' as const, title: 'Getting Started', color: '#3b82f6' },
+    { id: 'node-2', type: 'node' as const, title: 'Advanced Topics', color: '#10b981' },
+    { id: 'edge-1', type: 'edge' as const, title: 'Connect' },
+  ]);
+
+  return (
+    <div className="w-[272px]">
+      <MultiSelectPanel
+        selectedItems={items}
+        onColorChange={(color) => console.log('Color changed:', color)}
+        onDelete={() => console.log('Delete all clicked')}
+        onClear={() => console.log('Clear clicked')}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  args: {
+    selectedItems: [
+      { id: 'node-1', type: 'node', title: 'Getting Started', color: '#3b82f6' },
+      { id: 'node-2', type: 'node', title: 'Advanced Topics', color: '#10b981' },
+      { id: 'edge-1', type: 'edge', title: 'Connect' },
+    ],
+    onColorChange: () => {},
+    onDelete: () => {},
+    onClear: () => {},
+  },
+  render: DefaultComponent,
+};
+
+const MixedColorsComponent = () => {
+  const [items] = useState([
+    { id: 'node-1', type: 'node' as const, title: 'Node 1', color: '#3b82f6' },
+    { id: 'node-2', type: 'node' as const, title: 'Node 2', color: '#10b981' },
+    { id: 'node-3', type: 'node' as const, title: 'Node 3', color: '#f59e0b' },
+    { id: 'section-1', type: 'section' as const, title: 'Section A', color: '#ef4444' },
+  ]);
+
+  return (
+    <div className="w-[272px]">
+      <MultiSelectPanel
+        selectedItems={items}
+        onColorChange={(color) => console.log('Color changed:', color)}
+        onDelete={() => console.log('Delete all clicked')}
+        onClear={() => console.log('Clear clicked')}
+      />
+    </div>
+  );
+};
+
+export const MixedColors: Story = {
+  args: {
+    selectedItems: [
+      { id: 'node-1', type: 'node', title: 'Node 1', color: '#3b82f6' },
+      { id: 'node-2', type: 'node', title: 'Node 2', color: '#10b981' },
+      { id: 'node-3', type: 'node', title: 'Node 3', color: '#f59e0b' },
+      { id: 'section-1', type: 'section', title: 'Section A', color: '#ef4444' },
+    ],
+    onColorChange: () => {},
+    onDelete: () => {},
+    onClear: () => {},
+  },
+  render: MixedColorsComponent,
+};
+
+const SameColorComponent = () => {
+  const [items] = useState([
+    { id: 'node-1', type: 'node' as const, title: 'Node 1', color: '#3b82f6' },
+    { id: 'node-2', type: 'node' as const, title: 'Node 2', color: '#3b82f6' },
+    { id: 'node-3', type: 'node' as const, title: 'Node 3', color: '#3b82f6' },
+  ]);
+
+  return (
+    <div className="w-[272px]">
+      <MultiSelectPanel
+        selectedItems={items}
+        onColorChange={(color) => console.log('Color changed:', color)}
+        onDelete={() => console.log('Delete all clicked')}
+        onClear={() => console.log('Clear clicked')}
+      />
+    </div>
+  );
+};
+
+export const SameColor: Story = {
+  args: {
+    selectedItems: [
+      { id: 'node-1', type: 'node', title: 'Node 1', color: '#3b82f6' },
+      { id: 'node-2', type: 'node', title: 'Node 2', color: '#3b82f6' },
+      { id: 'node-3', type: 'node', title: 'Node 3', color: '#3b82f6' },
+    ],
+    onColorChange: () => {},
+    onDelete: () => {},
+    onClear: () => {},
+  },
+  render: SameColorComponent,
+};
+
+const ManyItemsComponent = () => {
+  const [items] = useState(
+    Array.from({ length: 15 }, (_, i) => ({
+      id: `item-${i}`,
+      type: (i % 4 === 0 ? 'node' : i % 4 === 1 ? 'edge' : i % 4 === 2 ? 'section' : 'text') as
+        | 'node'
+        | 'edge'
+        | 'section'
+        | 'text',
+      title: `Item ${i + 1}`,
+      color: ['#3b82f6', '#10b981', '#f59e0b', '#ef4444'][i % 4],
+    })),
+  );
+
+  return (
+    <div className="w-[272px]">
+      <MultiSelectPanel
+        selectedItems={items}
+        onColorChange={(color) => console.log('Color changed:', color)}
+        onDelete={() => console.log('Delete all clicked')}
+        onClear={() => console.log('Clear clicked')}
+      />
+    </div>
+  );
+};
+
+export const ManyItems: Story = {
+  args: {
+    selectedItems: Array.from({ length: 15 }, (_, i) => ({
+      id: `item-${i}`,
+      type: (i % 4 === 0 ? 'node' : i % 4 === 1 ? 'edge' : i % 4 === 2 ? 'section' : 'text') as
+        | 'node'
+        | 'edge'
+        | 'section'
+        | 'text',
+      title: `Item ${i + 1}`,
+      color: ['#3b82f6', '#10b981', '#f59e0b', '#ef4444'][i % 4],
+    })),
+    onColorChange: () => {},
+    onDelete: () => {},
+    onClear: () => {},
+  },
+  render: ManyItemsComponent,
+};

--- a/src/stories/roadmap-editor/NodePropertiesPanel.stories.tsx
+++ b/src/stories/roadmap-editor/NodePropertiesPanel.stories.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+
+import { NodePropertiesPanel } from '@/features/roadmap-editor/components/organisms/NodePropertiesPanel';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Roadmap Editor/Organisms/NodePropertiesPanel',
+  component: NodePropertiesPanel,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof NodePropertiesPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const DefaultComponent = () => {
+  const [title, setTitle] = useState('Learn React');
+  const [description, setDescription] = useState('Master React fundamentals and hooks');
+  const [color, setColor] = useState('#3b82f6');
+
+  return (
+    <NodePropertiesPanel
+      nodeId="node-1"
+      title={title}
+      description={description}
+      color={color}
+      onTitleChange={setTitle}
+      onDescriptionChange={setDescription}
+      onColorChange={setColor}
+    />
+  );
+};
+
+export const Default: Story = {
+  args: {
+    nodeId: 'node-1',
+    title: 'Learn React',
+    description: 'Master React fundamentals and hooks',
+    color: '#3b82f6',
+    onTitleChange: () => {},
+    onDescriptionChange: () => {},
+    onColorChange: () => {},
+  },
+  render: DefaultComponent,
+};
+
+const WithDeleteComponent = () => {
+  const [title, setTitle] = useState('Learn TypeScript');
+  const [description, setDescription] = useState('Learn type system and advanced types');
+  const [color, setColor] = useState('#10b981');
+
+  return (
+    <NodePropertiesPanel
+      nodeId="node-2"
+      title={title}
+      description={description}
+      color={color}
+      onTitleChange={setTitle}
+      onDescriptionChange={setDescription}
+      onColorChange={setColor}
+      onDelete={() => alert('Delete clicked')}
+    />
+  );
+};
+
+export const WithDelete: Story = {
+  args: {
+    nodeId: 'node-2',
+    title: 'Learn TypeScript',
+    description: 'Learn type system and advanced types',
+    color: '#10b981',
+    onTitleChange: () => {},
+    onDescriptionChange: () => {},
+    onColorChange: () => {},
+    onDelete: () => {},
+  },
+  render: WithDeleteComponent,
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
           environment: 'jsdom',
           include: ['src/**/*.test.{ts,tsx}'],
           setupFiles: ['./vitest.setup.ts'],
+          globals: true,
         },
         resolve: {
           alias: {


### PR DESCRIPTION
## Summary

Sub-Issue #98 implementation: Multi-select improvements with mixed state support for bulk editing.

## Changes

### Sidebar Width Update
- Reduced from 320px (w-80) to 272px (w-68) for all property panels
- Updated EditorSidebar, NodePropertiesPanel, EdgePropertiesPanel, MultiSelectPanel, SectionPropertiesPanel, TextPropertiesPanel, ResourcePropertiesPanel

### EditorCheckbox Component
- New checkbox atom with indeterminate state support
- Proper accessibility with ARIA attributes
- Disabled state handling
- Label support (optional)

### MultiSelectPanel Enhancements
- Mixed color state detection (shows "(Mixed)" indicator)
- "Bulk Edit" section for applying properties to all items
- Color picker with mixed state message
- Shows color indicators for each item in the list
- Collapsible "Selected Items" section (default closed)

### EdgePropertiesPanel Multi-Select Mode
- Dual mode: single edge / multi-select
- Mixed state detection for colors and stroke widths
- "Bulk Edit Style" section for bulk changes
- Shows mixed state messages when properties differ
- Displays all selected edges with their properties
- Collapsible "Selected Edges" section

## Test Plan

- [x] All tests passing (100/100)
- [x] Build successful
- [x] ESLint passing
- [x] Storybook documentation added
- [x] Accessibility (WCAG 2.1 AA)
  - [x] Indeterminate checkbox state
  - [x] ARIA attributes for mixed states
  - [x] Keyboard navigation
  - [x] Focus management
  - [x] Clear visual indicators for mixed states

## Related Issues

Closes #98

## Screenshots

(Storybook screenshots available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)