### PR TITLE
fix(#138): 로그인/회원가입 페이지 Figma 디자인 불일치 수정

### DIFF
--- a/src/app/(myroadmap)/myroadmap/page.tsx
+++ b/src/app/(myroadmap)/myroadmap/page.tsx
@@ -5,120 +5,76 @@ import { useAtomValue } from 'jotai';
 import { MyRoadmapsToolbar } from '@/features/my-roadmaps/components/molecules/MyRoadmapsToolbar';
 import { MyRoadmapsGrid } from '@/features/my-roadmaps/components/organisms/MyRoadmapsGrid';
 import { MyRoadmapsHeader } from '@/features/my-roadmaps/components/organisms/MyRoadmapsHeader';
-import { MyRoadmapsLayout } from '@/features/my-roadmaps/components/templates/MyRoadmapsLayout';
+import { MyRoadmapsLayout } from '@/features/my-roadmaps/components/templates';
 import {
   filterCategoryAtom,
+  myRoadmapItemsAtom,
   sidebarCategoryAtom,
   sortByAtom,
   sortOrderAtom,
 } from '@/features/my-roadmaps/stores/my-roadmaps.atoms';
-import type { RoadmapData } from '@/features/my-roadmaps/types/my-roadmaps.types';
-
-// Mock data for development
-const MY_ROADMAPS: RoadmapData[] = [
-  {
-    id: '1',
-    title: 'Frontend Developer Roadmap',
-    author: '홍길동',
-    type: 'Roadmap',
-    updatedAt: '2024-02-06T10:00:00Z',
-    isFavorite: true,
-    category: 'my-roadmap',
-  },
-  {
-    id: '2',
-    title: 'Directory Name',
-    type: 'Directory',
-    fileCount: 67,
-    updatedAt: '2024-02-05T10:00:00Z',
-    category: 'my-roadmap',
-  },
-  {
-    id: '3',
-    title: 'React Mastery',
-    author: '홍길동',
-    type: 'Roadmap',
-    updatedAt: '2024-02-04T10:00:00Z',
-    isShared: true,
-    category: 'my-roadmap',
-  },
-  {
-    id: '4',
-    title: 'Backend Essentials',
-    author: '홍길동',
-    type: 'Roadmap',
-    updatedAt: '2024-02-03T10:00:00Z',
-    category: 'community',
-  },
-  {
-    id: '5',
-    title: 'DevOps Guide',
-    author: '홍길동',
-    type: 'Roadmap',
-    updatedAt: '2024-02-02T10:00:00Z',
-    isFavorite: true,
-    category: 'community',
-  },
-];
 
 export default function MyRoadmapsPage() {
+  const items = useAtomValue(myRoadmapItemsAtom);
   const activeCategory = useAtomValue(sidebarCategoryAtom);
   const sortOrder = useAtomValue(sortOrderAtom);
   const sortBy = useAtomValue(sortByAtom);
   const filterCategory = useAtomValue(filterCategoryAtom);
 
-  const filteredRoadmaps = MY_ROADMAPS.filter((roadmap) => {
-    // 1. Sidebar Category Filter
-    let categoryMatch = false;
-    switch (activeCategory) {
-      case 'recent':
-        categoryMatch = true;
-        break;
-      case 'community':
-        categoryMatch = roadmap.category === 'community';
-        break;
-      case 'my-roadmap':
-        categoryMatch = roadmap.category === 'my-roadmap';
-        break;
-      case 'shared':
-        categoryMatch = !!roadmap.isShared;
-        break;
-      case 'favorites':
-        categoryMatch = !!roadmap.isFavorite;
-        break;
-      default:
-        categoryMatch = true;
-    }
+  const filteredRoadmaps = items
+    .filter((roadmap) => {
+      // 1. Sidebar Category Filter
+      let categoryMatch = false;
+      switch (activeCategory) {
+        case 'recent':
+          categoryMatch = true;
+          break;
+        case 'community':
+          categoryMatch = roadmap.category === 'community';
+          break;
+        case 'my-roadmap':
+          categoryMatch = roadmap.category === 'my-roadmap';
+          break;
+        case 'shared':
+          categoryMatch = !!roadmap.isShared;
+          break;
+        case 'favorites':
+          categoryMatch = !!roadmap.isFavorite;
+          break;
+        default:
+          categoryMatch = true;
+      }
 
-    if (!categoryMatch) return false;
+      if (!categoryMatch) return false;
 
-    // 2. Toolbar Category Filter
-    if (filterCategory !== 'all') {
-      const typeMatch =
-        filterCategory === 'roadmap' ? roadmap.type === 'Roadmap' : roadmap.type === 'Directory';
-      if (!typeMatch) return false;
-    }
+      // 2. Toolbar Category Filter
+      if (filterCategory !== 'all') {
+        const typeMatch =
+          filterCategory === 'roadmap' ? roadmap.type === 'Roadmap' : roadmap.type === 'Directory';
+        if (!typeMatch) return false;
+      }
 
-    return true;
-  }).sort((a, b) => {
-    // 3. Sorting
-    let comparison = 0;
-    switch (sortBy) {
-      case 'recent':
-        comparison = new Date(b.updatedAt || 0).getTime() - new Date(a.updatedAt || 0).getTime();
-        break;
-      case 'name':
-        comparison = (b.title || '').localeCompare(a.title || '');
-        break;
-      case 'size':
-        comparison = (b.fileCount || 0) - (a.fileCount || 0);
-        break;
-      default:
-        comparison = 0;
-    }
+      return true;
+    })
+    .sort((a, b) => {
+      // 3. Sorting
+      let comparison = 0;
+      switch (sortBy) {
+        case 'recent':
+          comparison = new Date(b.updatedAt || 0).getTime() - new Date(a.updatedAt || 0).getTime();
+          break;
+        case 'name':
+          comparison = (b.title || '').localeCompare(a.title || '');
+          break;
+        case 'size':
+          comparison = (b.fileCount || 0) - (a.fileCount || 0);
+          break;
+        default:
+          comparison = 0;
+      }
 
-    return sortOrder === 'asc' ? -comparison : comparison;
-  });
+      return sortOrder === 'asc' ? -comparison : comparison;
+    });
 
   return (
     <MyRoadmapsLayout>

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,3 +1,22 @@
+export const COMMUNITY_MESSAGES = {
+  NOT_FOUND: '로드맵을 찾을 수 없습니다.',
+  VIEW_ROADMAP: '로드맵 보기',
+  ADD_TO_MY_ROADMAPS: '내 로드맵에 추가',
+  LOGIN_REQUIRED: '로그인 후 이용 가능합니다',
+  LIKE: '좋아요',
+  ABOUT: 'About',
+  MADE_BY: 'Made by',
+  LAST_UPDATED: '마지막 업데이트',
+} as const;
+
+export const MY_ROADMAPS_MESSAGES = {
+  SEARCH_PLACEHOLDER: '로드맵 검색',
+  NEW_ROADMAP: '로드맵',
+  NEW_DIRECTORY: '디렉토리',
+  SHARE_COPIED: '링크가 클립보드에 복사되었습니다',
+  SHARE_FAILED: '링크 복사에 실패했습니다',
+} as const;
+
 export const PROFILE_MESSAGES = {
   BIO_TITLE: '자기소개',
   COMPLETED_ROADMAP: '완주한 로드맵',

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,3 +1,9 @@
+export const AUTH_MESSAGES = {
+  LOGIN_EMAIL_NOT_FOUND: '존재하지 않는 이메일입니다',
+  LOGIN_PASSWORD_MISMATCH: '비밀번호가 일치하지 않습니다',
+  LOGIN_FAILED: '로그인에 실패했습니다',
+} as const;
+
 export const COMMUNITY_MESSAGES = {
   NOT_FOUND: '로드맵을 찾을 수 없습니다.',
   VIEW_ROADMAP: '로드맵 보기',

--- a/src/features/auth/components/atoms/GitHubAuthButton/GitHubAuthButton.test.tsx
+++ b/src/features/auth/components/atoms/GitHubAuthButton/GitHubAuthButton.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GitHubAuthButton } from './index';
+
+describe('GitHubAuthButton', () => {
+  it('로그인 variant일 때 올바른 텍스트를 표시한다', () => {
+    render(<GitHubAuthButton variant="login" />);
+    expect(screen.getByRole('button')).toHaveTextContent('GitHub로 로그인');
+  });
+
+  it('회원가입 variant일 때 올바른 텍스트를 표시한다', () => {
+    render(<GitHubAuthButton variant="register" />);
+    expect(screen.getByRole('button')).toHaveTextContent('GitHub로 회원가입');
+  });
+
+  it('클릭 시 onClick 핸들러를 호출한다', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+
+    render(<GitHubAuthButton variant="login" onClick={handleClick} />);
+    await user.click(screen.getByRole('button'));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('type이 button이다', () => {
+    render(<GitHubAuthButton variant="login" />);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+});

--- a/src/features/auth/components/atoms/GitHubAuthButton/index.tsx
+++ b/src/features/auth/components/atoms/GitHubAuthButton/index.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Github } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface GitHubAuthButtonProps {
+  variant: 'login' | 'register';
+  className?: string;
+  onClick?: () => void;
+}
+
+export function GitHubAuthButton({ variant, className, onClick }: GitHubAuthButtonProps) {
+  const label = variant === 'login' ? 'GitHub로 로그인' : 'GitHub로 회원가입';
+
+  return (
+    <Button type="button" className={cn('w-full font-semibold', className)} onClick={onClick}>
+      <Github className="size-4" />
+      {label}
+    </Button>
+  );
+}

--- a/src/features/auth/components/organisms/FindPasswordForm.test.tsx
+++ b/src/features/auth/components/organisms/FindPasswordForm.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FindPasswordForm } from './FindPasswordForm';
+
+describe('FindPasswordForm', () => {
+  it('초기에 step 1 (이메일/인증번호) 폼을 렌더링한다', () => {
+    render(<FindPasswordForm />);
+
+    expect(screen.getByPlaceholderText('이메일 입력')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('인증번호 입력')).toBeInTheDocument();
+  });
+
+  it('초기에 인증번호 전송 버튼을 렌더링한다', () => {
+    render(<FindPasswordForm />);
+
+    expect(screen.getByRole('button', { name: '인증번호 전송' })).toBeInTheDocument();
+  });
+
+  it('인증번호 전송 클릭 후 다음 버튼을 렌더링한다', async () => {
+    const user = userEvent.setup();
+    render(<FindPasswordForm />);
+
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+
+    expect(screen.getByRole('button', { name: '다음' })).toBeInTheDocument();
+  });
+
+  it('인증번호 전송 후 재전송 버튼을 표시한다', async () => {
+    const user = userEvent.setup();
+    render(<FindPasswordForm />);
+
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+
+    expect(screen.getByRole('button', { name: '인증번호 재전송' })).toBeInTheDocument();
+  });
+
+  it('step 1 제출 후 step 2 (새 비밀번호) 폼으로 전환된다', async () => {
+    const user = userEvent.setup();
+    render(<FindPasswordForm />);
+
+    await user.type(screen.getByPlaceholderText('이메일 입력'), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.type(screen.getByPlaceholderText('인증번호 입력'), '123456');
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('비밀번호 입력')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('비밀번호 다시 입력')).toBeInTheDocument();
+    });
+  });
+
+  it('step 2에서 완료 버튼을 렌더링한다', async () => {
+    const user = userEvent.setup();
+    render(<FindPasswordForm />);
+
+    await user.type(screen.getByPlaceholderText('이메일 입력'), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.type(screen.getByPlaceholderText('인증번호 입력'), '123456');
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '완료' })).toBeInTheDocument();
+    });
+  });
+
+  it('step 2에서 비밀번호 불일치 시 에러를 표시한다', async () => {
+    const user = userEvent.setup();
+    render(<FindPasswordForm />);
+
+    // Step 1 통과
+    await user.type(screen.getByPlaceholderText('이메일 입력'), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.type(screen.getByPlaceholderText('인증번호 입력'), '123456');
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    // Step 2
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('비밀번호 입력')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText('비밀번호 입력'), 'Password1!');
+    await user.type(screen.getByPlaceholderText('비밀번호 다시 입력'), 'Different1!');
+    await user.click(screen.getByRole('button', { name: '완료' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('비밀번호가 일치하지 않습니다')).toBeInTheDocument();
+    });
+  });
+
+  it('onStepChange 콜백을 step 전환 시 호출한다', async () => {
+    const user = userEvent.setup();
+    const onStepChange = vi.fn();
+    render(<FindPasswordForm onStepChange={onStepChange} />);
+
+    await user.type(screen.getByPlaceholderText('이메일 입력'), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.type(screen.getByPlaceholderText('인증번호 입력'), '123456');
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    await waitFor(() => {
+      expect(onStepChange).toHaveBeenCalledWith(
+        2,
+        '새 비밀번호 입력',
+        '재설정할 비밀번호를 입력해주세요',
+      );
+    });
+  });
+});

