### PR TITLE
fix(#168): fix critical data loss bugs in schema and alignment

### DIFF
--- a/src/features/roadmap-editor/utils/align-nodes.ts
+++ b/src/features/roadmap-editor/utils/align-nodes.ts
@@ -21,6 +21,8 @@ export function alignNodes(
 
   const selectedNodes = nodes.filter((node) => selectedIdsSet.has(node.id));
 
+  if (selectedNodes.length < 2) return nodes;
+
   // Calculate target position based on direction
   let targetValue: number;
 

--- a/src/lib/roadmap-schema.test.ts
+++ b/src/lib/roadmap-schema.test.ts
@@ -114,12 +114,12 @@ describe('roadmapNodeDataSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects data missing label', () => {
+  it('accepts data missing label (optional for section/text nodes)', () => {
     const result = roadmapSchema.safeParse({
       ...validRoadmap,
       nodes: [{ ...validNode, data: { description: 'no label' } }],
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it('rejects data with non-string label', () => {
@@ -378,11 +378,11 @@ describe('parseRoadmaps', () => {
     });
   });
 
-  it('returns empty array and logs error for schema-mismatched JSON', () => {
+  it('filters out invalid entries instead of discarding all', () => {
     const invalid = JSON.stringify([{ id: 'bad', missing: 'fields' }]);
     expect(parseRoadmaps(invalid)).toEqual([]);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Invalid roadmap data in localStorage:',
+      'Skipping invalid roadmap entry:',
       expect.anything(),
     );
   });
@@ -391,8 +391,7 @@ describe('parseRoadmaps', () => {
     const input = JSON.stringify({ id: 'single-object' });
     expect(parseRoadmaps(input)).toEqual([]);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Invalid roadmap data in localStorage:',
-      expect.anything(),
+      'Invalid roadmap data in localStorage: expected array',
     );
   });
 });

--- a/src/lib/roadmap-schema.ts
+++ b/src/lib/roadmap-schema.ts
@@ -11,7 +11,7 @@ const roadmapAuthorSchema = z.object({
 });
 
 const roadmapNodeDataSchema = z.object({
-  label: z.string(),
+  label: z.string().optional(),
   description: z.string().optional(),
   resources: z.array(z.string()).optional(),
   variant: z.string().optional(),
@@ -61,22 +61,28 @@ export const roadmapsArraySchema = z.array(roadmapSchema);
 
 /**
  * Safely parse and validate roadmaps from localStorage
- * Returns empty array if validation fails
+ * Validates each item individually so one corrupt entry doesn't discard all data
  */
 export function parseRoadmaps(stored: string | null): unknown[] {
   if (!stored) return [];
 
   try {
     const parsed = JSON.parse(stored);
-    const result = roadmapsArraySchema.safeParse(parsed);
 
-    if (!result.success) {
+    if (!Array.isArray(parsed)) {
       // eslint-disable-next-line no-console
-      console.error('Invalid roadmap data in localStorage:', result.error);
+      console.error('Invalid roadmap data in localStorage: expected array');
       return [];
     }
 
-    return result.data;
+    return parsed.filter((item) => {
+      const result = roadmapSchema.safeParse(item);
+      if (!result.success) {
+        // eslint-disable-next-line no-console
+        console.error('Skipping invalid roadmap entry:', result.error);
+      }
+      return result.success;
+    });
   } catch {
     // eslint-disable-next-line no-console
     console.error('Failed to parse roadmap data from localStorage');


### PR DESCRIPTION
## Summary
- **parseRoadmaps**: per-item validation으로 변경 — 하나의 corrupt entry가 전체 로드맵 데이터를 삭제하는 버그 수정
- **roadmapNodeDataSchema**: `label`을 optional로 변경 — Section(`title`)/Text(`content`) 노드가 검증 실패하는 버그 수정
- **alignNodes**: 필터링 후 빈 배열 가드 추가 — `Math.min(...[])` = `Infinity`로 캔버스 깨지는 버그 수정

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds
- [x] `pnpm test --run` — 727/727 통과
- [x] 기존 테스트 3개 업데이트 (새 동작 반영)

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for node alignment operations to handle edge cases properly.

* **New Features**
  * Roadmap nodes can now be created without labels.

* **Improvements**
  * Invalid roadmap entries are now filtered out gracefully instead of rejecting the entire roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->