### PR TITLE
fix(#147): 사이드바 + Auth CSS Figma 정밀 맞춤

### DIFF
--- a/src/features/auth/components/organisms/LoginForm/index.tsx
+++ b/src/features/auth/components/organisms/LoginForm/index.tsx
@@ -86,7 +86,7 @@ export function LoginForm() {
           <Button type="submit" className="w-full">
             로그인
           </Button>
-          <Separator className="my-1" />
+          <Separator className="my-2" />
           <GoogleAuthButton variant="login" onClick={handleGoogleLogin} />
           <GitHubAuthButton variant="login" onClick={handleGitHubLogin} />
         </div>

--- a/src/features/auth/components/organisms/register-steps/RegisterStep1Form.tsx
+++ b/src/features/auth/components/organisms/register-steps/RegisterStep1Form.tsx
@@ -113,7 +113,7 @@ export function RegisterStep1Form({
               인증번호 전송
             </Button>
           )}
-          <Separator className="my-1" />
+          <Separator className="my-2" />
           <GoogleAuthButton variant="register" onClick={onGoogleRegister} />
           <GitHubAuthButton variant="register" onClick={onGitHubRegister} />
         </div>

--- a/src/features/auth/components/templates/AuthCard/index.tsx
+++ b/src/features/auth/components/templates/AuthCard/index.tsx
@@ -22,7 +22,7 @@ export function AuthCard({ title, description, children, footer, className }: Au
   return (
     <Card className={cn('w-[400px] gap-6 p-6 shadow-sm', className)}>
       <CardHeader className="gap-1 p-0">
-        <CardTitle className="text-base font-bold">{title}</CardTitle>
+        <CardTitle className="text-base font-semibold">{title}</CardTitle>
         {description && (
           <CardDescription className="text-sm tracking-[0.07px]">{description}</CardDescription>
         )}

--- a/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/index.tsx
+++ b/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/index.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
@@ -141,6 +142,7 @@ export function MyRoadmapsToolbar() {
             >
               <span className="text-[13px] font-semibold text-[#374151]">로드맵</span>
             </DropdownMenuItem>
+            <DropdownMenuSeparator />
             <DropdownMenuItem
               className="flex cursor-pointer items-center rounded-lg px-3 py-2.5 transition-colors outline-none focus:bg-[#F3F4F6]"
               onClick={() => setIsDirectoryModalOpen(true)}

--- a/src/features/my-roadmaps/components/organisms/MyRoadmapsSidebar/MyRoadmapsSidebar.test.tsx
+++ b/src/features/my-roadmaps/components/organisms/MyRoadmapsSidebar/MyRoadmapsSidebar.test.tsx
@@ -25,9 +25,9 @@ describe('MyRoadmapsSidebar', () => {
 
     const recentButton = screen.getByText('최근').closest('button')!;
     await user.click(recentButton);
-    expect(recentButton).toHaveClass('bg-[#E5E7EB]');
+    expect(recentButton).toHaveClass('bg-[#e2e8f0]');
 
     const myRoadmapButton = screen.getByText('내 로드맵').closest('button')!;
-    expect(myRoadmapButton).not.toHaveClass('bg-[#E5E7EB]');
+    expect(myRoadmapButton).not.toHaveClass('bg-[#e2e8f0]');
   });
 });

--- a/src/features/my-roadmaps/components/organisms/MyRoadmapsSidebar/index.tsx
+++ b/src/features/my-roadmaps/components/organisms/MyRoadmapsSidebar/index.tsx
@@ -1,34 +1,38 @@
 import { useAtom } from 'jotai';
-import {
-  ChevronDown,
-  Clock,
-  LayoutGrid,
-  Search,
-  Star,
-  Users,
-  Share2,
-  LucideIcon,
-} from 'lucide-react';
+import { BookOpen, ChevronDown, Clock, Files, Search, Star, Users } from 'lucide-react';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 
-import { SidebarCategory, sidebarCategoryAtom } from '../../../stores/my-roadmaps.atoms';
+import { type SidebarCategory, sidebarCategoryAtom } from '../../../stores/my-roadmaps.atoms';
+
+import type { LucideIcon } from 'lucide-react';
+
+interface SidebarItem {
+  icon: LucideIcon;
+  label: string;
+  id: SidebarCategory;
+}
+
+const SIDEBAR_GROUPS: SidebarItem[][] = [
+  [
+    { icon: Clock, label: '최근', id: 'recent' },
+    { icon: BookOpen, label: '커뮤니티', id: 'community' },
+  ],
+  [
+    { icon: Files, label: '내 로드맵', id: 'my-roadmap' },
+    { icon: Users, label: '공유된 로드맵', id: 'shared' },
+  ],
+  [{ icon: Star, label: '즐겨찾기', id: 'favorites' }],
+];
 
 interface MyRoadmapsSidebarProps {
   className?: string;
   userName?: string;
   userEmail?: string;
 }
-
-const SIDEBAR_ITEMS: { icon: LucideIcon; label: string; id: SidebarCategory }[] = [
-  { icon: Clock, label: '최근', id: 'recent' },
-  { icon: LayoutGrid, label: '커뮤니티', id: 'community' },
-  { icon: Share2, label: '내 로드맵', id: 'my-roadmap' },
-  { icon: Users, label: '공유된 로드맵', id: 'shared' },
-  { icon: Star, label: '즐겨찾기', id: 'favorites' },
-];
 
 export function MyRoadmapsSidebar({
   className,
@@ -38,59 +42,60 @@ export function MyRoadmapsSidebar({
   const [activeCategory, setActiveCategory] = useAtom(sidebarCategoryAtom);
 
   return (
-    <div className={cn('bg-sidebar flex min-h-screen w-52 flex-col border-r', className)}>
-      <div className="flex h-full flex-col">
-        {/* Profile Section */}
-        <div className="mb-2 flex items-center gap-2 p-4">
-          <Avatar className="h-8 w-8">
-            <AvatarImage src="/placeholder-avatar.png" />
-            <AvatarFallback>U</AvatarFallback>
-          </Avatar>
-          <div className="flex min-w-0 flex-1 flex-col">
-            <span className="truncate text-xs font-semibold text-[#1F2937]">{userName}</span>
-            <span className="text-muted-foreground truncate text-[10px] leading-none">
-              {userEmail}
-            </span>
-          </div>
-          <ChevronDown className="text-muted-foreground h-4 w-4" />
+    <div
+      className={cn(
+        'flex min-h-screen w-[240px] flex-col border-r border-[#e2e8f0] bg-[#f1f5f9] p-4',
+        className,
+      )}
+    >
+      {/* Profile Section */}
+      <div className="mb-4 flex items-center gap-3 rounded-md px-3 py-2">
+        <Avatar className="h-8 w-8">
+          <AvatarImage src="/placeholder-avatar.png" />
+          <AvatarFallback>U</AvatarFallback>
+        </Avatar>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-sm font-normal text-[#020617]">{userName}</span>
+          <span className="truncate text-xs leading-4 text-[#64748b]">{userEmail}</span>
         </div>
-
-        {/* Sidebar Search */}
-        <div className="mb-4 px-3">
-          <div className="relative">
-            <Search className="text-muted-foreground/60 absolute top-1/2 left-2.5 h-4 w-4 -translate-y-1/2" />
-            <Input
-              placeholder="Search"
-              className="h-9 border-none bg-white pl-9 text-xs shadow-xs"
-            />
-          </div>
-        </div>
-
-        {/* Navigation Items */}
-        <nav className="flex-1 space-y-0.5 px-2">
-          {SIDEBAR_ITEMS.map((item) => (
-            <button
-              key={item.label}
-              type="button"
-              onClick={() => setActiveCategory(item.id)}
-              className={cn(
-                'flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-[13px] font-medium transition-colors',
-                activeCategory === item.id
-                  ? 'bg-[#E5E7EB] text-[#1F2937]'
-                  : 'text-[#4B5563] hover:bg-black/5',
-              )}
-            >
-              <item.icon
-                className={cn(
-                  'h-4 w-4',
-                  activeCategory === item.id ? 'text-[#1F2937]' : 'text-[#6B7280]',
-                )}
-              />
-              {item.label}
-            </button>
-          ))}
-        </nav>
+        <ChevronDown className="h-5 w-5 text-[#64748b]" />
       </div>
+
+      {/* Search */}
+      <div className="mb-4">
+        <div className="relative">
+          <Search className="absolute top-1/2 left-3 h-5 w-5 -translate-y-1/2 text-[#64748b]" />
+          <Input
+            placeholder="Search"
+            className="h-9 border border-[#e2e8f0] bg-white pl-10 text-sm shadow-xs"
+          />
+        </div>
+      </div>
+
+      {/* Navigation */}
+      <nav className="flex flex-col">
+        {SIDEBAR_GROUPS.map((group, groupIndex) => (
+          <div key={groupIndex}>
+            {groupIndex > 0 && <Separator className="my-2" />}
+            {group.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setActiveCategory(item.id)}
+                className={cn(
+                  'flex h-8 w-full items-center gap-2 rounded-md px-3 py-1 text-sm transition-colors',
+                  activeCategory === item.id
+                    ? 'bg-[#e2e8f0] text-[#334155]'
+                    : 'text-[#334155] hover:bg-black/5',
+                )}
+              >
+                <item.icon className="h-5 w-5" />
+                {item.label}
+              </button>
+            ))}
+          </div>
+        ))}
+      </nav>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- 사이드바: 너비/아이콘/Separator/색상/간격 Figma 정밀 맞춤
- Auth: 제목 font-weight + Separator 높이 미세 조정
- New 드롭다운 로드맵/디렉토리 사이 Separator 추가

## Test plan
- [x] 24파일 130개 테스트 전부 통과
- [x] `pnpm lint` 에러 0

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced spacing consistency throughout authentication forms for improved visual balance
  * Reorganized navigation sidebar with refined item layout and visual grouping
  * Added visual separators to dropdown menus for clearer option distinction
  * Updated typography styling to refine visual presentation across UI components

* **Tests**
  * Updated test validations to reflect navigation styling changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->