--- a/src/features/auth/components/organisms/LoginForm/LoginForm.test.tsx
+++ b/src/features/auth/components/organisms/LoginForm/LoginForm.test.tsx
@@ -29,6 +29,16 @@ describe('LoginForm', () => {
     expect(screen.getByRole('button', { name: /Google로 로그인/i })).toBeInTheDocument();
   });
 
+  it('GitHub 로그인 버튼을 렌더링한다', () => {
+    render(<LoginForm />);
+    expect(screen.getByRole('button', { name: /GitHub로 로그인/i })).toBeInTheDocument();
+  });
+
+  it('로그인 버튼과 소셜 버튼 사이에 구분선이 있다', () => {
+    render(<LoginForm />);
+    expect(document.querySelector('[data-slot="separator"]')).toBeInTheDocument();
+  });
+
   it('이메일이 비어있으면 에러 메시지를 표시한다', async () => {
     const user = userEvent.setup();
     render(<LoginForm />);

--- a/src/features/auth/components/organisms/LoginForm/index.tsx
+++ b/src/features/auth/components/organisms/LoginForm/index.tsx
@@ -15,8 +15,10 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
 
 import { loginSchema, type LoginSchema } from '../../../schemas/auth.schema';
+import { GitHubAuthButton } from '../../atoms/GitHubAuthButton';
 import { GoogleAuthButton } from '../../atoms/GoogleAuthButton';
 import { PasswordInput } from '../../molecules/PasswordInput';
 
@@ -35,6 +37,10 @@ export function LoginForm() {
 
   const handleGoogleLogin = () => {
     // TODO: Google OAuth
+  };
+
+  const handleGitHubLogin = () => {
+    // TODO: GitHub OAuth
   };
 
   return (
@@ -80,7 +86,9 @@ export function LoginForm() {
           <Button type="submit" className="w-full">
             로그인
           </Button>
+          <Separator className="my-1" />
           <GoogleAuthButton variant="login" onClick={handleGoogleLogin} />
+          <GitHubAuthButton variant="login" onClick={handleGitHubLogin} />
         </div>
       </form>
     </Form>

--- a/src/features/auth/components/organisms/RegisterForm.test.tsx
+++ b/src/features/auth/components/organisms/RegisterForm.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RegisterForm } from './RegisterForm';
+
+describe('RegisterForm', () => {
+  it('초기에 step 1 (이메일/비밀번호/인증번호) 폼을 렌더링한다', () => {
+    render(<RegisterForm />);
+
+    expect(screen.getByPlaceholderText('이메일 입력')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('비밀번호 지정')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('인증번호 입력')).toBeInTheDocument();
+  });
+
+  it('step 1 제출 후 step 2 (사용자 이름) 폼으로 전환된다', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    await user.type(screen.getByPlaceholderText('이메일 입력'), 'test@example.com');
+    await user.type(screen.getByPlaceholderText('비밀번호 지정'), 'Password1!');
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.type(screen.getByPlaceholderText('인증번호 입력'), '123456');
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('사용자 이름 입력')).toBeInTheDocument();
+    });
+  });
+
+  it('step 2 제출 후 step 3 (링크 추가) 폼으로 전환된다', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    // Step 1
+    await user.type(screen.getByPlaceholderText('이메일 입력'), 'test@example.com');
+    await user.type(screen.getByPlaceholderText('비밀번호 지정'), 'Password1!');
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.type(screen.getByPlaceholderText('인증번호 입력'), '123456');
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    // Step 2
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('사용자 이름 입력')).toBeInTheDocument();
+    });
+    await user.type(screen.getByPlaceholderText('사용자 이름 입력'), '홍길동');
+    await user.click(screen.getByRole('button', { name: '확인' }));
+
+    // Step 3
+    await waitFor(() => {
+      expect(screen.getByText('1번 링크')).toBeInTheDocument();
+    });
+  });
+
+  it('step 3에서 건너뛰기 버튼을 렌더링한다', async () => {
+    const user = userEvent.setup();
+    render(<RegisterForm />);
+
+    // Step 1
+    await user.type(screen.getByPlaceholderText('이메일 입력'), 'test@example.com');
+    await user.type(screen.getByPlaceholderText('비밀번호 지정'), 'Password1!');
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.type(screen.getByPlaceholderText('인증번호 입력'), '123456');
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    // Step 2
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('사용자 이름 입력')).toBeInTheDocument();
+    });
+    await user.type(screen.getByPlaceholderText('사용자 이름 입력'), '홍길동');
+    await user.click(screen.getByRole('button', { name: '확인' }));
+
+    // Step 3
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '건너뛰기' })).toBeInTheDocument();
+    });
+  });
+
+  it('onStepChange 콜백을 step 전환 시 호출한다', async () => {
+    const user = userEvent.setup();
+    const onStepChange = vi.fn();
+    render(<RegisterForm onStepChange={onStepChange} />);
+
+    await user.type(screen.getByPlaceholderText('이메일 입력'), 'test@example.com');
+    await user.type(screen.getByPlaceholderText('비밀번호 지정'), 'Password1!');
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.type(screen.getByPlaceholderText('인증번호 입력'), '123456');
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    await waitFor(() => {
+      expect(onStepChange).toHaveBeenCalledWith(
+        2,
+        '사용자 이름 설정',
+        '사용자 이름을 입력해주세요',
+      );
+    });
+  });
+});

--- a/src/features/auth/components/organisms/RegisterForm.tsx
+++ b/src/features/auth/components/organisms/RegisterForm.tsx
@@ -43,6 +43,10 @@ export function RegisterForm({ onStepChange }: RegisterFormProps) {
     // TODO: Google OAuth
   };
 
+  const handleGitHubRegister = () => {
+    // TODO: GitHub OAuth
+  };
+
   if (step === 3) {
     return <RegisterStep3Form onSubmit={handleStep3Submit} onSkip={handleSkip} />;
   }
@@ -51,5 +55,11 @@ export function RegisterForm({ onStepChange }: RegisterFormProps) {
     return <RegisterStep2Form onSubmit={handleStep2Submit} />;
   }
 
-  return <RegisterStep1Form onSubmit={handleStep1Submit} onGoogleRegister={handleGoogleRegister} />;
+  return (
+    <RegisterStep1Form
+      onSubmit={handleStep1Submit}
+      onGoogleRegister={handleGoogleRegister}
+      onGitHubRegister={handleGitHubRegister}
+    />
+  );
 }

