### PR TITLE
fix(#141): 디렉토리 추가 모달 아이콘 버튼 제거

### DIFF
--- a/src/features/my-roadmaps/components/molecules/AddDirectoryModal/AddDirectoryModal.test.tsx
+++ b/src/features/my-roadmaps/components/molecules/AddDirectoryModal/AddDirectoryModal.test.tsx
@@ -12,7 +12,6 @@ describe('AddDirectoryModal', () => {
   it('renders correctly when open', () => {
     render(<AddDirectoryModal {...defaultProps} />);
     expect(screen.getByText('디렉토리 추가')).toBeInTheDocument();
-    expect(screen.getByText('아이콘 추가')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('디렉토리 이름을 입력하세요')).toBeInTheDocument();
   });
 

--- a/src/features/my-roadmaps/components/molecules/AddDirectoryModal/AddDirectoryModal.tsx
+++ b/src/features/my-roadmaps/components/molecules/AddDirectoryModal/AddDirectoryModal.tsx
@@ -2,8 +2,6 @@
 
 import { useState } from 'react';
 
-import { ImagePlus } from 'lucide-react';
-
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -42,13 +40,6 @@ export function AddDirectoryModal({ isOpen, onClose, onConfirm }: AddDirectoryMo
           <DialogTitle className="text-lg font-bold text-[#020617]">디렉토리 추가</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-4 py-4">
-          <Button
-            variant="outline"
-            className="flex h-9 w-fit items-center gap-2 rounded-lg border-slate-200 px-3 text-sm font-semibold text-slate-700 shadow-sm hover:bg-slate-50"
-          >
-            <ImagePlus className="h-4 w-4" />
-            아이콘 추가
-          </Button>
           <Input
             value={directoryName}
             onChange={(e) => setDirectoryName(e.target.value)}


### PR DESCRIPTION
## Summary
- AddDirectoryModal에서 Figma에 없는 "아이콘 추가" 버튼 제거
- 관련 테스트 업데이트

## Test plan
- [x] AddDirectoryModal 5개 테스트 통과
- [x] `pnpm lint` 에러 0

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)