### PR TITLE
fix(#155): align Profile page with Figma design

### DIFF
--- a/src/app/(profile)/profile/page.tsx
+++ b/src/app/(profile)/profile/page.tsx
@@ -3,9 +3,5 @@
 import { Profile } from '@/features/profile/components/templates/Profile';
 
 export default function ProfilePage() {
-  return (
-    <div className="flex w-full items-center justify-center p-4 sm:p-8">
-      <Profile />
-    </div>
-  );
+  return <Profile />;
 }

--- a/src/features/profile/components/atoms/ProfileEditButton/ProfileEditButton.test.tsx
+++ b/src/features/profile/components/atoms/ProfileEditButton/ProfileEditButton.test.tsx
@@ -4,14 +4,14 @@ import { describe, it, expect, vi } from 'vitest';
 import { ProfileEditButton } from './index';
 
 describe('ProfileEditButton', () => {
-  it('renders "프로필 수정" when variant is "show"', () => {
+  it('renders "편집하기" when variant is "show"', () => {
     render(<ProfileEditButton variant="show" />);
-    expect(screen.getByRole('button')).toHaveTextContent('프로필 수정');
+    expect(screen.getByRole('button')).toHaveTextContent('편집하기');
   });
 
-  it('renders "수정 완료" when variant is "edit"', () => {
+  it('renders "편집 모드 나가기" when variant is "edit"', () => {
     render(<ProfileEditButton variant="edit" />);
-    expect(screen.getByRole('button')).toHaveTextContent('수정 완료');
+    expect(screen.getByRole('button')).toHaveTextContent('편집 모드 나가기');
   });
 
   it('calls onClick when clicked', () => {

--- a/src/features/profile/components/atoms/ProfileEditButton/index.tsx
+++ b/src/features/profile/components/atoms/ProfileEditButton/index.tsx
@@ -10,10 +10,30 @@ interface ProfileEditButtonProps {
 }
 
 export function ProfileEditButton({ variant, className, onClick }: ProfileEditButtonProps) {
-  const label = variant === 'show' ? '프로필 수정' : '수정 완료';
+  const label = variant === 'show' ? '편집하기' : '편집 모드 나가기';
+
+  if (variant === 'show') {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        className={cn(
+          'h-[36px] rounded-lg border-[#cbd5e1] px-4 text-sm font-semibold text-[#020617]',
+          className,
+        )}
+        onClick={onClick}
+      >
+        {label}
+      </Button>
+    );
+  }
 
   return (
-    <Button type="button" className={cn('w-full font-semibold', className)} onClick={onClick}>
+    <Button
+      type="button"
+      className={cn('h-[36px] rounded-lg px-4 text-sm font-semibold', className)}
+      onClick={onClick}
+    >
       {label}
     </Button>
   );

--- a/src/features/profile/components/atoms/RoadmapCard/index.tsx
+++ b/src/features/profile/components/atoms/RoadmapCard/index.tsx
@@ -1,38 +1,36 @@
 import Image from 'next/image';
 
-import { Card, CardContent } from '@/components/ui/card';
+import { SquareDashed } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
 
 interface RoadmapCardProps {
   title: string;
   author: string;
   imageUrl?: string;
+  className?: string;
 }
 
-export function RoadmapCard({ title, author, imageUrl }: RoadmapCardProps) {
+export function RoadmapCard({ title, author, imageUrl, className }: RoadmapCardProps) {
   return (
-    <Card
+    <div
       data-testid="roadmap-card"
-      className="hover:bg-muted/40 w-full cursor-pointer overflow-hidden rounded-lg border p-0 shadow-none transition-colors"
-    >
-      {imageUrl ? (
-        <div className="bg-muted/50 relative aspect-[2/1] w-full">
-          <Image
-            src={imageUrl}
-            alt={title}
-            fill
-            className="object-cover"
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-          />
-        </div>
-      ) : (
-        <div className="bg-muted/50 flex aspect-[2/1] w-full items-center justify-center">
-          <p className="text-muted-foreground text-sm font-medium">Thumbnail</p>
-        </div>
+      className={cn(
+        'h-[200px] w-full cursor-pointer overflow-hidden rounded-lg border border-[#e2e8f0] bg-[#f1f5f9]',
+        className,
       )}
-      <CardContent className="m-2 flex h-5 flex-col items-start justify-end px-2">
-        <p className="text-foreground text-sm font-semibold">{title}</p>
-        <p className="text-muted-foreground py-1 text-xs">By {author}</p>
-      </CardContent>
-    </Card>
+    >
+      <div className="relative flex h-[146px] w-full items-center justify-center overflow-hidden">
+        {imageUrl ? (
+          <Image src={imageUrl} alt={title} fill className="object-cover" sizes="304px" />
+        ) : (
+          <SquareDashed className="text-muted-foreground/30 h-8 w-8" />
+        )}
+      </div>
+      <div className="flex flex-col border-t border-[#e2e8f0] bg-white px-3 py-2">
+        <p className="truncate text-sm leading-[21px] text-[#020617]">{title}</p>
+        <p className="truncate text-xs leading-4 text-[#64748b]">By {author}</p>
+      </div>
+    </div>
   );
 }

--- a/src/features/profile/components/molecules/ContributionGraph/index.tsx
+++ b/src/features/profile/components/molecules/ContributionGraph/index.tsx
@@ -44,14 +44,14 @@ export function ContributionGraph({ data }: { data: Contribution[] }) {
                       key={day.date}
                       title={`${day.date}: ${day.count} contributions`}
                       style={{
-                        width: 12,
-                        height: 12,
+                        width: 18,
+                        height: 18,
                         borderRadius: 2,
                         backgroundColor: COLORS[getLevel(day.count)],
                       }}
                     />
                   ) : (
-                    <div key={j} style={{ width: 12, height: 12 }} />
+                    <div key={j} style={{ width: 18, height: 18 }} />
                   ),
                 )}
               </div>

--- a/src/features/profile/components/molecules/ContributionGraph/index.tsx
+++ b/src/features/profile/components/molecules/ContributionGraph/index.tsx
@@ -35,23 +35,23 @@ export function ContributionGraph({ data }: { data: Contribution[] }) {
       </CardHeader>
       <CardContent className="flex flex-col">
         <div className="w-full overflow-x-auto py-2">
-          <div className="flex min-w-max gap-[1px]">
+          <div className="flex min-w-max gap-[2px]">
             {weeks.map((week, i) => (
-              <div key={i} className="flex flex-col gap-[1px]">
+              <div key={i} className="flex flex-col gap-[2px]">
                 {week.map((day, j) =>
                   day ? (
                     <div
                       key={day.date}
                       title={`${day.date}: ${day.count} contributions`}
                       style={{
-                        width: 8,
-                        height: 8,
+                        width: 12,
+                        height: 12,
                         borderRadius: 2,
                         backgroundColor: COLORS[getLevel(day.count)],
                       }}
                     />
                   ) : (
-                    <div key={j} style={{ width: 8, height: 8 }} />
+                    <div key={j} style={{ width: 12, height: 12 }} />
                   ),
                 )}
               </div>

--- a/src/features/profile/components/molecules/ContributionGraph/index.tsx
+++ b/src/features/profile/components/molecules/ContributionGraph/index.tsx
@@ -44,14 +44,14 @@ export function ContributionGraph({ data }: { data: Contribution[] }) {
                       key={day.date}
                       title={`${day.date}: ${day.count} contributions`}
                       style={{
-                        width: 18,
-                        height: 18,
+                        width: 16,
+                        height: 16,
                         borderRadius: 2,
                         backgroundColor: COLORS[getLevel(day.count)],
                       }}
                     />
                   ) : (
-                    <div key={j} style={{ width: 18, height: 18 }} />
+                    <div key={j} style={{ width: 16, height: 16 }} />
                   ),
                 )}
               </div>

--- a/src/features/profile/components/molecules/ProfileHeader/index.tsx
+++ b/src/features/profile/components/molecules/ProfileHeader/index.tsx
@@ -33,7 +33,7 @@ export function ProfileHeader({
   };
 
   return (
-    <div className="flex w-full flex-col items-center gap-6 sm:flex-row sm:gap-8">
+    <div className="flex w-full flex-col items-center gap-6 sm:flex-row sm:gap-6">
       <ProfilePicture src={imageSrc} userName={userName} onUpload={handleImageUpload} />
 
       <div className="w-full">

--- a/src/features/profile/components/templates/Profile/Profile.test.tsx
+++ b/src/features/profile/components/templates/Profile/Profile.test.tsx
@@ -1,7 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import { Provider, WritableAtom } from 'jotai';
 import { useHydrateAtoms } from 'jotai/utils';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    back: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+}));
 
 import { PROFILE_MESSAGES } from '@/constants/messages';
 

--- a/src/features/profile/components/templates/Profile/index.tsx
+++ b/src/features/profile/components/templates/Profile/index.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+
+import { ArrowLeft, Pencil } from 'lucide-react';
+
 import { ProfileBio } from '../../molecules/ProfileBio';
 import { ProfileCustomBoxArea } from '../../molecules/ProfileCustomBoxArea';
 import { ProfileHeader } from '../../molecules/ProfileHeader';
@@ -17,23 +21,39 @@ const MOCK_USER_DATA = {
 };
 
 export function Profile() {
+  const router = useRouter();
+
   return (
-    <div className="flex w-full max-w-[960px] flex-col gap-6 sm:gap-10">
-      <ProfileHeader
-        userName={MOCK_USER_DATA.userName}
-        email={MOCK_USER_DATA.email}
-        followerCount={MOCK_USER_DATA.followerCount}
-        followingCount={MOCK_USER_DATA.followingCount}
-      />
-      <ProfileBio bio={MOCK_USER_DATA.bio} />
-      <div className="flex w-full flex-col gap-4 md:flex-row md:gap-6">
-        <ProfileCustomBoxArea />
-        <div className="flex-1">
-          <ProfileStreak />
+    <div className="flex min-h-screen w-full flex-col items-center bg-white">
+      <header className="flex h-11 w-full items-center justify-between border-b border-[#e2e8f0] bg-white px-5">
+        <button className="flex items-center gap-1 text-sm" onClick={() => router.back()}>
+          <ArrowLeft size={14} />
+          <span>프로필</span>
+        </button>
+        <div className="flex items-center gap-1 text-sm">
+          <span>User</span>
+          <Pencil size={16} />
         </div>
+      </header>
+      <div className="flex w-full max-w-[960px] flex-col gap-10 px-6 py-10">
+        <ProfileHeader
+          userName={MOCK_USER_DATA.userName}
+          email={MOCK_USER_DATA.email}
+          followerCount={MOCK_USER_DATA.followerCount}
+          followingCount={MOCK_USER_DATA.followingCount}
+        />
+        <div className="flex w-full gap-[76px]">
+          <div className="w-[500px] shrink-0">
+            <ProfileBio bio={MOCK_USER_DATA.bio} />
+          </div>
+          <div className="flex-1">
+            <ProfileCustomBoxArea />
+          </div>
+        </div>
+        <ProfileStreak />
+        <ProfileThirdBox />
+        <MadeRoadmapList />
       </div>
-      <ProfileThirdBox />
-      <MadeRoadmapList />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add page header with back button and user info
- Restructure layout: Bio + CustomBox side by side, Streak independent
- Fix avatar-info gap (32px → 24px)
- Fix edit button labels ("편집하기"/"편집 모드 나가기") and outline style
- Rewrite Profile RoadmapCard (flat divs, 200px height, SquareDashed)
- Update tests for all changed components

## Test plan
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm build` succeeds
- [x] 16 test files, 57 tests all passing
- [x] Figma screenshot comparison verified

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a header navigation bar to the profile page with a back button and title section

* **Style**
  * Restructured profile page layout with left and right column arrangement
  * Updated profile card design and styling
  * Modified button labels and appearance variants
  * Adjusted spacing on responsive breakpoints
  * Changed profile page container styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->