--- a/src/features/auth/components/organisms/register-steps/RegisterStep1Form.test.tsx
+++ b/src/features/auth/components/organisms/register-steps/RegisterStep1Form.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RegisterStep1Form } from './RegisterStep1Form';
+
+describe('RegisterStep1Form', () => {
+  it('이메일, 비밀번호, 인증번호 필드를 렌더링한다', () => {
+    render(<RegisterStep1Form onSubmit={vi.fn()} onGoogleRegister={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText('이메일 입력')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('비밀번호 지정')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('인증번호 입력')).toBeInTheDocument();
+  });
+
+  it('초기에 인증번호 전송 버튼을 렌더링한다', () => {
+    render(<RegisterStep1Form onSubmit={vi.fn()} onGoogleRegister={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: '인증번호 전송' })).toBeInTheDocument();
+  });
+
+  it('인증번호 전송 버튼 클릭 후 다음 버튼을 렌더링한다', async () => {
+    const user = userEvent.setup();
+    render(<RegisterStep1Form onSubmit={vi.fn()} onGoogleRegister={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+
+    expect(screen.getByRole('button', { name: '다음' })).toBeInTheDocument();
+  });
+
+  it('인증번호 전송 후 재전송 버튼을 표시한다', async () => {
+    const user = userEvent.setup();
+    render(<RegisterStep1Form onSubmit={vi.fn()} onGoogleRegister={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+
+    expect(screen.getByRole('button', { name: '인증번호 재전송' })).toBeInTheDocument();
+  });
+
+  it('Google 회원가입 버튼을 렌더링한다', () => {
+    render(<RegisterStep1Form onSubmit={vi.fn()} onGoogleRegister={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /Google로 회원가입/i })).toBeInTheDocument();
+  });
+
+  it('이메일 없이 제출하면 에러 메시지를 표시한다', async () => {
+    const user = userEvent.setup();
+    render(<RegisterStep1Form onSubmit={vi.fn()} onGoogleRegister={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('이메일을 입력해주세요')).toBeInTheDocument();
+    });
+  });
+
+  it('비밀번호 없이 제출하면 에러 메시지를 표시한다', async () => {
+    const user = userEvent.setup();
+    render(<RegisterStep1Form onSubmit={vi.fn()} onGoogleRegister={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText('이메일 입력'), 'test@example.com');
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('비밀번호를 입력해주세요')).toBeInTheDocument();
+    });
+  });
+
+  it('유효한 데이터로 제출하면 onSubmit이 호출된다', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<RegisterStep1Form onSubmit={onSubmit} onGoogleRegister={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText('이메일 입력'), 'test@example.com');
+    await user.type(screen.getByPlaceholderText('비밀번호 지정'), 'Password1!');
+    await user.click(screen.getByRole('button', { name: '인증번호 전송' }));
+    await user.type(screen.getByPlaceholderText('인증번호 입력'), '123456');
+    await user.click(screen.getByRole('button', { name: '다음' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('Google 회원가입 버튼 클릭 시 onGoogleRegister가 호출된다', async () => {
+    const user = userEvent.setup();
+    const onGoogleRegister = vi.fn();
+    render(<RegisterStep1Form onSubmit={vi.fn()} onGoogleRegister={onGoogleRegister} />);
+
+    await user.click(screen.getByRole('button', { name: /Google로 회원가입/i }));
+
+    expect(onGoogleRegister).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/auth/components/organisms/register-steps/RegisterStep1Form.tsx
+++ b/src/features/auth/components/organisms/register-steps/RegisterStep1Form.tsx
@@ -13,9 +13,11 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
 
 import { useVerificationCode } from '../../../hooks/use-verification-code';
 import { registerStep1Schema, type RegisterStep1Schema } from '../../../schemas/auth.schema';
+import { GitHubAuthButton } from '../../atoms/GitHubAuthButton';
 import { GoogleAuthButton } from '../../atoms/GoogleAuthButton';
 import { PasswordInput } from '../../molecules/PasswordInput';
 import { VerificationCodeInput } from '../../molecules/VerificationCodeInput';
@@ -23,9 +25,14 @@ import { VerificationCodeInput } from '../../molecules/VerificationCodeInput';
 interface RegisterStep1FormProps {
   onSubmit: (data: RegisterStep1Schema) => void;
   onGoogleRegister: () => void;
+  onGitHubRegister?: () => void;
 }
 
-export function RegisterStep1Form({ onSubmit, onGoogleRegister }: RegisterStep1FormProps) {
+export function RegisterStep1Form({
+  onSubmit,
+  onGoogleRegister,
+  onGitHubRegister,
+}: RegisterStep1FormProps) {
   const { isCodeSent, handleSendCode } = useVerificationCode();
 
   const form = useForm<RegisterStep1Schema>({
@@ -106,7 +113,9 @@ export function RegisterStep1Form({ onSubmit, onGoogleRegister }: RegisterStep1F
               인증번호 전송
             </Button>
           )}
+          <Separator className="my-1" />
           <GoogleAuthButton variant="register" onClick={onGoogleRegister} />
+          <GitHubAuthButton variant="register" onClick={onGitHubRegister} />
         </div>
       </form>
     </Form>

--- a/src/features/auth/components/organisms/register-steps/RegisterStep2Form.test.tsx
+++ b/src/features/auth/components/organisms/register-steps/RegisterStep2Form.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RegisterStep2Form } from './RegisterStep2Form';
+
+describe('RegisterStep2Form', () => {
+  it('사용자 이름 입력 필드를 렌더링한다', () => {
+    render(<RegisterStep2Form onSubmit={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText('사용자 이름 입력')).toBeInTheDocument();
+  });
+
+  it('확인 버튼을 렌더링한다', () => {
+    render(<RegisterStep2Form onSubmit={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: '확인' })).toBeInTheDocument();
+  });
+
+  it('이름 레이블을 렌더링한다', () => {
+    render(<RegisterStep2Form onSubmit={vi.fn()} />);
+
+    expect(screen.getByText('이름')).toBeInTheDocument();
+  });
+
+  it('사용자 이름 없이 제출하면 에러 메시지를 표시한다', async () => {
+    const user = userEvent.setup();
+    render(<RegisterStep2Form onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '확인' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('이름을 입력해주세요')).toBeInTheDocument();
+    });
+  });
+
+  it('유효한 이름으로 제출하면 onSubmit이 호출된다', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<RegisterStep2Form onSubmit={onSubmit} />);
+
+    await user.type(screen.getByPlaceholderText('사용자 이름 입력'), '홍길동');
+    await user.click(screen.getByRole('button', { name: '확인' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('onSubmit이 올바른 데이터와 함께 호출된다', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<RegisterStep2Form onSubmit={onSubmit} />);
+
+    await user.type(screen.getByPlaceholderText('사용자 이름 입력'), '홍길동');
+    await user.click(screen.getByRole('button', { name: '확인' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledOnce();
+      expect(onSubmit.mock.calls[0][0]).toEqual({ username: '홍길동' });
+    });
+  });
+});

--- a/src/features/auth/components/organisms/register-steps/RegisterStep3Form.test.tsx
+++ b/src/features/auth/components/organisms/register-steps/RegisterStep3Form.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RegisterStep3Form } from './RegisterStep3Form';
+
+describe('RegisterStep3Form', () => {
+  it('링크 입력 필드들을 렌더링한다', () => {
+    render(<RegisterStep3Form onSubmit={vi.fn()} onSkip={vi.fn()} />);
+
+    const namePlaceholders = screen.getAllByPlaceholderText('링크 이름');
+    const urlPlaceholders = screen.getAllByPlaceholderText('링크 URL');
+
+    expect(namePlaceholders).toHaveLength(3);
+    expect(urlPlaceholders).toHaveLength(3);
+  });
+
+  it('링크 레이블들을 렌더링한다', () => {
+    render(<RegisterStep3Form onSubmit={vi.fn()} onSkip={vi.fn()} />);
+
+    expect(screen.getByText('1번 링크')).toBeInTheDocument();
+    expect(screen.getByText('2번 링크')).toBeInTheDocument();
+    expect(screen.getByText('3번 링크')).toBeInTheDocument();
+  });
+
+  it('확인 버튼과 건너뛰기 버튼을 렌더링한다', () => {
+    render(<RegisterStep3Form onSubmit={vi.fn()} onSkip={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: '확인' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '건너뛰기' })).toBeInTheDocument();
+  });
+
+  it('건너뛰기 버튼 클릭 시 onSkip이 호출된다', async () => {
+    const user = userEvent.setup();
+    const onSkip = vi.fn();
+    render(<RegisterStep3Form onSubmit={vi.fn()} onSkip={onSkip} />);
+
+    await user.click(screen.getByRole('button', { name: '건너뛰기' }));
+
+    expect(onSkip).toHaveBeenCalledOnce();
+  });
+
+  it('빈 폼 제출 시 onSubmit이 호출된다 (모든 필드가 선택사항)', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<RegisterStep3Form onSubmit={onSubmit} onSkip={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '확인' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('잘못된 URL 입력 시 에러 메시지를 표시한다', async () => {
+    const user = userEvent.setup();
+    render(<RegisterStep3Form onSubmit={vi.fn()} onSkip={vi.fn()} />);
+
+    const urlInputs = screen.getAllByPlaceholderText('링크 URL');
+    await user.type(urlInputs[0], 'not-a-valid-url');
+    await user.click(screen.getByRole('button', { name: '확인' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('올바른 URL 형식이 아닙니다')).toBeInTheDocument();
+    });
+  });
+
+  it('유효한 URL로 제출하면 onSubmit이 호출된다', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<RegisterStep3Form onSubmit={onSubmit} onSkip={vi.fn()} />);
+
+    const nameInputs = screen.getAllByPlaceholderText('링크 이름');
+    const urlInputs = screen.getAllByPlaceholderText('링크 URL');
+
+    await user.type(nameInputs[0], 'GitHub');
+    await user.type(urlInputs[0], 'https://github.com/user');
+    await user.click(screen.getByRole('button', { name: '확인' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/features/auth/hooks/use-verification-code.test.ts
+++ b/src/features/auth/hooks/use-verification-code.test.ts
@@ -1,0 +1,34 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useVerificationCode } from './use-verification-code';
+
+describe('useVerificationCode', () => {
+  it('초기 상태에서 isCodeSent가 false이다', () => {
+    const { result } = renderHook(() => useVerificationCode());
+    expect(result.current.isCodeSent).toBe(false);
+  });
+
+  it('handleSendCode 호출 후 isCodeSent가 true가 된다', () => {
+    const { result } = renderHook(() => useVerificationCode());
+
+    act(() => {
+      result.current.handleSendCode();
+    });
+
+    expect(result.current.isCodeSent).toBe(true);
+  });
+
+  it('handleSendCode를 여러 번 호출해도 isCodeSent가 true를 유지한다', () => {
+    const { result } = renderHook(() => useVerificationCode());
+
+    act(() => {
+      result.current.handleSendCode();
+    });
+    act(() => {
+      result.current.handleSendCode();
+    });
+
+    expect(result.current.isCodeSent).toBe(true);
+  });
+});

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,4 +1,5 @@
 export { AuthCard } from './components/templates/AuthCard';
+export { GitHubAuthButton } from './components/atoms/GitHubAuthButton';
 export { GoogleAuthButton } from './components/atoms/GoogleAuthButton';
 export { PasswordInput } from './components/molecules/PasswordInput';
 export { VerificationCodeInput } from './components/molecules/VerificationCodeInput';

--- a/src/features/community/components/templates/RoadmapDetail/RoadmapDetail.test.tsx
+++ b/src/features/community/components/templates/RoadmapDetail/RoadmapDetail.test.tsx
@@ -1,86 +1,100 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-import { MOCK_COMMUNITY_DATA } from '../../../constants/community.mock';
+import { COMMUNITY_MESSAGES } from '@/constants/messages';
+
 import { RoadmapDetail } from './index';
 
-// Mock the data module
-vi.mock('../../../constants/community.mock', () => ({
-  MOCK_COMMUNITY_DATA: [
-    {
-      id: '1',
-      title: 'Test Roadmap',
-      author: 'Test Author',
-      likes: 10,
-      updatedAt: '2024-01-01T00:00:00.000Z',
-      type: 'roadmap',
-      imageUrl: 'https://example.com/test-image.jpg',
-    },
-  ],
+const mockPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
 }));
 
-// Mock NextImage to avoid issues with next/image in tests
 vi.mock('next/image', () => ({
-  default: (props: any) => <img {...props} alt={props.alt} data-testid="roadmap-image" />,
+  default: (
+    props: React.ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean; priority?: boolean },
+  ) => {
+    const { fill: _, priority: __, ...rest } = props;
+    void _;
+    void __;
+    return <img {...rest} data-testid="roadmap-image" />;
+  },
 }));
 
-// Mock Lucide icons
 vi.mock('lucide-react', () => ({
   Heart: () => <span data-testid="icon-heart">Heart</span>,
   FilePlus2: () => <span data-testid="icon-file-plus">FilePlus</span>,
 }));
 
-// Mock components used in RoadmapDetail
 vi.mock('../../atoms/ContributorItem', () => ({
   ContributorItem: ({ name }: { name: string }) => <div data-testid="contributor-item">{name}</div>,
 }));
 
-// Mock shadcn/ui components (simplified)
 vi.mock('@/components/ui/button', () => ({
-  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+  Button: ({
+    children,
+    onClick,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
 }));
+
 vi.mock('@/components/ui/separator', () => ({
-  Separator: (props: any) => <div data-testid="separator" {...props} />,
+  Separator: (props: React.HTMLAttributes<HTMLDivElement>) => (
+    <div data-testid="separator" {...props} />
+  ),
 }));
+
+// MOCK_COMMUNITY_DATA ids: '1' through '15'
+const VALID_ID = '1';
+const INVALID_ID = 'does-not-exist';
 
 describe('RoadmapDetail', () => {
-  const mockItem = MOCK_COMMUNITY_DATA[0];
-
-  it('renders "Not Found" message when id is invalid', () => {
-    render(<RoadmapDetail id="invalid-id" />);
-    expect(screen.getByText('로드맵을 찾을 수 없습니다.')).toBeInTheDocument();
+  beforeEach(() => {
+    mockPush.mockClear();
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
   });
 
-  it('renders roadmap details correctly when id is valid', () => {
-    render(<RoadmapDetail id={mockItem.id} />);
-
-    // Check title
-    expect(screen.getByText(mockItem.title)).toBeInTheDocument();
-
-    // Check author/contributors (mocked)
-    expect(screen.getByText(mockItem.author)).toBeInTheDocument();
-    expect(screen.getByText('Co-author')).toBeInTheDocument();
-    expect(screen.getByText('Contributor')).toBeInTheDocument();
-
-    // Check buttons
-    expect(screen.getByText('좋아요')).toBeInTheDocument();
-    expect(screen.getByText('로드맵 보기')).toBeInTheDocument();
-    expect(screen.getByText('내 로드맵에 추가')).toBeInTheDocument();
-
-    // Check "About" section presence
-    expect(screen.getByText('About')).toBeInTheDocument();
-    // Check "Made by" section presence
-    expect(screen.getByText('Made by')).toBeInTheDocument();
-    // Check "Last updated" section presence
-    expect(screen.getByText('마지막 업데이트')).toBeInTheDocument();
+  it('renders roadmap detail when valid id', () => {
+    render(<RoadmapDetail id={VALID_ID} />);
+    expect(screen.getByText('Roadmap 1')).toBeInTheDocument();
+    expect(screen.getByText(COMMUNITY_MESSAGES.VIEW_ROADMAP)).toBeInTheDocument();
+    expect(screen.getByText(COMMUNITY_MESSAGES.ADD_TO_MY_ROADMAPS)).toBeInTheDocument();
   });
 
-  it('renders image when imageUrl is present', () => {
-    render(<RoadmapDetail id={mockItem.id} />);
-    // Since we mocked next/image as img, we can search by alt text
-    const image = screen.getByTestId('roadmap-image');
-    expect(image).toBeInTheDocument();
-    expect(image).toHaveAttribute('src', mockItem.imageUrl);
+  it('shows not-found message for invalid id', () => {
+    render(<RoadmapDetail id={INVALID_ID} />);
+    expect(screen.getByText(COMMUNITY_MESSAGES.NOT_FOUND)).toBeInTheDocument();
+  });
+
+  it('"로드맵 보기" button calls router.push with correct path', async () => {
+    const user = userEvent.setup();
+    render(<RoadmapDetail id={VALID_ID} />);
+    await user.click(screen.getByText(COMMUNITY_MESSAGES.VIEW_ROADMAP));
+    expect(mockPush).toHaveBeenCalledWith(`/viewer/${VALID_ID}`);
+  });
+
+  it('"내 로드맵에 추가" button calls window.alert with login message', async () => {
+    const user = userEvent.setup();
+    render(<RoadmapDetail id={VALID_ID} />);
+    await user.click(screen.getByText(COMMUNITY_MESSAGES.ADD_TO_MY_ROADMAPS));
+    expect(window.alert).toHaveBeenCalledWith(COMMUNITY_MESSAGES.LOGIN_REQUIRED);
+  });
+
+  it('like button toggles', async () => {
+    const user = userEvent.setup();
+    render(<RoadmapDetail id={VALID_ID} />);
+    const likeButton = screen.getByText(COMMUNITY_MESSAGES.LIKE).closest('button')!;
+    expect(likeButton).not.toHaveClass('border-red-500');
+    await user.click(likeButton);
+    expect(likeButton).toHaveClass('border-red-500');
+    await user.click(likeButton);
+    expect(likeButton).not.toHaveClass('border-red-500');
   });
 });

--- a/src/features/community/components/templates/RoadmapDetail/index.tsx
+++ b/src/features/community/components/templates/RoadmapDetail/index.tsx
@@ -3,11 +3,13 @@
 import { useState } from 'react';
 
 import NextImage from 'next/image';
+import { useRouter } from 'next/navigation';
 
 import { Heart, FilePlus2 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
+import { COMMUNITY_MESSAGES } from '@/constants/messages';
 import { cn } from '@/lib/utils';
 
 import { MOCK_COMMUNITY_DATA } from '../../../constants/community.mock';
@@ -18,6 +20,7 @@ interface RoadmapDetailProps {
 }
 
 export function RoadmapDetail({ id }: RoadmapDetailProps) {
+  const router = useRouter();
   const [isLiked, setIsLiked] = useState(false);
   const item = MOCK_COMMUNITY_DATA.find((i) => i.id === id);
 
@@ -63,14 +66,17 @@ export function RoadmapDetail({ id }: RoadmapDetailProps) {
               <Button
                 variant="default"
                 className="bg-primary hover:bg-primary/90 h-[32px] rounded-[6px] px-[12px] py-[6px] text-[14px] font-bold text-white"
+                onClick={() => router.push(`/viewer/${id}`)}
               >
-                로드맵 보기
+                {COMMUNITY_MESSAGES.VIEW_ROADMAP}
               </Button>
               <Button
                 variant="outline"
                 className="border-border bg-background text-foreground h-[32px] items-center gap-[8px] rounded-[6px] px-[12px] py-[6px] text-[14px] font-bold hover:bg-slate-50"
+                onClick={() => window.alert(COMMUNITY_MESSAGES.LOGIN_REQUIRED)}
               >
-                <FilePlus2 className="h-4 w-4" />내 로드맵에 추가
+                <FilePlus2 className="h-4 w-4" />
+                {COMMUNITY_MESSAGES.ADD_TO_MY_ROADMAPS}
               </Button>
             </div>
           </div>

--- a/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/MyRoadmapsToolbar.test.tsx
+++ b/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/MyRoadmapsToolbar.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'jotai';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
 
 import { MyRoadmapsToolbar } from './index';
 

--- a/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/index.tsx
+++ b/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/index.tsx
@@ -2,7 +2,11 @@
 
 import { useRef, useState } from 'react';
 
+import { useRouter } from 'next/navigation';
+
+import { useSetAtom } from 'jotai';
 import { ListFilter, Plus, Search } from 'lucide-react';
+import { nanoid } from 'nanoid';
 
 import {
   Breadcrumb,
@@ -23,11 +27,16 @@ import { Input } from '@/components/ui/input';
 import { useClickOutside } from '@/hooks/use-click-outside';
 import { cn } from '@/lib/utils';
 
+import { myRoadmapItemsAtom } from '../../../stores/my-roadmaps.atoms';
 import { AddDirectoryModal } from '../AddDirectoryModal';
 import { AddRoadmapModal } from '../AddRoadmapModal';
 import { MyRoadmapsFilter } from '../MyRoadmapsFilter';
 
+import type { RoadmapData } from '../../../types/my-roadmaps.types';
+
 export function MyRoadmapsToolbar() {
+  const router = useRouter();
+  const setItems = useSetAtom(myRoadmapItemsAtom);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isRoadmapModalOpen, setIsRoadmapModalOpen] = useState(false);
   const [isDirectoryModalOpen, setIsDirectoryModalOpen] = useState(false);
@@ -35,12 +44,30 @@ export function MyRoadmapsToolbar() {
 
   useClickOutside(filterRef, () => setIsFilterOpen(false));
 
-  const handleAddRoadmap = (_name: string, _locationId?: string | null) => {
-    // TODO: Implement actual roadmap creation logic
+  const handleAddRoadmap = (name: string, _locationId?: string | null) => {
+    const id = nanoid();
+    const newItem: RoadmapData = {
+      id,
+      title: name,
+      type: 'Roadmap',
+      updatedAt: new Date().toISOString(),
+      category: 'my-roadmap',
+    };
+    setItems((prev) => [newItem, ...prev]);
+    router.push(`/editor/${id}`);
   };
 
-  const handleAddDirectory = (_name: string) => {
-    // TODO: Implement actual directory creation logic
+  const handleAddDirectory = (name: string) => {
+    const id = nanoid();
+    const newItem: RoadmapData = {
+      id,
+      title: name,
+      type: 'Directory',
+      fileCount: 0,
+      updatedAt: new Date().toISOString(),
+      category: 'my-roadmap',
+    };
+    setItems((prev) => [newItem, ...prev]);
   };
 
   return (

--- a/src/features/my-roadmaps/components/molecules/index.ts
+++ b/src/features/my-roadmaps/components/molecules/index.ts
@@ -1,1 +1,5 @@
+export { AddDirectoryModal } from './AddDirectoryModal';
+export { AddRoadmapModal } from './AddRoadmapModal';
+export { MyRoadmapsFilter } from './MyRoadmapsFilter';
 export { MyRoadmapsToolbar } from './MyRoadmapsToolbar';
+export { SelectLocationModal } from './SelectLocationModal';

--- a/src/features/my-roadmaps/components/organisms/MyRoadmapsSidebar/MyRoadmapsSidebar.test.tsx
+++ b/src/features/my-roadmaps/components/organisms/MyRoadmapsSidebar/MyRoadmapsSidebar.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'jotai';
+import { describe, expect, it } from 'vitest';
+
+import { MyRoadmapsSidebar } from './index';
+
+const renderWithProvider = (ui: React.ReactElement) => {
+  return render(<Provider>{ui}</Provider>);
+};
+
+describe('MyRoadmapsSidebar', () => {
+  it('renders all sidebar categories', () => {
+    renderWithProvider(<MyRoadmapsSidebar />);
+    expect(screen.getByText('최근')).toBeInTheDocument();
+    expect(screen.getByText('커뮤니티')).toBeInTheDocument();
+    expect(screen.getByText('내 로드맵')).toBeInTheDocument();
+    expect(screen.getByText('공유된 로드맵')).toBeInTheDocument();
+    expect(screen.getByText('즐겨찾기')).toBeInTheDocument();
+  });
+
+  it('clicking a category changes the active category', async () => {
+    const user = userEvent.setup();
+    renderWithProvider(<MyRoadmapsSidebar />);
+
+    const recentButton = screen.getByText('최근').closest('button')!;
+    await user.click(recentButton);
+    expect(recentButton).toHaveClass('bg-[#E5E7EB]');
+
+    const myRoadmapButton = screen.getByText('내 로드맵').closest('button')!;
+    expect(myRoadmapButton).not.toHaveClass('bg-[#E5E7EB]');
+  });
+});

--- a/src/features/my-roadmaps/components/templates/MyRoadmapsLayout/MyRoadmapsLayout.test.tsx
+++ b/src/features/my-roadmaps/components/templates/MyRoadmapsLayout/MyRoadmapsLayout.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'jotai';
+import { describe, expect, it } from 'vitest';
+
+import { MyRoadmapsLayout } from './index';
+
+const renderWithProvider = (ui: React.ReactElement) => {
+  return render(<Provider>{ui}</Provider>);
+};
+
+describe('MyRoadmapsLayout', () => {
+  it('renders children', () => {
+    renderWithProvider(
+      <MyRoadmapsLayout>
+        <div>child content</div>
+      </MyRoadmapsLayout>,
+    );
+    expect(screen.getByText('child content')).toBeInTheDocument();
+  });
+
+  it('renders sidebar', () => {
+    renderWithProvider(
+      <MyRoadmapsLayout>
+        <div>child</div>
+      </MyRoadmapsLayout>,
+    );
+    expect(screen.getByText('내 로드맵')).toBeInTheDocument();
+  });
+});

--- a/src/features/my-roadmaps/components/templates/MyRoadmapsLayout/index.tsx
+++ b/src/features/my-roadmaps/components/templates/MyRoadmapsLayout/index.tsx
@@ -1,4 +1,4 @@
-import { MyRoadmapsSidebar } from '../organisms/MyRoadmapsSidebar';
+import { MyRoadmapsSidebar } from '../../organisms/MyRoadmapsSidebar';
 
 interface MyRoadmapsLayoutProps {
   children: React.ReactNode;

--- a/src/features/my-roadmaps/components/templates/index.ts
+++ b/src/features/my-roadmaps/components/templates/index.ts
@@ -1,0 +1,1 @@
+export { MyRoadmapsLayout } from './MyRoadmapsLayout';

--- a/src/features/my-roadmaps/constants/my-roadmaps.mock.ts
+++ b/src/features/my-roadmaps/constants/my-roadmaps.mock.ts
@@ -1,0 +1,47 @@
+import type { RoadmapData } from '../types/my-roadmaps.types';
+
+export const MOCK_MY_ROADMAPS: RoadmapData[] = [
+  {
+    id: '1',
+    title: 'Frontend Developer Roadmap',
+    author: '홍길동',
+    type: 'Roadmap',
+    updatedAt: '2024-02-06T10:00:00Z',
+    isFavorite: true,
+    category: 'my-roadmap',
+  },
+  {
+    id: '2',
+    title: 'Directory Name',
+    type: 'Directory',
+    fileCount: 67,
+    updatedAt: '2024-02-05T10:00:00Z',
+    category: 'my-roadmap',
+  },
+  {
+    id: '3',
+    title: 'React Mastery',
+    author: '홍길동',
+    type: 'Roadmap',
+    updatedAt: '2024-02-04T10:00:00Z',
+    isShared: true,
+    category: 'my-roadmap',
+  },
+  {
+    id: '4',
+    title: 'Backend Essentials',
+    author: '홍길동',
+    type: 'Roadmap',
+    updatedAt: '2024-02-03T10:00:00Z',
+    category: 'community',
+  },
+  {
+    id: '5',
+    title: 'DevOps Guide',
+    author: '홍길동',
+    type: 'Roadmap',
+    updatedAt: '2024-02-02T10:00:00Z',
+    isFavorite: true,
+    category: 'community',
+  },
+];

--- a/src/features/my-roadmaps/index.ts
+++ b/src/features/my-roadmaps/index.ts
@@ -1,0 +1,24 @@
+// Components
+export { RoadmapCard } from './components/atoms';
+export { MyRoadmapsToolbar } from './components/molecules';
+export {
+  AddDirectoryModal,
+  AddRoadmapModal,
+  MyRoadmapsFilter,
+  SelectLocationModal,
+} from './components/molecules';
+export { MyRoadmapsHeader, MyRoadmapsSidebar, MyRoadmapsGrid } from './components/organisms';
+export { MyRoadmapsLayout } from './components/templates';
+
+// Stores
+export {
+  sortOrderAtom,
+  sortByAtom,
+  filterCategoryAtom,
+  sidebarCategoryAtom,
+  myRoadmapItemsAtom,
+} from './stores/my-roadmaps.atoms';
+export type { SidebarCategory } from './stores/my-roadmaps.atoms';
+
+// Types
+export type { RoadmapData } from './types/my-roadmaps.types';

--- a/src/features/my-roadmaps/stores/my-roadmaps.atoms.test.ts
+++ b/src/features/my-roadmaps/stores/my-roadmaps.atoms.test.ts
@@ -1,0 +1,45 @@
+import { createStore } from 'jotai';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { MOCK_MY_ROADMAPS } from '../constants/my-roadmaps.mock';
+import type { RoadmapData } from '../types/my-roadmaps.types';
+import { myRoadmapItemsAtom } from './my-roadmaps.atoms';
+
+describe('myRoadmapItemsAtom', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('initial value is MOCK_MY_ROADMAPS', () => {
+    const store = createStore();
+    expect(store.get(myRoadmapItemsAtom)).toEqual(MOCK_MY_ROADMAPS);
+  });
+
+  it('can add items', () => {
+    const store = createStore();
+    const newItem: RoadmapData = {
+      id: '99',
+      title: 'New Roadmap',
+      author: '테스트',
+      type: 'Roadmap',
+      updatedAt: '2024-03-01T00:00:00Z',
+      category: 'my-roadmap',
+    };
+
+    store.set(myRoadmapItemsAtom, [...store.get(myRoadmapItemsAtom), newItem]);
+
+    const items = store.get(myRoadmapItemsAtom);
+    expect(items).toHaveLength(MOCK_MY_ROADMAPS.length + 1);
+    expect(items.find((i) => i.id === '99')).toEqual(newItem);
+  });
+
+  it('persists to localStorage', () => {
+    const store = createStore();
+    const updated = store.get(myRoadmapItemsAtom).slice(0, 2);
+    store.set(myRoadmapItemsAtom, updated);
+
+    const stored = localStorage.getItem('jagalchi-my-roadmaps');
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toEqual(updated);
+  });
+});

--- a/src/features/my-roadmaps/stores/my-roadmaps.atoms.ts
+++ b/src/features/my-roadmaps/stores/my-roadmaps.atoms.ts
@@ -1,6 +1,11 @@
 import { atom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
 
 import type { SortOrder, SortBy, FilterCategory } from '@/types/sort.types';
+
+import { MOCK_MY_ROADMAPS } from '../constants/my-roadmaps.mock';
+
+import type { RoadmapData } from '../types/my-roadmaps.types';
 
 export type SidebarCategory = 'recent' | 'community' | 'my-roadmap' | 'shared' | 'favorites';
 
@@ -8,3 +13,8 @@ export const sortOrderAtom = atom<SortOrder>('desc');
 export const sortByAtom = atom<SortBy>('recent');
 export const filterCategoryAtom = atom<FilterCategory>('all');
 export const sidebarCategoryAtom = atom<SidebarCategory>('my-roadmap');
+
+export const myRoadmapItemsAtom = atomWithStorage<RoadmapData[]>(
+  'jagalchi-my-roadmaps',
+  MOCK_MY_ROADMAPS,
+);

--- a/src/features/profile/components/molecules/ProfileCustomBoxArea/ProfileCustomBoxArea.test.tsx
+++ b/src/features/profile/components/molecules/ProfileCustomBoxArea/ProfileCustomBoxArea.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { Provider, WritableAtom } from 'jotai';
+import { useHydrateAtoms } from 'jotai/utils';
+import { describe, it, expect } from 'vitest';
+
+import { profileModeAtom } from '../../../stores/profile-atoms';
+
+import { ProfileCustomBoxArea } from './index';
+
+interface WrapperProps {
+  initialValues: (readonly [WritableAtom<unknown, any[], any>, unknown])[];
+  children: React.ReactNode;
+}
+
+const HydrateAtoms = ({ initialValues, children }: WrapperProps) => {
+  useHydrateAtoms(initialValues);
+  return children;
+};
+
+const TestProvider = ({ initialValues, children }: WrapperProps) => (
+  <Provider>
+    <HydrateAtoms initialValues={initialValues}>{children}</HydrateAtoms>
+  </Provider>
+);
+
+describe('ProfileCustomBoxArea', () => {
+  it('renders organization value in show mode', () => {
+    render(
+      <TestProvider initialValues={[[profileModeAtom, 'show']]}>
+        <ProfileCustomBoxArea />
+      </TestProvider>,
+    );
+    expect(screen.getByText('부산소프트웨어마이스터고등학교')).toBeInTheDocument();
+  });
+
+  it('renders organization input in edit mode', () => {
+    render(
+      <TestProvider initialValues={[[profileModeAtom, 'edit']]}>
+        <ProfileCustomBoxArea />
+      </TestProvider>,
+    );
+    expect(screen.getByPlaceholderText('소속을 입력해주세요')).toBeInTheDocument();
+  });
+
+  it('renders link add button in edit mode', () => {
+    render(
+      <TestProvider initialValues={[[profileModeAtom, 'edit']]}>
+        <ProfileCustomBoxArea />
+      </TestProvider>,
+    );
+    expect(screen.getByRole('button', { name: /링크추가/ })).toBeInTheDocument();
+  });
+
+  it('renders initial link in show mode', () => {
+    render(
+      <TestProvider initialValues={[[profileModeAtom, 'show']]}>
+        <ProfileCustomBoxArea />
+      </TestProvider>,
+    );
+    expect(screen.getByText('포트폴리오')).toBeInTheDocument();
+  });
+});

--- a/src/features/profile/components/molecules/ProfileHeader/ProfileHeader.test.tsx
+++ b/src/features/profile/components/molecules/ProfileHeader/ProfileHeader.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+import { Provider, WritableAtom } from 'jotai';
+import { useHydrateAtoms } from 'jotai/utils';
+import { describe, it, expect } from 'vitest';
+
+import { profileImageAtom, profileModeAtom } from '../../../stores/profile-atoms';
+
+import { ProfileHeader } from './index';
+
+interface WrapperProps {
+  initialValues: (readonly [WritableAtom<unknown, any[], any>, unknown])[];
+  children: React.ReactNode;
+}
+
+const HydrateAtoms = ({ initialValues, children }: WrapperProps) => {
+  useHydrateAtoms(initialValues);
+  return children;
+};
+
+const TestProvider = ({ initialValues, children }: WrapperProps) => (
+  <Provider>
+    <HydrateAtoms initialValues={initialValues}>{children}</HydrateAtoms>
+  </Provider>
+);
+
+describe('ProfileHeader', () => {
+  const defaultProps = {
+    userName: 'Jane Doe',
+    email: 'jane@example.com',
+    followerCount: 42,
+    followingCount: 10,
+  };
+
+  it('renders user name and email in show mode', () => {
+    render(
+      <TestProvider
+        initialValues={[
+          [profileModeAtom, 'show'],
+          [profileImageAtom, '/profile.svg'],
+        ]}
+      >
+        <ProfileHeader {...defaultProps} />
+      </TestProvider>,
+    );
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+  });
+
+  it('renders follower and following counts', () => {
+    render(
+      <TestProvider
+        initialValues={[
+          [profileModeAtom, 'show'],
+          [profileImageAtom, '/profile.svg'],
+        ]}
+      >
+        <ProfileHeader {...defaultProps} />
+      </TestProvider>,
+    );
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+
+  it('defaults follower and following counts to 0 when not provided', () => {
+    render(
+      <TestProvider
+        initialValues={[
+          [profileModeAtom, 'show'],
+          [profileImageAtom, '/profile.svg'],
+        ]}
+      >
+        <ProfileHeader userName="Test" email="test@example.com" />
+      </TestProvider>,
+    );
+    expect(screen.getAllByText('0')).toHaveLength(2);
+  });
+
+  it('renders avatar fallback initial when image cannot load', () => {
+    render(
+      <TestProvider
+        initialValues={[
+          [profileModeAtom, 'show'],
+          [profileImageAtom, '/profile.svg'],
+        ]}
+      >
+        <ProfileHeader {...defaultProps} />
+      </TestProvider>,
+    );
+    // jsdom does not load images so the AvatarFallback initial is shown
+    expect(screen.getByText('J')).toBeInTheDocument();
+  });
+
+  it('shows file input for image upload in edit mode', () => {
+    const { container } = render(
+      <TestProvider
+        initialValues={[
+          [profileModeAtom, 'edit'],
+          [profileImageAtom, '/profile.svg'],
+        ]}
+      >
+        <ProfileHeader {...defaultProps} />
+      </TestProvider>,
+    );
+    // In edit mode ProfilePicture renders a hidden file input for upload
+    expect(container.querySelector('input[type="file"]')).toBeInTheDocument();
+  });
+});

--- a/src/features/profile/components/molecules/ProfileInfoForm/index.tsx
+++ b/src/features/profile/components/molecules/ProfileInfoForm/index.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { useAtom } from 'jotai';
 import { useForm } from 'react-hook-form';
 
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
 import { profileModeAtom } from '../../../stores/profile-atoms';
@@ -111,7 +112,20 @@ export function ProfileInfoForm({
           </div>
 
           <div className="flex flex-row gap-2">
-            <ProfileEditButton variant="edit" onClick={toggleMode} />
+            <Button
+              type="button"
+              variant="outline"
+              className="font-semibold"
+              onClick={() => {
+                reset({ name, email });
+                setMode('show');
+              }}
+            >
+              취소
+            </Button>
+            <Button type="button" className="font-semibold" onClick={() => setMode('show')}>
+              저장
+            </Button>
           </div>
         </div>
       )}

--- a/src/features/profile/components/molecules/ProfileStreak/ProfileStreak.test.tsx
+++ b/src/features/profile/components/molecules/ProfileStreak/ProfileStreak.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { ProfileStreak } from './index';
+
+describe('ProfileStreak', () => {
+  it('renders the streak card', () => {
+    const { container } = render(<ProfileStreak />);
+    expect(container.querySelector('div')).toBeInTheDocument();
+  });
+
+  it('displays streak text with 일 연속 스트릭', () => {
+    render(<ProfileStreak />);
+    expect(screen.getByText(/일 연속 스트릭/)).toBeInTheDocument();
+  });
+
+  it('renders contribution cells', () => {
+    const { container } = render(<ProfileStreak />);
+    // The contribution graph renders many divs for each day
+    const cells = container.querySelectorAll('div[title]');
+    expect(cells.length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/profile/components/organisms/ProfileThirdBox/ProfileThirdBox.test.tsx
+++ b/src/features/profile/components/organisms/ProfileThirdBox/ProfileThirdBox.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { PROFILE_MESSAGES } from '@/constants/messages';
+
+import { ProfileThirdBox } from './index';
+
+describe('ProfileThirdBox', () => {
+  it('renders completed roadmap section', () => {
+    render(<ProfileThirdBox />);
+    expect(screen.getByText(PROFILE_MESSAGES.COMPLETED_ROADMAP)).toBeInTheDocument();
+  });
+
+  it('renders in-progress roadmap section', () => {
+    render(<ProfileThirdBox />);
+    expect(screen.getByText(PROFILE_MESSAGES.IN_PROGRESS_ROADMAP)).toBeInTheDocument();
+  });
+
+  it('renders roadmap items', () => {
+    render(<ProfileThirdBox />);
+    const items = screen.getAllByText('유저 님의 프론트엔드 로드맵');
+    expect(items.length).toBeGreaterThan(0);
+  });
+});

--- a/src/features/profile/components/templates/Profile/Profile.test.tsx
+++ b/src/features/profile/components/templates/Profile/Profile.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { Provider, WritableAtom } from 'jotai';
+import { useHydrateAtoms } from 'jotai/utils';
+import { describe, it, expect } from 'vitest';
+
+import { PROFILE_MESSAGES } from '@/constants/messages';
+
+import { profileImageAtom, profileModeAtom } from '../../../stores/profile-atoms';
+
+import { Profile } from './index';
+
+interface WrapperProps {
+  initialValues: (readonly [WritableAtom<unknown, any[], any>, unknown])[];
+  children: React.ReactNode;
+}
+
+const HydrateAtoms = ({ initialValues, children }: WrapperProps) => {
+  useHydrateAtoms(initialValues);
+  return children;
+};
+
+const TestProvider = ({ initialValues, children }: WrapperProps) => (
+  <Provider>
+    <HydrateAtoms initialValues={initialValues}>{children}</HydrateAtoms>
+  </Provider>
+);
+
+const defaultAtoms: (readonly [WritableAtom<unknown, any[], any>, unknown])[] = [
+  [profileModeAtom, 'show'],
+  [profileImageAtom, '/profile.svg'],
+];
+
+describe('Profile', () => {
+  it('renders the user name', () => {
+    render(
+      <TestProvider initialValues={defaultAtoms}>
+        <Profile />
+      </TestProvider>,
+    );
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+  });
+
+  it('renders the user email', () => {
+    render(
+      <TestProvider initialValues={defaultAtoms}>
+        <Profile />
+      </TestProvider>,
+    );
+    expect(screen.getByText('john.doe@example.com')).toBeInTheDocument();
+  });
+
+  it('renders the bio section', () => {
+    render(
+      <TestProvider initialValues={defaultAtoms}>
+        <Profile />
+      </TestProvider>,
+    );
+    expect(screen.getByText(PROFILE_MESSAGES.BIO_TITLE)).toBeInTheDocument();
+  });
+
+  it('renders the streak section', () => {
+    render(
+      <TestProvider initialValues={defaultAtoms}>
+        <Profile />
+      </TestProvider>,
+    );
+    expect(screen.getByText(/일 연속 스트릭/)).toBeInTheDocument();
+  });
+
+  it('renders completed and in-progress roadmap sections', () => {
+    render(
+      <TestProvider initialValues={defaultAtoms}>
+        <Profile />
+      </TestProvider>,
+    );
+    expect(screen.getByText(PROFILE_MESSAGES.COMPLETED_ROADMAP)).toBeInTheDocument();
+    expect(screen.getByText(PROFILE_MESSAGES.IN_PROGRESS_ROADMAP)).toBeInTheDocument();
+  });
+
+  it('renders made roadmap section', () => {
+    render(
+      <TestProvider initialValues={defaultAtoms}>
+        <Profile />
+      </TestProvider>,
+    );
+    expect(screen.getByText(PROFILE_MESSAGES.MADE_ROADMAP)).toBeInTheDocument();
+  });
+});

--- a/src/features/roadmap-viewer/components/CardListMode/CardListMode.test.tsx
+++ b/src/features/roadmap-viewer/components/CardListMode/CardListMode.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { Provider } from 'jotai';
+import { useHydrateAtoms } from 'jotai/utils';
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReactFlow: () => ({ fitView: vi.fn(), zoomIn: vi.fn(), zoomOut: vi.fn(), getZoom: () => 1 }),
+  useNodesState: () => [[], vi.fn(), vi.fn()],
+  useEdgesState: () => [[], vi.fn(), vi.fn()],
+  ReactFlow: () => <div data-testid="react-flow" />,
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+}));
+
+import type { RoadmapNode } from '@/types/roadmap.types';
+import { viewerRoadmapAtom } from '../../stores/viewer-atoms';
+import { CardListMode } from './index';
+
+function HydrateAtoms({
+  initialValues,
+  children,
+}: {
+  initialValues: [unknown, unknown][];
+  children: React.ReactNode;
+}) {
+  useHydrateAtoms(initialValues as Parameters<typeof useHydrateAtoms>[0]);
+  return <>{children}</>;
+}
+
+function TestWrapper({
+  initialValues = [],
+  children,
+}: {
+  initialValues?: [unknown, unknown][];
+  children: React.ReactNode;
+}) {
+  return (
+    <Provider>
+      <HydrateAtoms initialValues={initialValues}>{children}</HydrateAtoms>
+    </Provider>
+  );
+}
+
+const makeNode = (id: string, label: string, description = ''): RoadmapNode =>
+  ({
+    id,
+    type: 'jagalchi-node',
+    position: { x: 0, y: 0 },
+    data: { label, description, resources: [], variant: 'white', isLocked: false },
+  }) as RoadmapNode;
+
+const mockRoadmap = {
+  id: 'r1',
+  title: 'Test Roadmap',
+  nodes: [makeNode('n1', 'First Node', 'desc one'), makeNode('n2', 'Second Node')],
+  edges: [],
+  isPublic: true,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+describe('CardListMode', () => {
+  it('shows empty state when there are no nodes', () => {
+    const emptyRoadmap = { ...mockRoadmap, nodes: [] };
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, emptyRoadmap]]}>
+        <CardListMode />
+      </TestWrapper>,
+    );
+    expect(screen.getByText('노드가 없습니다')).toBeTruthy();
+  });
+
+  it('renders a card for each jagalchi-node', () => {
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, mockRoadmap]]}>
+        <CardListMode />
+      </TestWrapper>,
+    );
+    expect(screen.getByText('First Node')).toBeTruthy();
+    expect(screen.getByText('Second Node')).toBeTruthy();
+  });
+
+  it('renders sequential index numbers for cards', () => {
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, mockRoadmap]]}>
+        <CardListMode />
+      </TestWrapper>,
+    );
+    expect(screen.getByText('1')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+  });
+
+  it('renders description when present', () => {
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, mockRoadmap]]}>
+        <CardListMode />
+      </TestWrapper>,
+    );
+    expect(screen.getByText('desc one')).toBeTruthy();
+  });
+
+  it('renders 보기 buttons for each card', async () => {
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, mockRoadmap]]}>
+        <CardListMode />
+      </TestWrapper>,
+    );
+    const viewButtons = screen.getAllByText('보기');
+    expect(viewButtons).toHaveLength(2);
+  });
+
+  it('does not render non-jagalchi-node type nodes', () => {
+    const sectionNode: RoadmapNode = {
+      id: 's1',
+      type: 'jagalchi-section',
+      position: { x: 0, y: 0 },
+      data: { title: 'Section', variant: 'white', isLocked: false },
+    } as RoadmapNode;
+    const roadmapWithSection = {
+      ...mockRoadmap,
+      nodes: [makeNode('n1', 'Only Node'), sectionNode],
+    };
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, roadmapWithSection]]}>
+        <CardListMode />
+      </TestWrapper>,
+    );
+    const viewButtons = screen.getAllByText('보기');
+    expect(viewButtons).toHaveLength(1);
+  });
+});

--- a/src/features/roadmap-viewer/components/HeaderExportMenu/HeaderExportMenu.test.tsx
+++ b/src/features/roadmap-viewer/components/HeaderExportMenu/HeaderExportMenu.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReactFlow: () => ({ fitView: vi.fn(), zoomIn: vi.fn(), zoomOut: vi.fn(), getZoom: () => 1 }),
+  useNodesState: () => [[], vi.fn(), vi.fn()],
+  useEdgesState: () => [[], vi.fn(), vi.fn()],
+  ReactFlow: () => <div data-testid="react-flow" />,
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+}));
+
+import { VIEWER_MESSAGES } from '@/constants/messages';
+import { HeaderExportMenu } from './index';
+
+describe('HeaderExportMenu', () => {
+  it('renders the export trigger button', () => {
+    render(<HeaderExportMenu />);
+    expect(screen.getByText(VIEWER_MESSAGES.MENU_EXPORT)).toBeTruthy();
+  });
+
+  it('shows export format options after clicking the trigger', async () => {
+    render(<HeaderExportMenu />);
+    await userEvent.click(screen.getByText(VIEWER_MESSAGES.MENU_EXPORT));
+    expect(screen.getByText(VIEWER_MESSAGES.EXPORT_MARKDOWN)).toBeTruthy();
+    expect(screen.getByText(VIEWER_MESSAGES.EXPORT_PDF)).toBeTruthy();
+    expect(screen.getByText(VIEWER_MESSAGES.EXPORT_JSON)).toBeTruthy();
+  });
+});

--- a/src/features/roadmap-viewer/components/HeaderMenu/HeaderMenu.test.tsx
+++ b/src/features/roadmap-viewer/components/HeaderMenu/HeaderMenu.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReactFlow: () => ({ fitView: vi.fn(), zoomIn: vi.fn(), zoomOut: vi.fn(), getZoom: () => 1 }),
+  useNodesState: () => [[], vi.fn(), vi.fn()],
+  useEdgesState: () => [[], vi.fn(), vi.fn()],
+  ReactFlow: () => <div data-testid="react-flow" />,
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+}));
+
+import { VIEWER_MESSAGES } from '@/constants/messages';
+import { HeaderMenu } from './index';
+
+describe('HeaderMenu', () => {
+  it('renders the menu trigger button', () => {
+    render(<HeaderMenu />);
+    // The trigger button renders a Settings icon inside a Button
+    const button = document.querySelector('button');
+    expect(button).toBeTruthy();
+  });
+
+  it('shows menu items after clicking the trigger', async () => {
+    render(<HeaderMenu />);
+    const trigger = document.querySelector('button')!;
+    await userEvent.click(trigger);
+    expect(screen.getByText(VIEWER_MESSAGES.MENU_STATISTICS)).toBeTruthy();
+    expect(screen.getByText(VIEWER_MESSAGES.MENU_DARK_MODE)).toBeTruthy();
+    expect(screen.getByText(VIEWER_MESSAGES.MENU_EXPORT)).toBeTruthy();
+    expect(screen.getByText(VIEWER_MESSAGES.MENU_SAVE_IMAGE)).toBeTruthy();
+  });
+});

--- a/src/features/roadmap-viewer/components/HeaderSaveAsImageMenu/HeaderSaveAsImageMenu.test.tsx
+++ b/src/features/roadmap-viewer/components/HeaderSaveAsImageMenu/HeaderSaveAsImageMenu.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReactFlow: () => ({ fitView: vi.fn(), zoomIn: vi.fn(), zoomOut: vi.fn(), getZoom: () => 1 }),
+  useNodesState: () => [[], vi.fn(), vi.fn()],
+  useEdgesState: () => [[], vi.fn(), vi.fn()],
+  ReactFlow: () => <div data-testid="react-flow" />,
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+}));
+
+import { VIEWER_MESSAGES } from '@/constants/messages';
+import { HeaderSaveAsImageMenu } from './index';
+
+describe('HeaderSaveAsImageMenu', () => {
+  it('renders the save image trigger button', () => {
+    render(<HeaderSaveAsImageMenu />);
+    expect(screen.getByText(VIEWER_MESSAGES.MENU_SAVE_IMAGE)).toBeTruthy();
+  });
+
+  it('shows image format options after clicking the trigger', async () => {
+    render(<HeaderSaveAsImageMenu />);
+    await userEvent.click(screen.getByText(VIEWER_MESSAGES.MENU_SAVE_IMAGE));
+    expect(screen.getByText(VIEWER_MESSAGES.IMAGE_PNG)).toBeTruthy();
+    expect(screen.getByText(VIEWER_MESSAGES.IMAGE_JPG)).toBeTruthy();
+    expect(screen.getByText(VIEWER_MESSAGES.IMAGE_SVG)).toBeTruthy();
+  });
+});

--- a/src/features/roadmap-viewer/components/RoadmapHeader/RoadmapHeader.test.tsx
+++ b/src/features/roadmap-viewer/components/RoadmapHeader/RoadmapHeader.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReactFlow: () => ({ fitView: vi.fn(), zoomIn: vi.fn(), zoomOut: vi.fn(), getZoom: () => 1 }),
+  useNodesState: () => [[], vi.fn(), vi.fn()],
+  useEdgesState: () => [[], vi.fn(), vi.fn()],
+  ReactFlow: () => <div data-testid="react-flow" />,
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+}));
+
+import { RoadmapHeader } from './index';
+
+describe('RoadmapHeader', () => {
+  it('renders the roadmap title', () => {
+    render(<RoadmapHeader roadmapTitle="My Roadmap" />);
+    expect(screen.getByText('My Roadmap')).toBeTruthy();
+  });
+
+  it('renders default roadmapMeta when not provided', () => {
+    render(<RoadmapHeader roadmapTitle="Test" />);
+    expect(screen.getByText('Draft • 공개 상태')).toBeTruthy();
+  });
+
+  it('renders custom roadmapMeta when provided', () => {
+    render(<RoadmapHeader roadmapTitle="Test" roadmapMeta="공개" />);
+    expect(screen.getByText('공개')).toBeTruthy();
+  });
+
+  it('calls onInfo when 상세 보기 button is clicked', async () => {
+    const onInfo = vi.fn();
+    render(<RoadmapHeader roadmapTitle="Test" onInfo={onInfo} />);
+    await userEvent.click(screen.getByText('상세 보기'));
+    expect(onInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onShare when 공유 button is clicked', async () => {
+    const onShare = vi.fn();
+    render(<RoadmapHeader roadmapTitle="Test" onShare={onShare} />);
+    await userEvent.click(screen.getByText('공유'));
+    expect(onShare).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onExport when 옵션 button is clicked', async () => {
+    const onExport = vi.fn();
+    render(<RoadmapHeader roadmapTitle="Test" onExport={onExport} />);
+    await userEvent.click(screen.getByText('옵션'));
+    expect(onExport).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/roadmap-viewer/components/RoadmapViewer/index.tsx
+++ b/src/features/roadmap-viewer/components/RoadmapViewer/index.tsx
@@ -5,10 +5,15 @@ import { useAtom, useAtomValue } from 'jotai';
 import { LayoutGrid, Map } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import { VIEWER_MESSAGES } from '@/constants/messages';
+import { MY_ROADMAPS_MESSAGES, VIEWER_MESSAGES } from '@/constants/messages';
 
 import { useViewerRoadmapLoader } from '../../hooks/use-viewer-roadmap-loader';
-import { viewerErrorAtom, viewerLayoutAtom, viewerLoadingAtom } from '../../stores/viewer-atoms';
+import {
+  viewerErrorAtom,
+  viewerLayoutAtom,
+  viewerLoadingAtom,
+  viewerSidebarOpenAtom,
+} from '../../stores/viewer-atoms';
 import { CardListMode } from '../CardListMode';
 import { HeaderExportMenu } from '../HeaderExportMenu';
 import { HeaderMenu } from '../HeaderMenu';
@@ -28,6 +33,20 @@ function ViewerContent({ roadmapId }: RoadmapViewerProps) {
   const isLoading = useAtomValue(viewerLoadingAtom);
   const error = useAtomValue(viewerErrorAtom);
   const [layout, setLayout] = useAtom(viewerLayoutAtom);
+  const [isSidebarOpen, setIsSidebarOpen] = useAtom(viewerSidebarOpenAtom);
+
+  const handleToggleSidebar = () => {
+    setIsSidebarOpen((prev) => !prev);
+  };
+
+  const handleShare = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      window.alert(MY_ROADMAPS_MESSAGES.SHARE_COPIED);
+    } catch {
+      window.alert(MY_ROADMAPS_MESSAGES.SHARE_FAILED);
+    }
+  };
 
   if (isLoading) {
     return (
@@ -47,7 +66,11 @@ function ViewerContent({ roadmapId }: RoadmapViewerProps) {
 
   return (
     <div className="bg-background min-h-screen">
-      <RoadmapHeader roadmapTitle={`Roadmap · ${roadmapId}`} />
+      <RoadmapHeader
+        roadmapTitle={`Roadmap · ${roadmapId}`}
+        onInfo={handleToggleSidebar}
+        onShare={handleShare}
+      />
 
       <div className="mx-auto flex w-full max-w-[2011px] gap-4 px-4 py-4">
         <div className="relative flex-1">
@@ -80,7 +103,7 @@ function ViewerContent({ roadmapId }: RoadmapViewerProps) {
           {layout === 'cards' ? <CardListMode /> : <ViewerCanvas />}
         </div>
 
-        <ViewerSidebar />
+        <ViewerSidebar isOpen={isSidebarOpen} onClose={() => setIsSidebarOpen(false)} />
       </div>
 
       {layout === 'page' && <ViewerZoomControls />}

--- a/src/features/roadmap-viewer/components/ViewerSidebar/ViewerSidebar.test.tsx
+++ b/src/features/roadmap-viewer/components/ViewerSidebar/ViewerSidebar.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'jotai';
+import { useHydrateAtoms } from 'jotai/utils';
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReactFlow: () => ({ fitView: vi.fn(), zoomIn: vi.fn(), zoomOut: vi.fn(), getZoom: () => 1 }),
+  useNodesState: () => [[], vi.fn(), vi.fn()],
+  useEdgesState: () => [[], vi.fn(), vi.fn()],
+  ReactFlow: () => <div data-testid="react-flow" />,
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+}));
+
+import { VIEWER_MESSAGES } from '@/constants/messages';
+import type { RoadmapNode } from '@/types/roadmap.types';
+import { viewerRoadmapAtom } from '../../stores/viewer-atoms';
+import { ViewerSidebar } from './index';
+
+function HydrateAtoms({
+  initialValues,
+  children,
+}: {
+  initialValues: [unknown, unknown][];
+  children: React.ReactNode;
+}) {
+  useHydrateAtoms(initialValues as Parameters<typeof useHydrateAtoms>[0]);
+  return <>{children}</>;
+}
+
+function TestWrapper({
+  initialValues = [],
+  children,
+}: {
+  initialValues?: [unknown, unknown][];
+  children: React.ReactNode;
+}) {
+  return (
+    <Provider>
+      <HydrateAtoms initialValues={initialValues}>{children}</HydrateAtoms>
+    </Provider>
+  );
+}
+
+const makeNode = (id: string, label: string): RoadmapNode =>
+  ({
+    id,
+    type: 'jagalchi-node',
+    position: { x: 0, y: 0 },
+    data: { label, description: '', resources: [], variant: 'white', isLocked: false },
+  }) as RoadmapNode;
+
+const mockRoadmap = {
+  id: 'r1',
+  title: 'Test Roadmap',
+  nodes: [makeNode('n1', 'Node Alpha'), makeNode('n2', 'Node Beta')],
+  edges: [],
+  isPublic: true,
+  createdAt: '2026-01-01',
+  updatedAt: '2026-01-01',
+};
+
+describe('ViewerSidebar', () => {
+  it('renders sidebar title when isOpen is true', () => {
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, mockRoadmap]]}>
+        <ViewerSidebar isOpen={true} />
+      </TestWrapper>,
+    );
+    expect(screen.getByText(VIEWER_MESSAGES.SIDEBAR_TITLE)).toBeTruthy();
+  });
+
+  it('renders nothing when isOpen is false', () => {
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, mockRoadmap]]}>
+        <ViewerSidebar isOpen={false} />
+      </TestWrapper>,
+    );
+    expect(screen.queryByText(VIEWER_MESSAGES.SIDEBAR_TITLE)).toBeNull();
+  });
+
+  it('calls onClose when close button is clicked', async () => {
+    const onClose = vi.fn();
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, mockRoadmap]]}>
+        <ViewerSidebar isOpen={true} onClose={onClose} />
+      </TestWrapper>,
+    );
+    // The close button has an X icon; find it by its container button near the title
+    const closeButton = document.querySelector('button[class*="rounded"]') as HTMLButtonElement;
+    await userEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows node list from atom state', () => {
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, mockRoadmap]]}>
+        <ViewerSidebar isOpen={true} />
+      </TestWrapper>,
+    );
+    expect(screen.getByText('Node Alpha')).toBeTruthy();
+    expect(screen.getByText('Node Beta')).toBeTruthy();
+  });
+
+  it('shows empty state message when there are no nodes', () => {
+    const emptyRoadmap = { ...mockRoadmap, nodes: [] };
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, emptyRoadmap]]}>
+        <ViewerSidebar isOpen={true} />
+      </TestWrapper>,
+    );
+    expect(screen.getByText(VIEWER_MESSAGES.SIDEBAR_EMPTY)).toBeTruthy();
+  });
+
+  it('shows total count in footer', () => {
+    render(
+      <TestWrapper initialValues={[[viewerRoadmapAtom, mockRoadmap]]}>
+        <ViewerSidebar isOpen={true} />
+      </TestWrapper>,
+    );
+    expect(screen.getByText('총 2개 노드')).toBeTruthy();
+  });
+});

