### PR TITLE
fix(#143): Breadcrumb 하드코딩 → 동적 경로 반영

### DIFF
--- a/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/MyRoadmapsToolbar.test.tsx
+++ b/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/MyRoadmapsToolbar.test.tsx
@@ -14,11 +14,9 @@ const renderWithProvider = (ui: React.ReactElement) => {
 };
 
 describe('MyRoadmapsToolbar', () => {
-  it('renders breadcrumbs correctly', () => {
+  it('renders root breadcrumb when no path', () => {
     renderWithProvider(<MyRoadmapsToolbar />);
-    expect(screen.getByText('Home')).toBeDefined();
-    expect(screen.getByText('Components')).toBeDefined();
-    expect(screen.getByText('Breadcrumb')).toBeDefined();
+    expect(screen.getByText('내 전체 로드맵')).toBeDefined();
   });
 
   it('renders search input', () => {

--- a/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/index.tsx
+++ b/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/index.tsx
@@ -4,18 +4,10 @@ import { useRef, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { useSetAtom } from 'jotai';
-import { ListFilter, Plus, Search } from 'lucide-react';
+import { useAtom, useSetAtom } from 'jotai';
+import { ChevronRight, ListFilter, Plus, Search } from 'lucide-react';
 import { nanoid } from 'nanoid';
 
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -27,7 +19,7 @@ import { Input } from '@/components/ui/input';
 import { useClickOutside } from '@/hooks/use-click-outside';
 import { cn } from '@/lib/utils';
 
-import { myRoadmapItemsAtom } from '../../../stores/my-roadmaps.atoms';
+import { breadcrumbPathAtom, myRoadmapItemsAtom } from '../../../stores/my-roadmaps.atoms';
 import { AddDirectoryModal } from '../AddDirectoryModal';
 import { AddRoadmapModal } from '../AddRoadmapModal';
 import { MyRoadmapsFilter } from '../MyRoadmapsFilter';
@@ -37,6 +29,7 @@ import type { RoadmapData } from '../../../types/my-roadmaps.types';
 export function MyRoadmapsToolbar() {
   const router = useRouter();
   const setItems = useSetAtom(myRoadmapItemsAtom);
+  const [breadcrumbPath, setBreadcrumbPath] = useAtom(breadcrumbPathAtom);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isRoadmapModalOpen, setIsRoadmapModalOpen] = useState(false);
   const [isDirectoryModalOpen, setIsDirectoryModalOpen] = useState(false);
@@ -72,21 +65,40 @@ export function MyRoadmapsToolbar() {
 
   return (
     <div className="flex w-full items-center justify-between py-6">
-      <Breadcrumb className="flex h-9 items-center">
-        <BreadcrumbList>
-          <BreadcrumbItem>
-            <BreadcrumbLink href="/">Home</BreadcrumbLink>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>Components</BreadcrumbPage>
-          </BreadcrumbItem>
-          <BreadcrumbSeparator />
-          <BreadcrumbItem>
-            <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
-          </BreadcrumbItem>
-        </BreadcrumbList>
-      </Breadcrumb>
+      {breadcrumbPath.length === 0 ? (
+        <div className="flex h-9 items-center px-3">
+          <span className="text-sm font-semibold">내 전체 로드맵</span>
+        </div>
+      ) : (
+        <div className="flex h-9 items-center">
+          <button
+            type="button"
+            className="text-foreground text-xl font-semibold transition-colors hover:opacity-70"
+            onClick={() => setBreadcrumbPath([])}
+          >
+            내 전체 로드맵
+          </button>
+          {breadcrumbPath.map((segment, index) => {
+            const isLast = index === breadcrumbPath.length - 1;
+            return (
+              <div key={segment.id} className="flex items-center">
+                <ChevronRight className="text-muted-foreground mx-1 h-5 w-5" />
+                {isLast ? (
+                  <span className="text-base font-semibold text-blue-700">{segment.name}</span>
+                ) : (
+                  <button
+                    type="button"
+                    className="text-foreground text-base font-semibold transition-colors hover:opacity-70"
+                    onClick={() => setBreadcrumbPath(breadcrumbPath.slice(0, index + 1))}
+                  >
+                    {segment.name}
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
       <div className="flex items-center gap-[10px]">
         <div className="relative">
           <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />

--- a/src/features/my-roadmaps/stores/my-roadmaps.atoms.ts
+++ b/src/features/my-roadmaps/stores/my-roadmaps.atoms.ts
@@ -9,6 +9,13 @@ import type { RoadmapData } from '../types/my-roadmaps.types';
 
 export type SidebarCategory = 'recent' | 'community' | 'my-roadmap' | 'shared' | 'favorites';
 
+export interface BreadcrumbSegment {
+  id: string;
+  name: string;
+}
+
+export const breadcrumbPathAtom = atom<BreadcrumbSegment[]>([]);
+
 export const sortOrderAtom = atom<SortOrder>('desc');
 export const sortByAtom = atom<SortBy>('recent');
 export const filterCategoryAtom = atom<FilterCategory>('all');


### PR DESCRIPTION
## Summary
- 하드코딩된 `Home > Components > Breadcrumb`을 동적 경로로 교체
- 루트: "내 전체 로드맵" 표시
- depth 이동: `내 전체 로드맵 > Dir1 > Dir2` (현재 위치 파란색)
- 각 세그먼트 클릭 시 해당 depth로 이동

## Changes
- `breadcrumbPathAtom` 추가 (`BreadcrumbSegment[]`)
- `MyRoadmapsToolbar` Breadcrumb 동적 렌더링
- 미사용 shadcn Breadcrumb import 제거

## Test plan
- [x] 루트 breadcrumb 렌더링 테스트
- [x] 전체 44개 테스트 통과
- [x] `pnpm lint` 에러 0

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)