### PR TITLE
feat(#142): 카드 컨텍스트 메뉴 (더보기) 구현

### DIFF
--- a/src/features/my-roadmaps/components/atoms/RoadmapCard/RoadmapCard.test.tsx
+++ b/src/features/my-roadmaps/components/atoms/RoadmapCard/RoadmapCard.test.tsx
@@ -1,27 +1,51 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 import { RoadmapCard } from './index';
 
 describe('RoadmapCard', () => {
-  const defaultProps = {
-    title: 'Test Roadmap',
-  };
-
   it('renders title correctly', () => {
-    render(<RoadmapCard {...defaultProps} />);
-    expect(screen.getByText('Test Roadmap')).toBeDefined();
+    render(<RoadmapCard title="Test Roadmap" />);
+    expect(screen.getByText('Test Roadmap')).toBeInTheDocument();
   });
 
   it('renders directory type correctly', () => {
     render(<RoadmapCard title="Directory Name" type="Directory" fileCount={67} />);
-    expect(screen.getByText('Directory Name')).toBeDefined();
-    expect(screen.getByText('67개의 파일')).toBeDefined();
+    expect(screen.getByText('Directory Name')).toBeInTheDocument();
+    expect(screen.getByText('67개의 파일')).toBeInTheDocument();
   });
 
   it('renders roadmap type with author correctly', () => {
     render(<RoadmapCard title="Roadmap Name" type="Roadmap" author="홍길동" />);
-    expect(screen.getByText('Roadmap Name')).toBeDefined();
-    expect(screen.getByText('By 홍길동')).toBeDefined();
+    expect(screen.getByText('Roadmap Name')).toBeInTheDocument();
+    expect(screen.getByText('By 홍길동')).toBeInTheDocument();
+  });
+
+  it('shows context menu with all items for roadmap type', async () => {
+    const user = userEvent.setup();
+    render(<RoadmapCard title="Test" type="Roadmap" />);
+    await user.click(screen.getByLabelText('더 보기'));
+    expect(screen.getByText('즐겨찾기')).toBeInTheDocument();
+    expect(screen.getByText('이름수정')).toBeInTheDocument();
+    expect(screen.getByText('파일이동')).toBeInTheDocument();
+    expect(screen.getByText('삭제')).toBeInTheDocument();
+  });
+
+  it('hides 즐겨찾기 for directory type', async () => {
+    const user = userEvent.setup();
+    render(<RoadmapCard title="Test" type="Directory" />);
+    await user.click(screen.getByLabelText('더 보기'));
+    expect(screen.queryByText('즐겨찾기')).not.toBeInTheDocument();
+    expect(screen.getByText('이름수정')).toBeInTheDocument();
+  });
+
+  it('calls onDelete when 삭제 clicked', async () => {
+    const user = userEvent.setup();
+    const handleDelete = vi.fn();
+    render(<RoadmapCard title="Test" onDelete={handleDelete} />);
+    await user.click(screen.getByLabelText('더 보기'));
+    await user.click(screen.getByText('삭제'));
+    expect(handleDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/my-roadmaps/components/atoms/RoadmapCard/index.tsx
+++ b/src/features/my-roadmaps/components/atoms/RoadmapCard/index.tsx
@@ -1,8 +1,15 @@
 import Image from 'next/image';
 
-import { Ellipsis, SquareDashed } from 'lucide-react';
+import { Ellipsis, FolderInput, Pencil, SquareDashed, Star, Trash2 } from 'lucide-react';
 
 import { Card } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
 
 interface RoadmapCardProps {
@@ -12,7 +19,12 @@ interface RoadmapCardProps {
   author?: string;
   fileCount?: number;
   imageUrl?: string;
+  isFavorite?: boolean;
   className?: string;
+  onFavorite?: () => void;
+  onRename?: () => void;
+  onMove?: () => void;
+  onDelete?: () => void;
 }
 
 export function RoadmapCard({
@@ -21,7 +33,12 @@ export function RoadmapCard({
   author,
   fileCount,
   imageUrl,
+  isFavorite,
   className,
+  onFavorite,
+  onRename,
+  onMove,
+  onDelete,
 }: RoadmapCardProps) {
   const isDirectory = type === 'Directory';
 
@@ -61,13 +78,66 @@ export function RoadmapCard({
             {isDirectory ? `${fileCount ?? 0}개의 파일` : `By ${author ?? '홍길동'}`}
           </p>
         </div>
-        <button
-          type="button"
-          aria-label="더 보기"
-          className="text-muted-foreground/60 hover:text-foreground shrink-0 p-1 transition-colors"
-        >
-          <Ellipsis className="h-4 w-4" />
-        </button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="더 보기"
+              className="text-muted-foreground/60 hover:text-foreground shrink-0 p-1 transition-colors"
+            >
+              <Ellipsis className="h-4 w-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-[72px] min-w-0 p-[10px]">
+            {!isDirectory && (
+              <>
+                <DropdownMenuItem
+                  className="cursor-pointer gap-2 text-sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onFavorite?.();
+                  }}
+                >
+                  <Star className={cn('h-3.5 w-3.5', isFavorite && 'fill-current')} />
+                  즐겨찾기
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            )}
+            <DropdownMenuItem
+              className="cursor-pointer gap-2 text-sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRename?.();
+              }}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+              이름수정
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="cursor-pointer gap-2 text-sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onMove?.();
+              }}
+            >
+              <FolderInput className="h-3.5 w-3.5" />
+              파일이동
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-destructive cursor-pointer gap-2 text-sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete?.();
+              }}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary
- RoadmapCard에 DropdownMenu 컨텍스트 메뉴 추가
- 로드맵: 즐겨찾기/이름수정/파일이동/삭제
- 디렉토리: 이름수정/파일이동/삭제 (즐겨찾기 없음)

## Test plan
- [x] 로드맵 카드 메뉴 4개 항목 렌더링 테스트
- [x] 디렉토리 카드 즐겨찾기 숨김 테스트
- [x] 삭제 콜백 호출 테스트
- [x] `pnpm lint` 에러 0
- [x] 전체 6개 테스트 통과

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced roadmap card menus with interactive dropdown displaying dedicated action buttons: favorite, rename, move, and delete
  * Favorite option appears for roadmaps only; other actions available for all item types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->