### PR TITLE
fix(#157): align all editor components with Figma design

### DIFF
--- a/src/components/roadmap/constants/node-colors.ts
+++ b/src/components/roadmap/constants/node-colors.ts
@@ -3,6 +3,7 @@ import type { NodeColorVariant, TextColorVariant, NodeState } from '@/types/road
 export interface NodeColorClasses {
   bg: string;
   border: string;
+  sectionBorder: string;
   text: string;
   handle: string;
   badge: string;
@@ -13,13 +14,15 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
     default: {
       bg: 'bg-background',
       border: 'border-border',
+      sectionBorder: 'border-[#e2e8f0]',
       text: 'text-foreground',
       handle: 'bg-primary',
-      badge: 'bg-muted text-muted-foreground',
+      badge: 'bg-muted text-[#0f172a]',
     },
     focus: {
       bg: 'bg-background',
       border: 'border-[#3f8dff]',
+      sectionBorder: 'border-[#8ec5ff]',
       text: 'text-foreground',
       handle: 'bg-primary',
       badge: 'bg-blue-500 text-white',
@@ -29,6 +32,7 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
     default: {
       bg: 'bg-primary',
       border: 'border-border',
+      sectionBorder: 'border-[#64748b]',
       text: 'text-primary-foreground',
       handle: 'bg-primary-foreground',
       badge: 'bg-primary text-primary-foreground',
@@ -36,6 +40,7 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
     focus: {
       bg: 'bg-primary',
       border: 'border-[#3f8dff]',
+      sectionBorder: 'border-[#8ec5ff]',
       text: 'text-primary-foreground',
       handle: 'bg-primary-foreground',
       badge: 'bg-blue-500 text-white',
@@ -44,7 +49,8 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
   blue: {
     default: {
       bg: 'bg-[#155dfc]',
-      border: 'border-[#155dfc]',
+      border: 'border-[#e2e8f0]',
+      sectionBorder: 'border-[#8ec5ff]',
       text: 'text-white',
       handle: 'bg-white',
       badge: 'bg-[#155dfc] text-white',
@@ -52,6 +58,7 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
     focus: {
       bg: 'bg-[#155dfc]',
       border: 'border-[#3f8dff]',
+      sectionBorder: 'border-[#8ec5ff]',
       text: 'text-white',
       handle: 'bg-white',
       badge: 'bg-blue-500 text-white',
@@ -60,7 +67,8 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
   purple: {
     default: {
       bg: 'bg-[#9810fa]',
-      border: 'border-[#9810fa]',
+      border: 'border-[#e2e8f0]',
+      sectionBorder: 'border-[#dab2ff]',
       text: 'text-white',
       handle: 'bg-white',
       badge: 'bg-[#9810fa] text-white',
@@ -68,6 +76,7 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
     focus: {
       bg: 'bg-[#9810fa]',
       border: 'border-[#3f8dff]',
+      sectionBorder: 'border-[#8ec5ff]',
       text: 'text-white',
       handle: 'bg-white',
       badge: 'bg-blue-500 text-white',
@@ -76,7 +85,8 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
   red: {
     default: {
       bg: 'bg-[#ec003f]',
-      border: 'border-[#ec003f]',
+      border: 'border-[#e2e8f0]',
+      sectionBorder: 'border-[#ffa1ad]',
       text: 'text-white',
       handle: 'bg-white',
       badge: 'bg-[#ec003f] text-white',
@@ -84,6 +94,7 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
     focus: {
       bg: 'bg-[#ec003f]',
       border: 'border-[#3f8dff]',
+      sectionBorder: 'border-[#8ec5ff]',
       text: 'text-white',
       handle: 'bg-white',
       badge: 'bg-blue-500 text-white',
@@ -92,14 +103,16 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
   orange: {
     default: {
       bg: 'bg-[#f54a00]',
-      border: 'border-[#f54a00]',
+      border: 'border-[#e2e8f0]',
+      sectionBorder: 'border-[#ffb86a]',
       text: 'text-white',
       handle: 'bg-white',
-      badge: 'bg-[#f54a00] text-white',
+      badge: 'bg-[#e17100] text-white',
     },
     focus: {
       bg: 'bg-[#f54a00]',
       border: 'border-[#3f8dff]',
+      sectionBorder: 'border-[#8ec5ff]',
       text: 'text-white',
       handle: 'bg-white',
       badge: 'bg-blue-500 text-white',
@@ -108,12 +121,12 @@ export const NODE_COLOR_CLASSES: Record<NodeColorVariant, Record<NodeState, Node
 } as const;
 
 export const TEXT_COLOR_CLASSES: Record<TextColorVariant, string> = {
-  gray: 'text-[#64748b]',
+  white: 'text-white',
   black: 'text-foreground',
-  blue: 'text-[#3b82f6]',
-  purple: 'text-[#8b5cf6]',
-  red: 'text-[#f43f5e]',
-  orange: 'text-[#f59e0b]',
+  blue: 'text-[#155dfc]',
+  purple: 'text-[#9810fa]',
+  red: 'text-[#ec003f]',
+  orange: 'text-[#e17100]',
 } as const;
 
 export function getNodeColors(variant: NodeColorVariant, state: NodeState): NodeColorClasses {

--- a/src/components/roadmap/nodes/JagalchiNodeBase/index.tsx
+++ b/src/components/roadmap/nodes/JagalchiNodeBase/index.tsx
@@ -35,25 +35,25 @@ export const JagalchiNodeBase = memo(function JagalchiNodeBase({
         type="source"
         position={Position.Top}
         id="top"
-        className={cn('!border-background !h-1.5 !w-1.5 !rounded-full !border-2', colors.handle)}
+        className={cn('!border-background !h-1.5 !w-1.5 !rounded-[4px] !border-2', colors.handle)}
       />
       <Handle
         type="source"
         position={Position.Bottom}
         id="bottom"
-        className={cn('!border-background !h-1.5 !w-1.5 !rounded-full !border-2', colors.handle)}
+        className={cn('!border-background !h-1.5 !w-1.5 !rounded-[4px] !border-2', colors.handle)}
       />
       <Handle
         type="source"
         position={Position.Left}
         id="left"
-        className={cn('!border-background !h-1.5 !w-1.5 !rounded-full !border-2', colors.handle)}
+        className={cn('!border-background !h-1.5 !w-1.5 !rounded-[4px] !border-2', colors.handle)}
       />
       <Handle
         type="source"
         position={Position.Right}
         id="right"
-        className={cn('!border-background !h-1.5 !w-1.5 !rounded-full !border-2', colors.handle)}
+        className={cn('!border-background !h-1.5 !w-1.5 !rounded-[4px] !border-2', colors.handle)}
       />
 
       <span className="truncate text-base font-medium">{data.label}</span>

--- a/src/components/roadmap/nodes/JagalchiSectionBase/index.tsx
+++ b/src/components/roadmap/nodes/JagalchiSectionBase/index.tsx
@@ -38,7 +38,7 @@ export const JagalchiSectionBase = memo(function JagalchiSectionBase({
       <div
         className={cn(
           'bg-background w-full flex-1 rounded-lg border-2 transition-colors',
-          colors.border,
+          colors.sectionBorder,
         )}
       />
     </div>

--- a/src/features/roadmap-editor/canvas/components/JagalchiSection/index.tsx
+++ b/src/features/roadmap-editor/canvas/components/JagalchiSection/index.tsx
@@ -46,7 +46,7 @@ export const JagalchiSection = memo(function JagalchiSection({
         minWidth={200}
         minHeight={200}
         onResizeEnd={handleResize}
-        handleClassName="h-3! w-3! rounded-sm! border-2! border-blue-600! bg-background!"
+        handleClassName="h-3! w-3! rounded-none! border-2! border-blue-600! bg-background!"
       />
     </JagalchiSectionBase>
   );

--- a/src/features/roadmap-editor/canvas/components/JagalchiText/JagalchiText.stories.tsx
+++ b/src/features/roadmap-editor/canvas/components/JagalchiText/JagalchiText.stories.tsx
@@ -62,9 +62,9 @@ export const Default: Story = {
   },
 };
 
-export const Gray: Story = {
+export const White: Story = {
   args: {
-    data: { ...defaultData, content: 'Gray Text', variant: 'gray' },
+    data: { ...defaultData, content: 'White Text', variant: 'white' },
   },
 };
 

--- a/src/features/roadmap-editor/canvas/components/JagalchiText/JagalchiText.test.tsx
+++ b/src/features/roadmap-editor/canvas/components/JagalchiText/JagalchiText.test.tsx
@@ -32,8 +32,8 @@ describe('JagalchiText', () => {
   });
 
   it('renders with different color variants', () => {
-    const variants: Array<'gray' | 'black' | 'blue' | 'purple' | 'red' | 'orange'> = [
-      'gray',
+    const variants: Array<'white' | 'black' | 'blue' | 'purple' | 'red' | 'orange'> = [
+      'white',
       'black',
       'blue',
       'purple',

--- a/src/features/roadmap-editor/components/molecules/EditorAiMenu/index.tsx
+++ b/src/features/roadmap-editor/components/molecules/EditorAiMenu/index.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useState } from 'react';
 
-import { Settings, Sparkles, WandSparkles } from 'lucide-react';
+import { Sparkles, WandSparkles, ChevronDown } from 'lucide-react';
 
 import {
   DropdownMenu,
@@ -33,13 +33,14 @@ export const EditorAiMenu = memo(function EditorAiMenu() {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <div>
+          <div className="flex items-center">
             <ToolbarButton
-              icon={<Settings className="h-5 w-5" />}
+              icon={<Sparkles className="h-[15px] w-[15px]" />}
               label={EDITOR_MESSAGES.TOOLBAR_GEAR_TOOLTIP}
               isActive={false}
               onClick={() => {}}
             />
+            <ChevronDown className="h-2 w-2 text-slate-500" />
           </div>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="center" side="top" sideOffset={8}>

--- a/src/features/roadmap-editor/constants/preset-colors.ts
+++ b/src/features/roadmap-editor/constants/preset-colors.ts
@@ -10,12 +10,12 @@ export const NODE_PRESET_COLORS: { variant: NodeColorVariant; hex: string; label
 ];
 
 export const TEXT_PRESET_COLORS: { variant: TextColorVariant; hex: string; label: string }[] = [
-  { variant: 'gray', hex: '#64748b', label: 'Gray' },
+  { variant: 'white', hex: '#ffffff', label: 'White' },
   { variant: 'black', hex: '#000000', label: 'Black' },
-  { variant: 'blue', hex: '#3b82f6', label: 'Blue' },
-  { variant: 'purple', hex: '#8b5cf6', label: 'Purple' },
-  { variant: 'red', hex: '#f43f5e', label: 'Red' },
-  { variant: 'orange', hex: '#f59e0b', label: 'Orange' },
+  { variant: 'blue', hex: '#155dfc', label: 'Blue' },
+  { variant: 'purple', hex: '#9810fa', label: 'Purple' },
+  { variant: 'red', hex: '#ec003f', label: 'Red' },
+  { variant: 'orange', hex: '#e17100', label: 'Orange' },
 ];
 
 export function hexToNodeVariant(hex: string): NodeColorVariant {
@@ -25,7 +25,7 @@ export function hexToNodeVariant(hex: string): NodeColorVariant {
 
 export function hexToTextVariant(hex: string): TextColorVariant {
   const found = TEXT_PRESET_COLORS.find((c) => c.hex.toLowerCase() === hex.toLowerCase());
-  return found?.variant ?? 'gray';
+  return found?.variant ?? 'white';
 }
 
 export function nodeVariantToHex(variant: NodeColorVariant): string {
@@ -33,5 +33,5 @@ export function nodeVariantToHex(variant: NodeColorVariant): string {
 }
 
 export function textVariantToHex(variant: TextColorVariant): string {
-  return TEXT_PRESET_COLORS.find((c) => c.variant === variant)?.hex ?? '#64748b';
+  return TEXT_PRESET_COLORS.find((c) => c.variant === variant)?.hex ?? '#ffffff';
 }

--- a/src/features/roadmap-editor/core/components/EditorHeader/EditorHeader.test.tsx
+++ b/src/features/roadmap-editor/core/components/EditorHeader/EditorHeader.test.tsx
@@ -51,7 +51,7 @@ describe('EditorHeader', () => {
     expect(header).toHaveClass('top-4');
     expect(header).toHaveClass('left-4');
     expect(header).toHaveClass('rounded-lg');
-    expect(header).toHaveClass('shadow-sm');
+    expect(header).toHaveClass('shadow-md');
   });
 
   it('is a memo component', () => {

--- a/src/features/roadmap-editor/core/components/EditorHeader/index.tsx
+++ b/src/features/roadmap-editor/core/components/EditorHeader/index.tsx
@@ -5,7 +5,7 @@ import { memo } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { useAtomValue } from 'jotai';
-import { ArrowLeft } from 'lucide-react';
+import { ChevronLeft, Ellipsis } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 
@@ -28,18 +28,37 @@ export const EditorHeader = memo(function EditorHeader({ onBack }: EditorHeaderP
   };
 
   return (
-    <header className="absolute top-4 left-4 z-10 flex items-center gap-2 rounded-lg border bg-white px-3 py-2 shadow-sm">
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-6 w-6"
-        onClick={handleBackClick}
-        aria-label="뒤로가기"
-      >
-        <ArrowLeft className="h-4 w-4" />
-      </Button>
+    <header className="absolute top-4 left-4 z-10 flex max-w-[320px] flex-col gap-4 rounded-lg border border-[#e2e8f0] bg-white p-2 shadow-md">
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          className="min-h-8 min-w-8 rounded-lg p-[7px]"
+          onClick={handleBackClick}
+          aria-label="뒤로가기"
+        >
+          <ChevronLeft className="h-[15px] w-[15px]" />
+        </Button>
 
-      <span className="text-sm font-medium">{title || 'Jagalchi Roadmap'}</span>
+        <span className="text-base leading-6 font-semibold text-[#020617]">
+          {title || 'Jagalchi Roadmap'}
+        </span>
+
+        <span className="text-xs leading-4 font-medium tracking-[0.18px] text-[#64748b]">
+          (수정중)
+        </span>
+
+        <button
+          type="button"
+          className="flex min-h-8 min-w-8 items-center justify-center rounded-lg p-[7px] hover:bg-slate-100"
+          aria-label="더보기"
+        >
+          <Ellipsis className="h-[15px] w-[15px] text-[#020617]" />
+        </button>
+      </div>
+
+      <Button className="h-8 w-full rounded-lg bg-[#0f172a] px-3 py-[5.5px] text-sm font-semibold text-white hover:bg-[#1e293b]">
+        Readme 수정
+      </Button>
     </header>
   );
 });

--- a/src/features/roadmap-editor/properties/components/ColorPresetButton/ColorPresetButton.test.tsx
+++ b/src/features/roadmap-editor/properties/components/ColorPresetButton/ColorPresetButton.test.tsx
@@ -41,21 +41,19 @@ describe('ColorPresetButton', () => {
     expect(button).toHaveAttribute('aria-label', '색상: #155dfc');
   });
 
-  it('Figma 디자인 스타일을 적용한다 (36px 높이, 8px border-radius)', () => {
+  it('Figma 디자인 스타일을 적용한다 (h-8 높이, 8px border-radius)', () => {
     render(<ColorPresetButton color="#155dfc" />);
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('h-[36px]');
+    expect(button).toHaveClass('h-8');
     expect(button).toHaveClass('rounded-[8px]');
     expect(button).toHaveClass('border');
-    expect(button).toHaveClass('border-slate-200');
     expect(button).toHaveClass('shadow-sm');
   });
 
-  it('고정 너비를 가진다 (36px x 36px 정사각형)', () => {
+  it('flex-1로 균등 너비를 가진다', () => {
     render(<ColorPresetButton color="#155dfc" />);
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('w-[36px]');
-    expect(button).toHaveClass('min-w-[36px]');
+    expect(button).toHaveClass('flex-1');
   });
 
   it('disabled 상태일 때 클릭이 동작하지 않는다', async () => {

--- a/src/features/roadmap-editor/properties/components/ColorPresetButton/index.tsx
+++ b/src/features/roadmap-editor/properties/components/ColorPresetButton/index.tsx
@@ -26,25 +26,17 @@ export interface ColorPresetButtonProps {
  */
 export const ColorPresetButton = forwardRef<HTMLButtonElement, ColorPresetButtonProps>(
   ({ color, isSelected = false, onClick, className }, ref) => {
-    // white/black 색상은 더 진한 border 사용
-    const isLightColor = color.toLowerCase() === 'white' || color.toLowerCase() === '#ffffff';
-    const isDarkColor = color.toLowerCase() === 'black' || color.toLowerCase() === '#000000';
-
     return (
       <button
         ref={ref}
         type="button"
         onClick={onClick}
         className={cn(
-          // Figma 정확한 스타일 (36px x 36px 정사각형, 8px border-radius)
-          'h-[36px] min-h-[36px] w-[36px] min-w-[36px]',
+          // 32px 높이, 너비는 flex-1로 균등 분할
+          'h-8 min-h-[32px] min-w-[32px] flex-1',
           'rounded-[8px]',
-          // Border: white/black은 더 진하게
-          isLightColor
-            ? 'border-2 border-slate-300'
-            : isDarkColor
-              ? 'border-2 border-slate-700'
-              : 'border border-slate-200',
+          // Border: 모든 색상 동일한 1px 테두리
+          'border border-[#e2e8f0]',
           'shadow-sm',
           // 인터랙션
           'transition-all duration-200',

--- a/src/features/roadmap-editor/properties/components/ColorSelector/ColorSelector.stories.tsx
+++ b/src/features/roadmap-editor/properties/components/ColorSelector/ColorSelector.stories.tsx
@@ -37,7 +37,7 @@ const nodeColorPresets = [
 ];
 
 const textColorPresets = [
-  { variant: 'gray' as TextColorVariant, hex: '#64748b', label: 'Gray' },
+  { variant: 'white' as TextColorVariant, hex: '#ffffff', label: 'White' },
   { variant: 'black' as TextColorVariant, hex: '#000000', label: 'Black' },
   { variant: 'blue' as TextColorVariant, hex: '#155dfc', label: 'Blue' },
   { variant: 'purple' as TextColorVariant, hex: '#9810fa', label: 'Purple' },
@@ -89,12 +89,12 @@ export const NodePurple: Story = {
   },
 };
 
-// Text type with gray preset selected
-export const TextGray: Story = {
+// Text type with white preset selected
+export const TextWhite: Story = {
   args: {
     type: 'text',
     nodeId: 'text-1',
-    currentVariant: 'gray',
+    currentVariant: 'white',
     presets: textColorPresets,
     onPresetSelect: (variant) => console.log('Selected preset:', variant),
   },
@@ -141,7 +141,7 @@ export const Interactive: Story = {
 
 // Interactive story component for text type
 function InteractiveTextColorSelector(args: React.ComponentProps<typeof ColorSelector>) {
-  const [currentVariant, setCurrentVariant] = useState<TextColorVariant>('gray');
+  const [currentVariant, setCurrentVariant] = useState<TextColorVariant>('white');
 
   return (
     <ColorSelector
@@ -161,7 +161,7 @@ export const InteractiveText: Story = {
   args: {
     type: 'text',
     nodeId: 'text-1',
-    currentVariant: 'gray',
+    currentVariant: 'white',
     presets: textColorPresets,
     onPresetSelect: (variant) => console.log('Selected preset:', variant),
   },

--- a/src/features/roadmap-editor/properties/components/ColorSelector/ColorSelector.test.tsx
+++ b/src/features/roadmap-editor/properties/components/ColorSelector/ColorSelector.test.tsx
@@ -174,7 +174,7 @@ describe('ColorSelector', () => {
   it('handles text type correctly', () => {
     const handlePresetSelect = vi.fn();
     const textPresets = [
-      { variant: 'gray' as const, hex: '#64748b', label: 'Gray' },
+      { variant: 'white' as const, hex: '#ffffff', label: 'White' },
       { variant: 'black' as const, hex: '#000000', label: 'Black' },
       { variant: 'blue' as const, hex: '#155dfc', label: 'Blue' },
     ];
@@ -184,7 +184,7 @@ describe('ColorSelector', () => {
         <ColorSelector
           type="text"
           nodeId="text-1"
-          currentVariant="gray"
+          currentVariant="white"
           presets={textPresets}
           onPresetSelect={handlePresetSelect}
         />
@@ -192,8 +192,8 @@ describe('ColorSelector', () => {
     );
 
     // 현재 색상 확인
-    const colorPreviewButton = screen.getByLabelText('현재 색상: #64748b');
-    expect(colorPreviewButton).toHaveStyle({ backgroundColor: '#64748b' });
+    const colorPreviewButton = screen.getByLabelText('현재 색상: #ffffff');
+    expect(colorPreviewButton).toHaveStyle({ backgroundColor: '#ffffff' });
   });
 
   it('renders with Figma design specs (36px height, 8px border-radius)', () => {
@@ -213,7 +213,7 @@ describe('ColorSelector', () => {
 
     // 현재 색상 프리뷰 버튼의 클래스 확인 (Figma 스펙)
     const colorPreviewButton = screen.getByLabelText('현재 색상: #155dfc');
-    expect(colorPreviewButton).toHaveClass('h-[36px]');
+    expect(colorPreviewButton).toHaveClass('h-8');
     expect(colorPreviewButton).toHaveClass('rounded-[8px]');
   });
 });

--- a/src/features/roadmap-editor/properties/components/ColorSelector/index.tsx
+++ b/src/features/roadmap-editor/properties/components/ColorSelector/index.tsx
@@ -48,13 +48,13 @@ export const ColorSelector = memo(function ColorSelector({
   const currentColorHex = presets.find((p) => p.variant === currentVariant)?.hex ?? '#ffffff';
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       {/* 기본 컬러 (Preset) */}
       <div>
-        <label className="text-sm font-medium text-slate-700">
+        <label className="text-sm font-medium text-[#020617]">
           {EDITOR_MESSAGES.SIDEBAR_COLOR_PRESET_LABEL}
         </label>
-        <div className="mt-2 flex gap-1">
+        <div className="mt-1.5 flex gap-1">
           {presets.map((preset) => (
             <ColorPresetButton
               key={preset.variant}
@@ -68,10 +68,10 @@ export const ColorSelector = memo(function ColorSelector({
 
       {/* 커스텀 색상 */}
       <div>
-        <label className="text-sm font-medium text-slate-700">
+        <label className="text-sm font-medium text-[#020617]">
           {EDITOR_MESSAGES.SIDEBAR_COLOR_CUSTOM_LABEL}
         </label>
-        <div className="mt-2 flex items-center gap-2">
+        <div className="mt-1.5 flex items-center gap-2">
           {/* Palette 아이콘 버튼 */}
           <button
             type="button"
@@ -82,11 +82,11 @@ export const ColorSelector = memo(function ColorSelector({
             <Palette className="size-6" />
           </button>
 
-          {/* 현재 색상 프리뷰 버튼 (Figma 스펙: 36px 높이, 8px border-radius) */}
+          {/* 현재 색상 프리뷰 버튼 (32px 높이, 8px border-radius) */}
           <button
             type="button"
             onClick={handleCustomColorClick}
-            className="h-[36px] min-h-[36px] w-full flex-1 rounded-[8px] border border-slate-200 shadow-sm transition-all hover:scale-105 hover:shadow-md focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95"
+            className="h-8 min-h-[32px] w-full flex-1 rounded-[8px] border border-slate-200 shadow-sm transition-all hover:scale-105 hover:shadow-md focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:outline-none active:scale-95"
             style={{ backgroundColor: currentColorHex }}
             aria-label={`현재 색상: ${currentColorHex}`}
           />

--- a/src/features/roadmap-editor/properties/components/EdgePropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/properties/components/EdgePropertiesPanel/index.tsx
@@ -73,14 +73,14 @@ export const EdgePropertiesPanel = memo(function EdgePropertiesPanel({
       {/* Content */}
       <div className="flex-1 space-y-0 overflow-y-auto p-4">
         {/* 라벨 */}
-        <div className="border-b border-slate-200 pb-4">
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-900">
+        <div className="border-b border-[#e2e8f0] pb-4">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-[#020617]">
               {EDITOR_MESSAGES.SIDEBAR_EDGE_LABEL_LABEL}
             </label>
             <input
               type="text"
-              placeholder="Value"
+              placeholder="라벨 없음"
               disabled
               className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
             />
@@ -88,9 +88,9 @@ export const EdgePropertiesPanel = memo(function EdgePropertiesPanel({
         </div>
 
         {/* 라인 스타일 */}
-        <div className="border-b border-slate-200 py-4">
+        <div className="border-b border-[#e2e8f0] py-4">
           <div className="space-y-4">
-            <label className="text-sm font-medium text-slate-900">
+            <label className="text-sm font-medium text-[#020617]">
               {EDITOR_MESSAGES.SIDEBAR_EDGE_STYLE_LABEL}
             </label>
             <div className="space-y-4">
@@ -201,15 +201,15 @@ export const EdgePropertiesPanel = memo(function EdgePropertiesPanel({
         </div>
 
         {/* 두께 */}
-        <div className="border-b border-slate-200 py-4">
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-900">
+        <div className="border-b border-[#e2e8f0] py-4">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-[#020617]">
               {EDITOR_MESSAGES.SIDEBAR_EDGE_THICKNESS_LABEL}
             </label>
             <div className="flex items-center gap-2">
               <input
                 type="text"
-                placeholder="Value"
+                placeholder="1"
                 disabled
                 className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
               />
@@ -219,7 +219,7 @@ export const EdgePropertiesPanel = memo(function EdgePropertiesPanel({
         </div>
 
         {/* 기본 컬러 */}
-        <div className="border-b border-slate-200 py-4">
+        <div className="border-b border-[#e2e8f0] py-4">
           <ColorSelector
             type="node"
             nodeId={edge.id}

--- a/src/features/roadmap-editor/properties/components/EditorInput/index.tsx
+++ b/src/features/roadmap-editor/properties/components/EditorInput/index.tsx
@@ -60,7 +60,7 @@ export const EditorInput = forwardRef<HTMLInputElement | HTMLTextAreaElement, Ed
       'shadow-sm',
       // 폰트
       'text-sm leading-[21px] tracking-[0.07px]',
-      'text-slate-900 placeholder:text-slate-500',
+      'text-[#020617] placeholder:text-slate-500',
       // 인터랙션
       'outline-none transition-colors',
       'focus-visible:border-slate-300 focus-visible:ring-2 focus-visible:ring-slate-100',
@@ -76,7 +76,7 @@ export const EditorInput = forwardRef<HTMLInputElement | HTMLTextAreaElement, Ed
     return (
       <div className="flex flex-col gap-1.5">
         {label && (
-          <Label htmlFor={id} className="text-sm font-medium text-slate-900">
+          <Label htmlFor={id} className="text-sm font-medium text-[#020617]">
             {label}
           </Label>
         )}

--- a/src/features/roadmap-editor/properties/components/NodePropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/properties/components/NodePropertiesPanel/index.tsx
@@ -96,8 +96,8 @@ export const NodePropertiesPanel = memo(function NodePropertiesPanel({
         />
 
         {/* 형부자료 */}
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-slate-900">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-[#020617]">
             {EDITOR_MESSAGES.SIDEBAR_RESOURCES_LABEL}
           </label>
           <div className="space-y-2">

--- a/src/features/roadmap-editor/properties/components/PanelHeader.tsx
+++ b/src/features/roadmap-editor/properties/components/PanelHeader.tsx
@@ -17,21 +17,21 @@ interface PanelHeaderProps {
  */
 export function PanelHeader({ title, subtitle, isLocked, onToggleLock }: PanelHeaderProps) {
   return (
-    <div className="flex items-center justify-between gap-4 border-b border-slate-200 p-4">
+    <div className="flex items-center justify-between gap-4 border-b border-[#e2e8f0] p-4">
       <div className="flex flex-col gap-1">
-        <h3 className="text-base font-semibold text-slate-900">{title}</h3>
-        <p className="text-xs text-slate-600">{subtitle}</p>
+        <h3 className="text-base font-semibold text-[#020617]">{title}</h3>
+        <p className="text-xs text-[#020617]">{subtitle}</p>
       </div>
       <button
         type="button"
         onClick={onToggleLock}
-        className="rounded-md p-1 transition-colors hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:outline-none"
+        className="rounded-sm p-1 transition-colors hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:outline-none"
         aria-label={isLocked ? '잠금 해제' : '잠금'}
       >
         {isLocked ? (
-          <Lock className="h-4 w-4 text-slate-700" />
+          <Lock className="h-[13px] w-[13px] text-[#020617]" />
         ) : (
-          <Unlock className="h-4 w-4 text-slate-500" />
+          <Unlock className="h-[13px] w-[13px] text-[#020617]" />
         )}
       </button>
     </div>

--- a/src/features/roadmap-editor/properties/components/SectionPropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/properties/components/SectionPropertiesPanel/index.tsx
@@ -55,9 +55,9 @@ export const SectionPropertiesPanel = memo(function SectionPropertiesPanel({
       </div>
 
       {/* 크기 */}
-      <div className="border-b border-slate-200 p-4">
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-slate-900">크기</label>
+      <div className="border-b border-[#e2e8f0] p-4">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-[#020617]">크기</label>
           <div className="flex items-center gap-4">
             <div className="flex flex-1 items-center gap-2">
               <p className="text-sm text-black">W</p>

--- a/src/features/roadmap-editor/properties/components/TextPropertiesPanel/TextPropertiesPanel.stories.tsx
+++ b/src/features/roadmap-editor/properties/components/TextPropertiesPanel/TextPropertiesPanel.stories.tsx
@@ -67,7 +67,7 @@ export const Empty: Story = {
       position: { x: 0, y: 0 },
       data: {
         content: '',
-        variant: 'gray',
+        variant: 'white',
         fontSize: 16,
         fontWeight: 'normal',
         isLocked: false,
@@ -154,7 +154,7 @@ export const GrayText: Story = {
       data: {
         ...baseText.data,
         content: '참고',
-        variant: 'gray',
+        variant: 'white',
       },
     },
   },

--- a/src/features/roadmap-editor/properties/components/TextPropertiesPanel/TextPropertiesPanel.test.tsx
+++ b/src/features/roadmap-editor/properties/components/TextPropertiesPanel/TextPropertiesPanel.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { Provider } from 'jotai';
 import { describe, expect, it } from 'vitest';
 
@@ -39,34 +38,9 @@ describe('TextPropertiesPanel', () => {
     expect(screen.getByRole('button', { name: /잠금/ })).toBeInTheDocument();
   });
 
-  it('renders text content textarea', () => {
-    renderWithProvider(mockText);
-    expect(screen.getByDisplayValue('Test Text Content')).toBeInTheDocument();
-  });
-
   it('renders color selector', () => {
     renderWithProvider(mockText);
     expect(screen.getByText('기본 컬러')).toBeInTheDocument();
-  });
-
-  it('disables text content textarea when locked', () => {
-    const lockedText = { ...mockText, data: { ...mockText.data, isLocked: true } };
-    renderWithProvider(lockedText);
-
-    const contentTextarea = screen.getByDisplayValue('Test Text Content');
-    expect(contentTextarea).toBeDisabled();
-  });
-
-  it('allows user to interact with content textarea when unlocked', async () => {
-    const user = userEvent.setup();
-    renderWithProvider(mockText);
-
-    const contentTextarea = screen.getByDisplayValue('Test Text Content');
-    expect(contentTextarea).not.toBeDisabled();
-
-    // Verify textarea can receive focus
-    await user.click(contentTextarea);
-    expect(contentTextarea).toHaveFocus();
   });
 
   it('shows unlock icon when text is unlocked', () => {

--- a/src/features/roadmap-editor/properties/components/TextPropertiesPanel/index.tsx
+++ b/src/features/roadmap-editor/properties/components/TextPropertiesPanel/index.tsx
@@ -42,22 +42,10 @@ export const TextPropertiesPanel = memo(function TextPropertiesPanel({
 
       {/* Content */}
       <div className="flex-1 space-y-0 overflow-y-auto p-4">
-        {/* 텍스트 내용 */}
-        <div className="border-b border-slate-200 pb-4">
-          <EditorInput
-            label="텍스트 내용"
-            value={node.data.content}
-            onChange={(value) => updateNode({ content: value })}
-            placeholder="텍스트를 입력하세요"
-            isMultiline
-            isDisabled={node.data.isLocked}
-          />
-        </div>
-
         {/* 텍스트 크기 */}
-        <div className="border-b border-slate-200 py-4">
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-slate-900">텍스트 크기</label>
+        <div className="border-b border-[#e2e8f0] py-4">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium text-[#020617]">텍스트 크기</label>
             <div className="flex items-center gap-2">
               <EditorInput value="" onChange={() => {}} placeholder="Value" isDisabled />
               <p className="text-sm text-black">px</p>
@@ -66,7 +54,7 @@ export const TextPropertiesPanel = memo(function TextPropertiesPanel({
         </div>
 
         {/* 기본 컬러 */}
-        <div className="border-b border-slate-200 py-4">
+        <div className="border-b border-[#e2e8f0] py-4">
           <ColorSelector
             type="text"
             nodeId={node.id}

--- a/src/features/roadmap-editor/sidebar/components/EditorSidebar/index.tsx
+++ b/src/features/roadmap-editor/sidebar/components/EditorSidebar/index.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { memo } from 'react';
+import { memo, useState } from 'react';
 
 import { useAtomValue } from 'jotai';
+import { ChevronsLeft, ChevronsRight } from 'lucide-react';
 
 import { EDITOR_MESSAGES } from '@/constants/messages';
 
@@ -29,11 +30,31 @@ export const EditorSidebar = memo(function EditorSidebar() {
   const selectedNode = useAtomValue(singleSelectedNodeAtom);
   const selectedEdge = useAtomValue(singleSelectedEdgeAtom);
   const selectedNodeIds = useAtomValue(selectedNodeIdsAtom);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const collapseButton = (
+    <button
+      className="flex h-8 w-8 items-center justify-center rounded-bl-lg border-b border-l border-[#e2e8f0] bg-white"
+      onClick={() => setIsCollapsed((prev) => !prev)}
+      aria-label={isCollapsed ? '사이드바 열기' : '사이드바 닫기'}
+    >
+      {isCollapsed ? <ChevronsLeft className="h-4 w-4" /> : <ChevronsRight className="h-4 w-4" />}
+    </button>
+  );
+
+  if (isCollapsed) {
+    return (
+      <div className="relative flex h-full flex-col">
+        <div className="absolute top-0 right-0">{collapseButton}</div>
+      </div>
+    );
+  }
 
   // Multi-select (2개 이상 노드 선택)
   if (selectedNodeIds.length >= 2) {
     return (
-      <aside className="h-full w-[240px] border-l bg-white">
+      <aside className="relative h-full w-[240px] border-l bg-white">
+        <div className="absolute top-0 left-0">{collapseButton}</div>
         <MultiSelectPanel />
       </aside>
     );
@@ -42,7 +63,8 @@ export const EditorSidebar = memo(function EditorSidebar() {
   // Edge가 선택된 경우
   if (selectedEdge) {
     return (
-      <aside className="h-full w-[240px] border-l bg-white">
+      <aside className="relative h-full w-[240px] border-l bg-white">
+        <div className="absolute top-0 left-0">{collapseButton}</div>
         <EdgePropertiesPanel edge={selectedEdge} />
       </aside>
     );
@@ -52,7 +74,8 @@ export const EditorSidebar = memo(function EditorSidebar() {
   if (selectedNode) {
     if (selectedNode.type === 'jagalchi-node') {
       return (
-        <aside className="h-full w-[240px] border-l bg-white">
+        <aside className="relative h-full w-[240px] border-l bg-white">
+          <div className="absolute top-0 left-0">{collapseButton}</div>
           <NodePropertiesPanel node={selectedNode as JagalchiNodeType} />
         </aside>
       );
@@ -60,7 +83,8 @@ export const EditorSidebar = memo(function EditorSidebar() {
 
     if (selectedNode.type === 'jagalchi-section') {
       return (
-        <aside className="h-full w-[240px] border-l bg-white">
+        <aside className="relative h-full w-[240px] border-l bg-white">
+          <div className="absolute top-0 left-0">{collapseButton}</div>
           <SectionPropertiesPanel node={selectedNode as JagalchiSectionType} />
         </aside>
       );
@@ -68,7 +92,8 @@ export const EditorSidebar = memo(function EditorSidebar() {
 
     if (selectedNode.type === 'jagalchi-text') {
       return (
-        <aside className="h-full w-[240px] border-l bg-white">
+        <aside className="relative h-full w-[240px] border-l bg-white">
+          <div className="absolute top-0 left-0">{collapseButton}</div>
           <TextPropertiesPanel node={selectedNode as JagalchiTextType} />
         </aside>
       );
@@ -77,7 +102,8 @@ export const EditorSidebar = memo(function EditorSidebar() {
 
   // 아무것도 선택되지 않은 경우
   return (
-    <aside className="flex h-full w-[240px] items-center justify-center border-l bg-white">
+    <aside className="relative flex h-full w-[240px] items-center justify-center border-l bg-white">
+      <div className="absolute top-0 left-0">{collapseButton}</div>
       <p className="text-muted-foreground text-sm">{EDITOR_MESSAGES.SIDEBAR_EMPTY_STATE}</p>
     </aside>
   );

--- a/src/features/roadmap-editor/sidebar/components/EditorSidebar/index.tsx
+++ b/src/features/roadmap-editor/sidebar/components/EditorSidebar/index.tsx
@@ -53,7 +53,7 @@ export const EditorSidebar = memo(function EditorSidebar() {
   // Multi-select (2개 이상 노드 선택)
   if (selectedNodeIds.length >= 2) {
     return (
-      <aside className="relative h-full w-[240px] border-l bg-white">
+      <aside className="relative h-full w-[240px] border-l bg-white shadow-md">
         <div className="absolute top-0 left-0">{collapseButton}</div>
         <MultiSelectPanel />
       </aside>
@@ -63,7 +63,7 @@ export const EditorSidebar = memo(function EditorSidebar() {
   // Edge가 선택된 경우
   if (selectedEdge) {
     return (
-      <aside className="relative h-full w-[240px] border-l bg-white">
+      <aside className="relative h-full w-[240px] border-l bg-white shadow-md">
         <div className="absolute top-0 left-0">{collapseButton}</div>
         <EdgePropertiesPanel edge={selectedEdge} />
       </aside>
@@ -74,7 +74,7 @@ export const EditorSidebar = memo(function EditorSidebar() {
   if (selectedNode) {
     if (selectedNode.type === 'jagalchi-node') {
       return (
-        <aside className="relative h-full w-[240px] border-l bg-white">
+        <aside className="relative h-full w-[240px] border-l bg-white shadow-md">
           <div className="absolute top-0 left-0">{collapseButton}</div>
           <NodePropertiesPanel node={selectedNode as JagalchiNodeType} />
         </aside>
@@ -83,7 +83,7 @@ export const EditorSidebar = memo(function EditorSidebar() {
 
     if (selectedNode.type === 'jagalchi-section') {
       return (
-        <aside className="relative h-full w-[240px] border-l bg-white">
+        <aside className="relative h-full w-[240px] border-l bg-white shadow-md">
           <div className="absolute top-0 left-0">{collapseButton}</div>
           <SectionPropertiesPanel node={selectedNode as JagalchiSectionType} />
         </aside>
@@ -92,7 +92,7 @@ export const EditorSidebar = memo(function EditorSidebar() {
 
     if (selectedNode.type === 'jagalchi-text') {
       return (
-        <aside className="relative h-full w-[240px] border-l bg-white">
+        <aside className="relative h-full w-[240px] border-l bg-white shadow-md">
           <div className="absolute top-0 left-0">{collapseButton}</div>
           <TextPropertiesPanel node={selectedNode as JagalchiTextType} />
         </aside>

--- a/src/features/roadmap-editor/sidebar/components/MultiSelectPanel/MultiSelectPanel.test.tsx
+++ b/src/features/roadmap-editor/sidebar/components/MultiSelectPanel/MultiSelectPanel.test.tsx
@@ -60,7 +60,7 @@ describe('MultiSelectPanel', () => {
     const spacingLabel = screen.getByText(/간격/);
     expect(spacingLabel).toBeInTheDocument();
 
-    const input = screen.getByPlaceholderText(/Value/);
+    const input = screen.getByPlaceholderText(/Mixed/);
     expect(input).toBeDisabled();
   });
 

--- a/src/features/roadmap-editor/sidebar/components/MultiSelectPanel/index.tsx
+++ b/src/features/roadmap-editor/sidebar/components/MultiSelectPanel/index.tsx
@@ -11,7 +11,7 @@ import {
   AlignCenterHorizontal,
   AlignEndHorizontal,
   AlignHorizontalJustifyCenter,
-  LockKeyhole,
+  LockKeyholeOpen,
 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -62,20 +62,20 @@ export const MultiSelectPanel = memo(function MultiSelectPanel() {
   return (
     <div className="h-full w-full space-y-4 p-4">
       {/* Header */}
-      <div className="flex items-center justify-between gap-4">
+      <div className="flex items-center justify-between gap-4 border-b border-[#e2e8f0] pb-4">
         <div className="flex flex-col gap-1">
-          <h3 className="text-base font-semibold text-slate-900">
+          <h3 className="text-base font-bold text-[#020617]">
             {EDITOR_MESSAGES.MULTI_SELECT_TITLE}
           </h3>
-          <p className="text-xs text-slate-600">노드</p>
+          <p className="text-xs text-[#020617]">노드</p>
         </div>
-        <Button variant="ghost" size="icon" disabled>
-          <LockKeyhole className="h-4 w-4" />
+        <Button variant="ghost" size="icon" className="rounded-[4px]" disabled>
+          <LockKeyholeOpen className="h-[13px] w-[13px]" />
         </Button>
       </div>
 
       {/* Alignment Section */}
-      <div>
+      <div className="border-b border-[#e2e8f0] pb-4">
         <Label className="mb-2 block">{EDITOR_MESSAGES.MULTI_SELECT_ALIGN_LABEL}</Label>
         <div className="flex items-start justify-between">
           {/* Horizontal alignment */}
@@ -87,7 +87,7 @@ export const MultiSelectPanel = memo(function MultiSelectPanel() {
               title={EDITOR_MESSAGES.MULTI_SELECT_ALIGN_LEFT}
               className="h-8 w-8 rounded-r-none"
             >
-              <AlignStartVertical className="h-4 w-4" />
+              <AlignStartVertical className="h-[15px] w-[15px]" />
             </Button>
             <Button
               variant="outline"
@@ -96,7 +96,7 @@ export const MultiSelectPanel = memo(function MultiSelectPanel() {
               title={EDITOR_MESSAGES.MULTI_SELECT_ALIGN_CENTER}
               className="h-8 w-8 rounded-none border-r-0 border-l-0"
             >
-              <AlignCenterVertical className="h-4 w-4" />
+              <AlignCenterVertical className="h-[15px] w-[15px]" />
             </Button>
             <Button
               variant="outline"
@@ -105,7 +105,7 @@ export const MultiSelectPanel = memo(function MultiSelectPanel() {
               title={EDITOR_MESSAGES.MULTI_SELECT_ALIGN_RIGHT}
               className="h-8 w-8 rounded-l-none"
             >
-              <AlignEndVertical className="h-4 w-4" />
+              <AlignEndVertical className="h-[15px] w-[15px]" />
             </Button>
           </div>
 
@@ -118,7 +118,7 @@ export const MultiSelectPanel = memo(function MultiSelectPanel() {
               title={EDITOR_MESSAGES.MULTI_SELECT_ALIGN_TOP}
               className="h-8 w-8 rounded-r-none"
             >
-              <AlignStartHorizontal className="h-4 w-4" />
+              <AlignStartHorizontal className="h-[15px] w-[15px]" />
             </Button>
             <Button
               variant="outline"
@@ -127,7 +127,7 @@ export const MultiSelectPanel = memo(function MultiSelectPanel() {
               title={EDITOR_MESSAGES.MULTI_SELECT_ALIGN_MIDDLE}
               className="h-8 w-8 rounded-none border-r-0 border-l-0"
             >
-              <AlignCenterHorizontal className="h-4 w-4" />
+              <AlignCenterHorizontal className="h-[15px] w-[15px]" />
             </Button>
             <Button
               variant="outline"
@@ -136,18 +136,18 @@ export const MultiSelectPanel = memo(function MultiSelectPanel() {
               title={EDITOR_MESSAGES.MULTI_SELECT_ALIGN_BOTTOM}
               className="h-8 w-8 rounded-l-none"
             >
-              <AlignEndHorizontal className="h-4 w-4" />
+              <AlignEndHorizontal className="h-[15px] w-[15px]" />
             </Button>
           </div>
         </div>
       </div>
 
       {/* Spacing Section */}
-      <div>
+      <div className="border-b border-[#e2e8f0] pb-4">
         <Label className="mb-2 block">{EDITOR_MESSAGES.MULTI_SELECT_SPACING_LABEL}</Label>
         <div className="flex items-center gap-2">
           <AlignHorizontalJustifyCenter className="h-6 w-6 shrink-0" />
-          <Input placeholder="Value" disabled className="flex-1" />
+          <Input placeholder="Mixed" disabled className="flex-1" />
         </div>
       </div>
 

--- a/src/features/roadmap-editor/toolbar/components/EditorToolbar/EditorToolbar.test.tsx
+++ b/src/features/roadmap-editor/toolbar/components/EditorToolbar/EditorToolbar.test.tsx
@@ -62,7 +62,7 @@ describe('EditorToolbar', () => {
     const { container } = renderToolbar();
     const divider = container.querySelector('.w-px');
     expect(divider).toBeInTheDocument();
-    expect(divider).toHaveClass('h-6');
+    expect(divider).toHaveClass('h-8');
   });
 
   it('is fixed at bottom center', () => {

--- a/src/features/roadmap-editor/toolbar/components/EditorToolbar/index.tsx
+++ b/src/features/roadmap-editor/toolbar/components/EditorToolbar/index.tsx
@@ -3,7 +3,7 @@
 import { memo } from 'react';
 
 import { useAtom, useSetAtom } from 'jotai';
-import { Square, Minus, RectangleHorizontal, Type } from 'lucide-react';
+import { SquarePlus, Spline, Frame, Type } from 'lucide-react';
 
 import { EDITOR_MESSAGES } from '@/constants/messages';
 
@@ -50,33 +50,33 @@ export const EditorToolbar = memo(function EditorToolbar() {
 
   return (
     <div className="fixed bottom-8 left-1/2 z-50 -translate-x-1/2">
-      <div className="bg-background flex items-center gap-2 rounded-lg border p-2 shadow-lg">
+      <div className="bg-background flex items-center gap-2 rounded-lg border p-2 shadow-md">
         <ToolbarButton
-          icon={<Square className="h-5 w-5" />}
+          icon={<SquarePlus className="h-[15px] w-[15px]" />}
           label={EDITOR_MESSAGES.TOOLBAR_NODE_TOOLTIP}
           isActive={activeTool === 'node'}
           onClick={handleNodeAdd}
         />
         <ToolbarButton
-          icon={<Minus className="h-5 w-5" />}
+          icon={<Spline className="h-[15px] w-[15px]" />}
           label={EDITOR_MESSAGES.TOOLBAR_LINE_TOOLTIP}
           isActive={activeTool === 'line'}
           onClick={handleLineAdd}
         />
         <ToolbarButton
-          icon={<RectangleHorizontal className="h-5 w-5" />}
+          icon={<Frame className="h-[15px] w-[15px]" />}
           label={EDITOR_MESSAGES.TOOLBAR_SECTION_TOOLTIP}
           isActive={activeTool === 'section'}
           onClick={handleSectionAdd}
         />
         <ToolbarButton
-          icon={<Type className="h-5 w-5" />}
+          icon={<Type className="h-[15px] w-[15px]" />}
           label={EDITOR_MESSAGES.TOOLBAR_TEXT_TOOLTIP}
           isActive={activeTool === 'text'}
           onClick={handleTextAdd}
         />
 
-        <div className="bg-border mx-1 h-6 w-px" />
+        <div className="bg-border mx-1 h-8 w-px" />
 
         <EditorAiMenu />
       </div>

--- a/src/features/roadmap-editor/toolbar/components/ToolbarButton/ToolbarButton.test.tsx
+++ b/src/features/roadmap-editor/toolbar/components/ToolbarButton/ToolbarButton.test.tsx
@@ -75,11 +75,11 @@ describe('ToolbarButton', () => {
     expect(tooltip).toHaveTextContent('노드');
   });
 
-  it('size가 10x10 (40px)이다', () => {
+  it('size가 8x8 (32px)이다', () => {
     render(<ToolbarButton icon={<Square />} label="노드" isActive={false} onClick={() => {}} />);
     const button = screen.getByRole('button');
-    expect(button).toHaveClass('h-10');
-    expect(button).toHaveClass('w-10');
+    expect(button).toHaveClass('h-8');
+    expect(button).toHaveClass('w-8');
   });
 
   it('shadcn/ui Button 컴포넌트를 사용한다', () => {

--- a/src/features/roadmap-editor/toolbar/components/ToolbarButton/index.tsx
+++ b/src/features/roadmap-editor/toolbar/components/ToolbarButton/index.tsx
@@ -17,7 +17,7 @@ export interface ToolbarButtonProps {
  * 툴바 버튼 컴포넌트
  *
  * Figma EditorHeader (4472:2494)의 툴바 버튼 디자인
- * - 크기: 40px x 40px
+ * - 크기: 32px x 32px
  * - Active: 파란색 배경, 흰색 아이콘
  * - Inactive: 투명 배경, 회색 아이콘
  */
@@ -35,8 +35,8 @@ export const ToolbarButton = memo(
                 aria-label={label}
                 aria-pressed={isActive}
                 className={cn(
-                  // 크기 및 레이아웃 (Figma: 40px x 40px, 8px radius)
-                  'inline-flex h-10 w-10 items-center justify-center',
+                  // 크기 및 레이아웃 (Figma: 32px x 32px, 8px radius)
+                  'inline-flex h-8 w-8 items-center justify-center p-[7px]',
                   'rounded-lg',
                   // 기본 스타일
                   'transition-colors',

--- a/src/features/roadmap-editor/utils/node-factory.ts
+++ b/src/features/roadmap-editor/utils/node-factory.ts
@@ -74,7 +74,7 @@ export function createJagalchiSection(options: CreateSectionOptions): JagalchiSe
 export function createJagalchiText(options: CreateTextOptions): JagalchiTextType {
   const {
     position,
-    variant = 'gray',
+    variant = 'white',
     content = EDITOR_MESSAGES.FLOW_TEXT_DEFAULT_CONTENT,
   } = options;
 

--- a/src/types/roadmap.types.ts
+++ b/src/types/roadmap.types.ts
@@ -3,7 +3,7 @@ import type { Edge, Node } from '@xyflow/react';
 // === Node Data Types ===
 
 export type NodeColorVariant = 'white' | 'black' | 'blue' | 'purple' | 'red' | 'orange';
-export type TextColorVariant = 'gray' | 'black' | 'blue' | 'purple' | 'red' | 'orange';
+export type TextColorVariant = 'white' | 'black' | 'blue' | 'purple' | 'red' | 'orange';
 export type NodeState = 'default' | 'focus';
 
 interface BaseNodeData {


### PR DESCRIPTION
## Summary
- EditorHeader: 2-row layout, ChevronLeft, "(수정중)" status, "Readme 수정" button
- EditorToolbar: SquarePlus/Spline/Frame icons, 32px buttons, Sparkles AI
- Node borders: all variants use #e2e8f0 gray in default state
- Section borders: pastel strokes (#8ec5ff, #dab2ff, #ffa1ad, #ffb86a)
- ColorSelector: 32px flex-1 cells, uniform borders, gap corrections
- Text preset colors aligned to Figma spec
- Sidebar: collapse button, shadow-md, section dividers
- All panels: foreground/label/subtitle colors unified to #020617
- 32 files changed, 7 test files updated

## Test plan
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm build` succeeds
- [x] 215 editor tests passing (27 test files)
- [x] Figma design context comparison verified

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible sidebar for improved editor space management.
  * Enhanced editor header with extra controls and status label.

* **Style**
  * Replaced gray text preset with a white variant; updated text and preset color palette.
  * Refined spacing, borders, and sizing across panels, buttons, and toolbar; adjusted icon sizes.
  * Updated handle and resizer corner radii for nodes and sections.

* **UI Changes**
  * Removed text content editing from the properties panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->