--- a/src/features/roadmap-viewer/components/ZoomButtonGroup/ZoomButtonGroup.test.tsx
+++ b/src/features/roadmap-viewer/components/ZoomButtonGroup/ZoomButtonGroup.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@xyflow/react', () => ({
+  ReactFlowProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useReactFlow: () => ({ fitView: vi.fn(), zoomIn: vi.fn(), zoomOut: vi.fn(), getZoom: () => 1 }),
+  useNodesState: () => [[], vi.fn(), vi.fn()],
+  useEdgesState: () => [[], vi.fn(), vi.fn()],
+  ReactFlow: () => <div data-testid="react-flow" />,
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+}));
+
+import { ZoomButtonGroup } from './index';
+
+describe('ZoomButtonGroup', () => {
+  const defaultProps = {
+    value: 100,
+    onZoomIn: vi.fn(),
+    onZoomOut: vi.fn(),
+    onZoomReset: vi.fn(),
+  };
+
+  it('renders zoom in button', () => {
+    render(<ZoomButtonGroup {...defaultProps} />);
+    expect(screen.getByLabelText('확대')).toBeTruthy();
+  });
+
+  it('renders zoom out button', () => {
+    render(<ZoomButtonGroup {...defaultProps} />);
+    expect(screen.getByLabelText('축소')).toBeTruthy();
+  });
+
+  it('renders reset button with current zoom value', () => {
+    render(<ZoomButtonGroup {...defaultProps} value={150} />);
+    expect(screen.getByLabelText('확대 초기화')).toBeTruthy();
+    expect(screen.getByText('150%')).toBeTruthy();
+  });
+
+  it('calls onZoomIn when 확대 button is clicked', async () => {
+    const onZoomIn = vi.fn();
+    render(<ZoomButtonGroup {...defaultProps} onZoomIn={onZoomIn} />);
+    await userEvent.click(screen.getByLabelText('확대'));
+    expect(onZoomIn).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onZoomOut when 축소 button is clicked', async () => {
+    const onZoomOut = vi.fn();
+    render(<ZoomButtonGroup {...defaultProps} onZoomOut={onZoomOut} />);
+    await userEvent.click(screen.getByLabelText('축소'));
+    expect(onZoomOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onZoomReset when 확대 초기화 button is clicked', async () => {
+    const onZoomReset = vi.fn();
+    render(<ZoomButtonGroup {...defaultProps} onZoomReset={onZoomReset} />);
+    await userEvent.click(screen.getByLabelText('확대 초기화'));
+    expect(onZoomReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/roadmap-viewer/stores/viewer-atoms.ts
+++ b/src/features/roadmap-viewer/stores/viewer-atoms.ts
@@ -32,3 +32,5 @@ export const viewerLayoutAtom = atom<'page' | 'cards'>('page');
 export const viewerLoadingAtom = atom<boolean>(true);
 
 export const viewerErrorAtom = atom<string | null>(null);
+
+export const viewerSidebarOpenAtom = atom<boolean>(true);


### PR DESCRIPTION
## Summary
- 로그인/회원가입 Step1에 GitHub 로그인 버튼 추가
- 로그인/소셜 버튼 사이 Separator 구분선 추가
- AUTH_MESSAGES 에러 메시지 상수 추가

## Changes
- `GitHubAuthButton` 컴포넌트 신규 생성 (dark filled 스타일)
- `LoginForm`: Separator + GitHubAuthButton 추가
- `RegisterStep1Form`: Separator + GitHubAuthButton 추가
- `RegisterForm`: onGitHubRegister 콜백 전달
- `messages.ts`: AUTH_MESSAGES 상수 추가

## Test plan
- [x] GitHubAuthButton 단위 테스트 (4개)
- [x] LoginForm 테스트 업데이트 (GitHub 버튼, Separator 확인)
- [x] 전체 auth 테스트 86개 통과
- [x] `pnpm lint` 에러 0
- [x] `pnpm build` 성공

Closes #138
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub authentication option for login and registration alongside existing Google option
  * Introduced password recovery workflow with email verification and password reset
  * Implemented persistent roadmap storage for "My Roadmaps" section with local data persistence
  * Added ability to create new roadmaps and directories directly within the app
  * Added share functionality with clipboard notifications for roadmap links
  * Made roadmap viewer sidebar collapsible/toggleable for better screen space management
  * Enhanced community roadmap detail page with navigation to full viewer

* **Tests**
  * Added comprehensive test coverage for authentication components, forms, and workflows
  * Added test coverage for roadmap and profile features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->