### PR TITLE
chore(#182): Phase 0 — 인프라/공통 기반 구축

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "nanoid": "^5.1.7",
     "next": "16.2.1",
     "next-seo": "^7.2.0",
+    "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-colorful": "^5.6.1",
     "react-dom": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       next-seo:
         specifier: ^7.2.0
         version: 7.2.0(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      radix-ui:
+        specifier: ^1.4.3
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -1681,6 +1684,45 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-accessible-icon@1.1.7':
+    resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-accordion@1.2.12':
+    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
@@ -1694,8 +1736,60 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-aspect-ratio@1.1.7':
+    resolution: {integrity: sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-avatar@1.1.11':
     resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1727,6 +1821,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.2':
@@ -1817,6 +1924,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-form@0.1.8':
+    resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -1824,6 +1957,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-label@2.1.8':
@@ -1841,6 +1987,71 @@ packages:
 
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.16':
+    resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.14':
+    resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.8':
+    resolution: {integrity: sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.3':
+    resolution: {integrity: sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.15':
+    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1917,6 +2128,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -1956,8 +2193,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-separator@1.1.8':
     resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.6':
+    resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1985,6 +2248,84 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.11':
+    resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tooltip@1.2.8':
@@ -5118,6 +5459,19 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  radix-ui@1.4.3:
+    resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   react-colorful@5.6.1:
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
     peerDependencies:
@@ -7285,9 +7639,71 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -7300,6 +7716,38 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -7324,6 +7772,20 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
@@ -7410,12 +7872,52 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-label@2.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -7444,6 +7946,105 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       aria-hidden: 1.2.6
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -7502,6 +8103,34 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -7571,9 +8200,37 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -7593,6 +8250,98 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11011,6 +11760,69 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   react-colorful@5.6.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,17 +1,16 @@
 import { apiClient } from './client';
 
-// === Request Types ===
+// === Request Types (aligned with docs/api.md) ===
 
 interface LoginRequest {
   email: string;
   password: string;
 }
 
-interface RegisterRequest {
+interface SignUpRequest {
   email: string;
+  name: string;
   password: string;
-  username: string;
-  links?: { name: string; url: string }[];
 }
 
 interface SendVerificationCodeRequest {
@@ -23,67 +22,82 @@ interface VerifyCodeRequest {
   code: string;
 }
 
-interface ResetPasswordRequest {
+interface ChangePasswordRequest {
   email: string;
   newPassword: string;
 }
 
+interface RefreshTokenRequest {
+  refreshToken?: string;
+}
+
 // === Response Types ===
 
-interface AuthUser {
-  id: string;
+interface LoginResponse {
+  accessToken: string;
+}
+
+interface SignUpResponse {
+  id: number;
   email: string;
-  username: string;
-  bio?: string;
-  links: { name: string; url: string }[];
-  createdAt: string;
+  name: string;
 }
 
-interface AuthResponse {
-  token: string;
-  user: AuthUser;
-}
-
-interface SendVerificationCodeResponse {
-  message: string;
-  expiresIn: number;
-}
-
-interface VerifyCodeResponse {
-  isVerified: boolean;
-}
-
-interface ResetPasswordResponse {
+interface MessageResponse {
   message: string;
 }
 
-// === API Functions ===
+interface RefreshTokenResponse {
+  accessToken: string;
+}
 
-export const login = (data: LoginRequest) => apiClient.post<AuthResponse>('/auth/login', data);
+// === API Functions (endpoints match docs/api.md) ===
 
-export const register = (data: RegisterRequest) =>
-  apiClient.post<AuthResponse>('/auth/register', data);
+/** POST /users/auth/login */
+export const login = (data: LoginRequest) =>
+  apiClient.post<LoginResponse>('/users/auth/login', data);
 
+/** POST /users */
+export const signUp = (data: SignUpRequest) => apiClient.post<SignUpResponse>('/users', data);
+
+/** POST /users/verification — 회원가입 인증코드 전송 */
 export const sendVerificationCode = (data: SendVerificationCodeRequest) =>
-  apiClient.post<SendVerificationCodeResponse>('/auth/send-verification-code', data);
+  apiClient.post<MessageResponse>('/users/verification', data);
 
+/** PATCH /users/verification — 회원가입 인증코드 확인 */
 export const verifyCode = (data: VerifyCodeRequest) =>
-  apiClient.post<VerifyCodeResponse>('/auth/verify-code', data);
+  apiClient.patch<MessageResponse>('/users/verification', data);
 
-export const resetPassword = (data: ResetPasswordRequest) =>
-  apiClient.post<ResetPasswordResponse>('/auth/reset-password', data);
+/** PATCH /users/auth/password-reset — 비밀번호 리셋 코드 전송 */
+export const sendPasswordResetCode = (data: SendVerificationCodeRequest) =>
+  apiClient.patch<MessageResponse>('/users/auth/password-reset', data);
+
+/** PATCH /users/auth/password-reset/verify — 비밀번호 리셋 코드 확인 */
+export const verifyPasswordResetCode = (data: VerifyCodeRequest) =>
+  apiClient.patch<MessageResponse>('/users/auth/password-reset/verify', data);
+
+/** POST /users/auth/reset-password — 비밀번호 변경 (레거시, MSW용) */
+export const resetPassword = (data: ChangePasswordRequest) =>
+  apiClient.post<MessageResponse>('/users/auth/reset-password', data);
+
+/** PATCH /users/auth/refresh — 토큰 갱신 */
+export const refreshToken = (data?: RefreshTokenRequest) =>
+  apiClient.patch<RefreshTokenResponse>('/users/auth/refresh', data);
+
+/** DELETE /users — 계정 삭제 */
+export const deleteAccount = () => apiClient.delete<void>('/users');
 
 // === Type Exports ===
 
 export type {
   LoginRequest,
-  RegisterRequest,
+  SignUpRequest,
   SendVerificationCodeRequest,
   VerifyCodeRequest,
-  ResetPasswordRequest,
-  AuthUser,
-  AuthResponse,
-  SendVerificationCodeResponse,
-  VerifyCodeResponse,
-  ResetPasswordResponse,
+  ChangePasswordRequest,
+  RefreshTokenRequest,
+  LoginResponse,
+  SignUpResponse,
+  MessageResponse,
+  RefreshTokenResponse,
 };

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,7 @@
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '/api';
 
+export const ACCESS_TOKEN_KEY = 'jagalchi-access-token';
+
 interface ApiError {
   message: string;
   status: number;
@@ -26,18 +28,30 @@ class ApiClientError extends Error {
 /** localStorage에서 액세스 토큰 읽기 */
 function getAccessToken(): string | null {
   if (typeof window === 'undefined') return null;
-  return localStorage.getItem('jagalchi-access-token');
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
 }
 
-/** 액세스 토큰 저장 */
+/** 액세스 토큰 저장 (localStorage + 미들웨어용 쿠키) */
 export function setAccessToken(token: string): void {
-  localStorage.setItem('jagalchi-access-token', token);
+  localStorage.setItem(ACCESS_TOKEN_KEY, token);
+  if (typeof document !== 'undefined') {
+    document.cookie = `${ACCESS_TOKEN_KEY}=${token}; path=/; SameSite=Strict`;
+  }
 }
 
-/** 액세스 토큰 삭제 */
+/** 액세스 토큰 삭제 (localStorage + 쿠키) */
 export function clearAccessToken(): void {
-  localStorage.removeItem('jagalchi-access-token');
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  if (typeof document !== 'undefined') {
+    document.cookie = `${ACCESS_TOKEN_KEY}=; path=/; max-age=0`;
+  }
 }
+
+/** 인증 엔드포인트 여부 (401 시 리다이렉트 스킵) */
+const isAuthEndpoint = (endpoint: string): boolean =>
+  endpoint.includes('/users/auth/') ||
+  endpoint === '/users' ||
+  endpoint.includes('/users/verification');
 
 async function request<T>(
   endpoint: string,
@@ -63,14 +77,19 @@ async function request<T>(
     },
   });
 
-  if (response.status === 401) {
-    clearAccessToken();
-    if (typeof window !== 'undefined' && !endpoint.includes('/auth/')) {
-      window.location.href = '/login';
-    }
-  }
-
   if (!response.ok) {
+    if (response.status === 401 && !isAuthEndpoint(endpoint)) {
+      clearAccessToken();
+      if (typeof window !== 'undefined') {
+        window.location.href = '/login';
+      }
+      throw new ApiClientError({
+        message: '인증이 만료되었습니다',
+        status: 401,
+        code: 'AUTH_REQUIRED',
+      });
+    }
+
     const errorBody = (await response.json().catch(() => ({
       message: '알 수 없는 오류가 발생했습니다',
     }))) as { message: string; code?: string };

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,6 +3,7 @@ const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '/api';
 interface ApiError {
   message: string;
   status: number;
+  code?: string;
 }
 
 interface RequestOptions {
@@ -12,12 +13,30 @@ interface RequestOptions {
 
 class ApiClientError extends Error {
   status: number;
+  code?: string;
 
-  constructor({ message, status }: ApiError) {
+  constructor({ message, status, code }: ApiError) {
     super(message);
     this.name = 'ApiClientError';
     this.status = status;
+    this.code = code;
   }
+}
+
+/** localStorage에서 액세스 토큰 읽기 */
+function getAccessToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('jagalchi-access-token');
+}
+
+/** 액세스 토큰 저장 */
+export function setAccessToken(token: string): void {
+  localStorage.setItem('jagalchi-access-token', token);
+}
+
+/** 액세스 토큰 삭제 */
+export function clearAccessToken(): void {
+  localStorage.removeItem('jagalchi-access-token');
 }
 
 async function request<T>(
@@ -31,23 +50,40 @@ async function request<T>(
 ): Promise<T> {
   const url = `${BASE_URL}${endpoint}`;
 
+  const token = getAccessToken();
+  const authHeader: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+
   const response = await fetch(url, {
     ...init,
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
+      ...authHeader,
       ...init.headers,
     },
   });
 
+  if (response.status === 401) {
+    clearAccessToken();
+    if (typeof window !== 'undefined' && !endpoint.includes('/auth/')) {
+      window.location.href = '/login';
+    }
+  }
+
   if (!response.ok) {
     const errorBody = (await response.json().catch(() => ({
       message: '알 수 없는 오류가 발생했습니다',
-    }))) as { message: string };
+    }))) as { message: string; code?: string };
 
     throw new ApiClientError({
       message: errorBody.message,
       status: response.status,
+      code: errorBody.code,
     });
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
   }
 
   return response.json() as Promise<T>;
@@ -68,6 +104,13 @@ export const apiClient = {
     request<T>(endpoint, {
       ...options,
       method: 'PUT',
+      body: body ? JSON.stringify(body) : undefined,
+    }),
+
+  patch: <T>(endpoint: string, body?: unknown, options?: RequestOptions) =>
+    request<T>(endpoint, {
+      ...options,
+      method: 'PATCH',
       body: body ? JSON.stringify(body) : undefined,
     }),
 

--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -1,0 +1,100 @@
+import { apiClient } from './client';
+
+// === Request Types (aligned with docs/api.md) ===
+
+interface UpdateProfileRequest {
+  user: {
+    profileImage?: string;
+    bio?: string;
+    externalLinks?: Record<string, string>;
+  };
+}
+
+interface FollowToggleRequest {
+  toggle: boolean;
+}
+
+// === Response Types ===
+
+interface UserStats {
+  followersCount: number;
+  followingCount: number;
+}
+
+interface QueryUserDto {
+  name: string;
+  email: string;
+  profileImageUrl: string | null;
+  bio: string | null;
+  isFollowed: boolean;
+  stats: UserStats;
+  externalLinks: Record<string, string>;
+}
+
+interface StreakActivity {
+  date: string;
+  count: number;
+}
+
+interface StreakResponseDto {
+  currentStreak: number;
+  activities: StreakActivity[];
+}
+
+interface QueryUserResponse {
+  user: QueryUserDto;
+  streak: StreakResponseDto;
+}
+
+interface MessageResponse {
+  message: string;
+}
+
+interface FollowUserResponse {
+  id: number;
+  name: string;
+  profileImage: string | null;
+  isFollowing: boolean;
+}
+
+interface FollowListResponse {
+  userId: number;
+  type: 'FOLLOWERS' | 'FOLLOWINGS';
+  totalCount: number;
+  users: FollowUserResponse[];
+}
+
+// === API Functions ===
+
+/** GET /users?name={name} — 사용자 프로필 조회 */
+export const getProfile = (name: string) =>
+  apiClient.get<QueryUserResponse>(`/users?name=${encodeURIComponent(name)}`);
+
+/** PATCH /users/profile — 프로필 수정 */
+export const updateProfile = (data: UpdateProfileRequest) =>
+  apiClient.patch<MessageResponse>('/users/profile', data);
+
+/** PATCH /users/{name}/follow — 팔로우 토글 */
+export const toggleFollow = (name: string, data: FollowToggleRequest) =>
+  apiClient.patch<MessageResponse>(`/users/${encodeURIComponent(name)}/follow`, data);
+
+/** GET /users/{name}/followers — 팔로워 목록 */
+export const getFollowers = (name: string) =>
+  apiClient.get<FollowListResponse>(`/users/${encodeURIComponent(name)}/followers`);
+
+/** GET /users/{name}/followings — 팔로잉 목록 */
+export const getFollowings = (name: string) =>
+  apiClient.get<FollowListResponse>(`/users/${encodeURIComponent(name)}/followings`);
+
+// === Type Exports ===
+
+export type {
+  UpdateProfileRequest,
+  FollowToggleRequest,
+  QueryUserDto,
+  QueryUserResponse,
+  StreakResponseDto,
+  StreakActivity,
+  FollowUserResponse,
+  FollowListResponse,
+};

--- a/src/api/roadmap.ts
+++ b/src/api/roadmap.ts
@@ -1,0 +1,20 @@
+import { apiClient } from './client';
+
+// === Types (aligned with docs/api.md Node service) ===
+
+interface RoadmapEvent {
+  type: string;
+  eventId: string;
+  sequence: number;
+  payload: Record<string, unknown>;
+}
+
+// === API Functions ===
+
+/** GET /api/roadmap/{roadmapId}/events?since={sequence} — 이벤트 히스토리 조회 */
+export const getRoadmapEvents = (roadmapId: string, since = 0) =>
+  apiClient.get<RoadmapEvent[]>(`/roadmap/${roadmapId}/events?since=${since}`);
+
+// === Type Exports ===
+
+export type { RoadmapEvent };

--- a/src/app/(myroadmap)/myroadmap/page.tsx
+++ b/src/app/(myroadmap)/myroadmap/page.tsx
@@ -9,6 +9,7 @@ import { MyRoadmapsLayout } from '@/features/my-roadmaps/components/templates';
 import {
   filterCategoryAtom,
   myRoadmapItemsAtom,
+  searchQueryAtom,
   sidebarCategoryAtom,
   sortByAtom,
   sortOrderAtom,
@@ -20,6 +21,7 @@ export default function MyRoadmapsPage() {
   const sortOrder = useAtomValue(sortOrderAtom);
   const sortBy = useAtomValue(sortByAtom);
   const filterCategory = useAtomValue(filterCategoryAtom);
+  const searchQuery = useAtomValue(searchQueryAtom);
 
   const filteredRoadmaps = items
     .filter((roadmap) => {
@@ -54,6 +56,12 @@ export default function MyRoadmapsPage() {
         if (!typeMatch) return false;
       }
 
+      // 3. Search Query Filter
+      if (searchQuery.trim()) {
+        const query = searchQuery.trim().toLowerCase();
+        if (!roadmap.title.toLowerCase().includes(query)) return false;
+      }
+
       return true;
     })
     .sort((a, b) => {
@@ -83,7 +91,10 @@ export default function MyRoadmapsPage() {
         <div className="flex-1 px-20 pb-20">
           <MyRoadmapsToolbar />
           <div className="mt-6">
-            <MyRoadmapsGrid roadmaps={filteredRoadmaps} />
+            <MyRoadmapsGrid
+              roadmaps={filteredRoadmaps}
+              isSearching={searchQuery.trim().length > 0}
+            />
           </div>
         </div>
       </div>

--- a/src/app/(myroadmap)/myroadmap/page.tsx
+++ b/src/app/(myroadmap)/myroadmap/page.tsx
@@ -1,7 +1,12 @@
 'use client';
 
-import { useAtomValue } from 'jotai';
+import { useMemo } from 'react';
 
+import { useRouter } from 'next/navigation';
+
+import { useAtomValue, useSetAtom } from 'jotai';
+
+import { logoutAtom } from '@/features/auth';
 import { MyRoadmapsToolbar } from '@/features/my-roadmaps/components/molecules/MyRoadmapsToolbar';
 import { MyRoadmapsGrid } from '@/features/my-roadmaps/components/organisms/MyRoadmapsGrid';
 import { MyRoadmapsHeader } from '@/features/my-roadmaps/components/organisms/MyRoadmapsHeader';
@@ -16,6 +21,8 @@ import {
 } from '@/features/my-roadmaps/stores/my-roadmaps.atoms';
 
 export default function MyRoadmapsPage() {
+  const router = useRouter();
+  const logout = useSetAtom(logoutAtom);
   const items = useAtomValue(myRoadmapItemsAtom);
   const activeCategory = useAtomValue(sidebarCategoryAtom);
   const sortOrder = useAtomValue(sortOrderAtom);
@@ -23,78 +30,87 @@ export default function MyRoadmapsPage() {
   const filterCategory = useAtomValue(filterCategoryAtom);
   const searchQuery = useAtomValue(searchQueryAtom);
 
-  const filteredRoadmaps = items
-    .filter((roadmap) => {
-      // 1. Sidebar Category Filter
-      let categoryMatch = false;
-      switch (activeCategory) {
-        case 'recent':
-          categoryMatch = true;
-          break;
-        case 'community':
-          categoryMatch = roadmap.category === 'community';
-          break;
-        case 'my-roadmap':
-          categoryMatch = roadmap.category === 'my-roadmap';
-          break;
-        case 'shared':
-          categoryMatch = !!roadmap.isShared;
-          break;
-        case 'favorites':
-          categoryMatch = !!roadmap.isFavorite;
-          break;
-        default:
-          categoryMatch = true;
-      }
+  const handleLogout = () => {
+    logout();
+    router.push('/login');
+  };
 
-      if (!categoryMatch) return false;
+  const filteredRoadmaps = useMemo(
+    () =>
+      items
+        .filter((roadmap) => {
+          // 1. Sidebar Category Filter
+          let categoryMatch = false;
+          switch (activeCategory) {
+            case 'recent':
+              categoryMatch = true;
+              break;
+            case 'community':
+              categoryMatch = roadmap.category === 'community';
+              break;
+            case 'my-roadmap':
+              categoryMatch = roadmap.category === 'my-roadmap';
+              break;
+            case 'shared':
+              categoryMatch = !!roadmap.isShared;
+              break;
+            case 'favorites':
+              categoryMatch = !!roadmap.isFavorite;
+              break;
+            default:
+              categoryMatch = true;
+          }
 
-      // 2. Toolbar Category Filter
-      if (filterCategory !== 'all') {
-        const typeMatch =
-          filterCategory === 'roadmap' ? roadmap.type === 'Roadmap' : roadmap.type === 'Directory';
-        if (!typeMatch) return false;
-      }
+          if (!categoryMatch) return false;
 
-      // 3. Search Query Filter
-      if (searchQuery.trim()) {
-        const query = searchQuery.trim().toLowerCase();
-        if (!roadmap.title.toLowerCase().includes(query)) return false;
-      }
+          // 2. Toolbar Category Filter
+          if (filterCategory !== 'all') {
+            const typeMatch =
+              filterCategory === 'roadmap'
+                ? roadmap.type === 'Roadmap'
+                : roadmap.type === 'Directory';
+            if (!typeMatch) return false;
+          }
 
-      return true;
-    })
-    .sort((a, b) => {
-      // 3. Sorting
-      let comparison = 0;
-      switch (sortBy) {
-        case 'recent':
-          comparison = new Date(b.updatedAt || 0).getTime() - new Date(a.updatedAt || 0).getTime();
-          break;
-        case 'name':
-          comparison = (b.title || '').localeCompare(a.title || '');
-          break;
-        case 'size':
-          comparison = (b.fileCount || 0) - (a.fileCount || 0);
-          break;
-        default:
-          comparison = 0;
-      }
+          // 3. Search Query Filter
+          if (searchQuery.trim()) {
+            const lowerQuery = searchQuery.toLowerCase();
+            if (!roadmap.title.toLowerCase().includes(lowerQuery)) return false;
+          }
 
-      return sortOrder === 'asc' ? -comparison : comparison;
-    });
+          return true;
+        })
+        .sort((a, b) => {
+          // 4. Sorting
+          let comparison = 0;
+          switch (sortBy) {
+            case 'recent':
+              comparison =
+                new Date(b.updatedAt || 0).getTime() - new Date(a.updatedAt || 0).getTime();
+              break;
+            case 'name':
+              comparison = (b.title || '').localeCompare(a.title || '');
+              break;
+            case 'size':
+              comparison = (b.fileCount || 0) - (a.fileCount || 0);
+              break;
+            default:
+              comparison = 0;
+          }
+
+          return sortOrder === 'asc' ? -comparison : comparison;
+        }),
+    [items, sortOrder, sortBy, filterCategory, activeCategory, searchQuery],
+  );
 
   return (
-    <MyRoadmapsLayout>
+    <MyRoadmapsLayout onLogout={handleLogout}>
       <div className="flex h-full flex-col">
         <MyRoadmapsHeader />
         <div className="flex-1 px-20 pb-20">
           <MyRoadmapsToolbar />
           <div className="mt-6">
-            <MyRoadmapsGrid
-              roadmaps={filteredRoadmaps}
-              isSearching={searchQuery.trim().length > 0}
-            />
+            <MyRoadmapsGrid roadmaps={filteredRoadmaps} />
           </div>
         </div>
       </div>

--- a/src/components/roadmap/nodes/DetailNodeBase/index.tsx
+++ b/src/components/roadmap/nodes/DetailNodeBase/index.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { memo } from 'react';
+
+import { Handle, Position } from '@xyflow/react';
+
+import { getNodeColors } from '@/components/roadmap/constants/node-colors';
+import { cn } from '@/lib/utils';
+import type { JagalchiNodeData } from '@/types/roadmap.types';
+
+interface DetailNodeBaseProps {
+  data: JagalchiNodeData;
+  selected?: boolean;
+  children?: React.ReactNode;
+}
+
+export const DetailNodeBase = memo(function DetailNodeBase({
+  data,
+  selected,
+  children,
+}: DetailNodeBaseProps) {
+  const state = selected ? 'focus' : 'default';
+  const colors = getNodeColors(data.variant, state);
+
+  return (
+    <div
+      className={cn(
+        'relative flex min-w-[200px] flex-col gap-1 rounded-lg border-2 px-5 py-3 transition-colors',
+        colors.bg,
+        colors.border,
+        colors.text,
+      )}
+    >
+      <Handle
+        type="source"
+        position={Position.Top}
+        id="top"
+        className={cn('!border-background !h-1.5 !w-1.5 !rounded-[4px] !border-2', colors.handle)}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="bottom"
+        className={cn('!border-background !h-1.5 !w-1.5 !rounded-[4px] !border-2', colors.handle)}
+      />
+
+      <span className="truncate text-base font-bold">{data.label}</span>
+      {data.description && (
+        <span className="line-clamp-2 text-sm opacity-70">{data.description}</span>
+      )}
+
+      {children}
+    </div>
+  );
+});

--- a/src/components/roadmap/nodes/index.ts
+++ b/src/components/roadmap/nodes/index.ts
@@ -1,3 +1,4 @@
 export { JagalchiNodeBase } from './JagalchiNodeBase';
 export { JagalchiSectionBase } from './JagalchiSectionBase';
 export { JagalchiTextBase } from './JagalchiTextBase';
+export { DetailNodeBase } from './DetailNodeBase';

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import * as React from 'react';
+
+import { AlertDialog as AlertDialogPrimitive } from 'radix-ui';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: 'default' | 'sm';
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          'group/alert-dialog-content bg-background data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        'grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        'flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        'text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogMedia({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "bg-muted mb-2 inline-flex size-16 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({
+  className,
+  variant = 'default',
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  );
+}
+
+function AlertDialogCancel({
+  className,
+  variant = 'outline',
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, 'variant' | 'size'>) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -73,6 +73,8 @@ export const VIEWER_MESSAGES = {
   // View mode
   VIEW_CANVAS: '캔버스',
   VIEW_CARDS: '카드',
+  // Sidebar toggle
+  SIDEBAR_OPEN_BUTTON_LABEL: '노드 목록 열기',
 } as const;
 
 export const EDITOR_MESSAGES = {
@@ -80,6 +82,7 @@ export const EDITOR_MESSAGES = {
   SAVE_FAILED: '저장 실패',
   // Phase 1: React Flow 노드 기본값
   FLOW_NODE_DEFAULT_LABEL: '새 노드',
+  FLOW_DETAIL_NODE_DEFAULT_LABEL: '새 상세 노드',
   FLOW_SECTION_DEFAULT_TITLE: '빈 섹션',
   FLOW_TEXT_DEFAULT_CONTENT: '텍스트',
   // Phase 2: Sidebar 라벨

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -21,6 +21,12 @@ export const MY_ROADMAPS_MESSAGES = {
   NEW_DIRECTORY: '디렉토리',
   SHARE_COPIED: '링크가 클립보드에 복사되었습니다',
   SHARE_FAILED: '링크 복사에 실패했습니다',
+  RENAME_PROMPT: '새 이름을 입력하세요',
+  DELETE_CONFIRM: '정말 삭제하시겠습니까?',
+  EMPTY_SEARCH: '검색 결과가 없습니다',
+  EMPTY_SEARCH_DESCRIPTION: '다른 검색어를 입력해보세요',
+  EMPTY_LIST: '로드맵이 없습니다',
+  EMPTY_LIST_DESCRIPTION: 'New 버튼으로 새 로드맵을 만들어보세요',
 } as const;
 
 export const PROFILE_MESSAGES = {

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -2,6 +2,11 @@ export const AUTH_MESSAGES = {
   LOGIN_EMAIL_NOT_FOUND: '존재하지 않는 이메일입니다',
   LOGIN_PASSWORD_MISMATCH: '비밀번호가 일치하지 않습니다',
   LOGIN_FAILED: '로그인에 실패했습니다',
+  VERIFICATION_CODE_SENDING: '전송 중...',
+  VERIFICATION_CODE_SEND: '인증번호 전송',
+  VERIFICATION_CODE_RESEND: '재전송',
+  VERIFICATION_CODE_RESEND_COOLDOWN: '초 후 재전송',
+  LOGOUT: '로그아웃',
 } as const;
 
 export const COMMUNITY_MESSAGES = {
@@ -21,12 +26,16 @@ export const MY_ROADMAPS_MESSAGES = {
   NEW_DIRECTORY: '디렉토리',
   SHARE_COPIED: '링크가 클립보드에 복사되었습니다',
   SHARE_FAILED: '링크 복사에 실패했습니다',
-  RENAME_PROMPT: '새 이름을 입력하세요',
-  DELETE_CONFIRM: '정말 삭제하시겠습니까?',
-  EMPTY_SEARCH: '검색 결과가 없습니다',
-  EMPTY_SEARCH_DESCRIPTION: '다른 검색어를 입력해보세요',
-  EMPTY_LIST: '로드맵이 없습니다',
-  EMPTY_LIST_DESCRIPTION: 'New 버튼으로 새 로드맵을 만들어보세요',
+  // Delete dialog
+  DELETE_TITLE: '정말 삭제하시겠습니까?',
+  DELETE_DESCRIPTION: '이 작업은 되돌릴 수 없습니다.',
+  DELETE_CANCEL: '취소',
+  DELETE_CONFIRM: '삭제',
+  // Rename dialog
+  RENAME_TITLE: '이름 수정',
+  RENAME_CANCEL: '취소',
+  RENAME_CONFIRM: '확인',
+  RENAME_PLACEHOLDER: '새 이름을 입력하세요',
 } as const;
 
 export const PROFILE_MESSAGES = {

--- a/src/features/auth/components/organisms/FindPasswordForm.tsx
+++ b/src/features/auth/components/organisms/FindPasswordForm.tsx
@@ -17,6 +17,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { AUTH_MESSAGES } from '@/constants/messages';
 
 import { useResetPassword } from '../../hooks/use-reset-password';
 import { useVerificationCode } from '../../hooks/use-verification-code';
@@ -39,7 +40,14 @@ export function FindPasswordForm({ onStepChange }: FindPasswordFormProps) {
   const router = useRouter();
   const [step, setStep] = useState<FindPasswordStep>(1);
   const [verifiedEmail, setVerifiedEmail] = useState('');
-  const { isCodeSent, handleSendCode, handleVerifyCode, isSendingCode } = useVerificationCode();
+  const {
+    isCodeSent,
+    handleSendCode,
+    handleVerifyCode,
+    isSendingCode,
+    isCooldownActive,
+    cooldownSeconds,
+  } = useVerificationCode();
   const resetPasswordMutation = useResetPassword();
 
   const step1Form = useForm<FindPasswordStep1Schema>({
@@ -84,6 +92,14 @@ export function FindPasswordForm({ onStepChange }: FindPasswordFormProps) {
       },
     );
   };
+
+  const handleResend = () => {
+    handleSendCode(step1Form.getValues('email'), () => {
+      step1Form.setValue('verificationCode', '');
+    });
+  };
+
+  const isResendDisabled = isCooldownActive || isSendingCode;
 
   if (step === 2) {
     return (
@@ -156,7 +172,7 @@ export function FindPasswordForm({ onStepChange }: FindPasswordFormProps) {
             <FormItem>
               <FormLabel>이메일</FormLabel>
               <FormControl>
-                <Input type="email" placeholder="이메일 입력" {...field} />
+                <Input type="email" placeholder="이메일 입력" disabled={isCodeSent} {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -176,10 +192,13 @@ export function FindPasswordForm({ onStepChange }: FindPasswordFormProps) {
                   <button
                     type="button"
                     aria-label="인증번호 재전송"
-                    className="cursor-pointer text-sm tracking-[0.07px] text-neutral-900 underline transition-colors hover:text-neutral-700"
-                    onClick={() => handleSendCode(step1Form.getValues('email'))}
+                    disabled={isResendDisabled}
+                    className="cursor-pointer text-sm tracking-[0.07px] text-neutral-900 underline transition-colors hover:text-neutral-700 disabled:cursor-not-allowed disabled:text-neutral-400 disabled:no-underline"
+                    onClick={handleResend}
                   >
-                    재전송
+                    {isCooldownActive
+                      ? `${cooldownSeconds}${AUTH_MESSAGES.VERIFICATION_CODE_RESEND_COOLDOWN}`
+                      : AUTH_MESSAGES.VERIFICATION_CODE_RESEND}
                   </button>
                 )}
               </div>
@@ -202,7 +221,9 @@ export function FindPasswordForm({ onStepChange }: FindPasswordFormProps) {
             disabled={isSendingCode}
             onClick={() => handleSendCode(step1Form.getValues('email'))}
           >
-            {isSendingCode ? '전송 중...' : '인증번호 전송'}
+            {isSendingCode
+              ? AUTH_MESSAGES.VERIFICATION_CODE_SENDING
+              : AUTH_MESSAGES.VERIFICATION_CODE_SEND}
           </Button>
         )}
       </form>

--- a/src/features/auth/components/organisms/LoginForm/index.tsx
+++ b/src/features/auth/components/organisms/LoginForm/index.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useSetAtom } from 'jotai';
 import { useForm } from 'react-hook-form';
 
 import { Button } from '@/components/ui/button';
@@ -20,6 +21,7 @@ import { Separator } from '@/components/ui/separator';
 
 import { useLogin } from '../../../hooks/use-login';
 import { loginSchema, type LoginSchema } from '../../../schemas/auth.schema';
+import { loginAtom } from '../../../stores/auth.atoms';
 import { GitHubAuthButton } from '../../atoms/GitHubAuthButton';
 import { GoogleAuthButton } from '../../atoms/GoogleAuthButton';
 import { PasswordInput } from '../../molecules/PasswordInput';
@@ -27,6 +29,7 @@ import { PasswordInput } from '../../molecules/PasswordInput';
 export function LoginForm() {
   const router = useRouter();
   const loginMutation = useLogin();
+  const setLogin = useSetAtom(loginAtom);
 
   const form = useForm<LoginSchema>({
     resolver: zodResolver(loginSchema),
@@ -38,7 +41,8 @@ export function LoginForm() {
 
   const onSubmit = (data: LoginSchema) => {
     loginMutation.mutate(data, {
-      onSuccess: () => {
+      onSuccess: (response) => {
+        setLogin(response.accessToken);
         router.push('/');
       },
       onError: (error) => {

--- a/src/features/auth/components/organisms/RegisterForm.tsx
+++ b/src/features/auth/components/organisms/RegisterForm.tsx
@@ -62,7 +62,10 @@ export function RegisterForm({ onStepChange }: RegisterFormProps) {
       },
       {
         onSuccess: () => {
-          router.push('/');
+          router.push('/login');
+        },
+        onError: () => {
+          // registerMutation.error로 에러 상태 접근 가능
         },
       },
     );

--- a/src/features/auth/components/organisms/RegisterForm.tsx
+++ b/src/features/auth/components/organisms/RegisterForm.tsx
@@ -50,15 +50,15 @@ export function RegisterForm({ onStepChange }: RegisterFormProps) {
     onStepChange?.(3, '사용자 프로필 링크 추가', '사용자 프로필에 표시할 링크를 입력해주세요');
   };
 
-  const completeRegistration = (links?: { name: string; url: string }[]) => {
+  const completeRegistration = (_links?: { name: string; url: string }[]) => {
     if (!step1DataRef.current || !step2DataRef.current) return;
 
+    // TODO: _links는 회원가입 후 프로필 업데이트 API로 별도 처리
     registerMutation.mutate(
       {
         email: step1DataRef.current.email,
+        name: step2DataRef.current.username,
         password: step1DataRef.current.password,
-        username: step2DataRef.current.username,
-        links,
       },
       {
         onSuccess: () => {

--- a/src/features/auth/components/organisms/register-steps/RegisterStep1Form.tsx
+++ b/src/features/auth/components/organisms/register-steps/RegisterStep1Form.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
+import { AUTH_MESSAGES } from '@/constants/messages';
 
 import { useVerificationCode } from '../../../hooks/use-verification-code';
 import { registerStep1Schema, type RegisterStep1Schema } from '../../../schemas/auth.schema';
@@ -33,7 +34,8 @@ export function RegisterStep1Form({
   onGoogleRegister,
   onGitHubRegister,
 }: RegisterStep1FormProps) {
-  const { isCodeSent, handleSendCode, isSendingCode } = useVerificationCode();
+  const { isCodeSent, handleSendCode, isSendingCode, isCooldownActive, cooldownSeconds } =
+    useVerificationCode();
 
   const form = useForm<RegisterStep1Schema>({
     resolver: zodResolver(registerStep1Schema),
@@ -43,6 +45,14 @@ export function RegisterStep1Form({
       verificationCode: '',
     },
   });
+
+  const handleResend = () => {
+    handleSendCode(form.getValues('email'), () => {
+      form.setValue('verificationCode', '');
+    });
+  };
+
+  const isResendDisabled = isCooldownActive || isSendingCode;
 
   return (
     <Form {...form}>
@@ -54,7 +64,7 @@ export function RegisterStep1Form({
             <FormItem>
               <FormLabel>이메일</FormLabel>
               <FormControl>
-                <Input type="email" placeholder="이메일 입력" {...field} />
+                <Input type="email" placeholder="이메일 입력" disabled={isCodeSent} {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -88,10 +98,13 @@ export function RegisterStep1Form({
                   <button
                     type="button"
                     aria-label="인증번호 재전송"
-                    className="cursor-pointer text-sm tracking-[0.07px] text-neutral-900 underline transition-colors hover:text-neutral-700"
-                    onClick={() => handleSendCode(form.getValues('email'))}
+                    disabled={isResendDisabled}
+                    className="cursor-pointer text-sm tracking-[0.07px] text-neutral-900 underline transition-colors hover:text-neutral-700 disabled:cursor-not-allowed disabled:text-neutral-400 disabled:no-underline"
+                    onClick={handleResend}
                   >
-                    재전송
+                    {isCooldownActive
+                      ? `${cooldownSeconds}${AUTH_MESSAGES.VERIFICATION_CODE_RESEND_COOLDOWN}`
+                      : AUTH_MESSAGES.VERIFICATION_CODE_RESEND}
                   </button>
                 )}
               </div>
@@ -115,7 +128,9 @@ export function RegisterStep1Form({
               disabled={isSendingCode}
               onClick={() => handleSendCode(form.getValues('email'))}
             >
-              {isSendingCode ? '전송 중...' : '인증번호 전송'}
+              {isSendingCode
+                ? AUTH_MESSAGES.VERIFICATION_CODE_SENDING
+                : AUTH_MESSAGES.VERIFICATION_CODE_SEND}
             </Button>
           )}
           <Separator className="my-2" />

--- a/src/features/auth/hooks/use-login.ts
+++ b/src/features/auth/hooks/use-login.ts
@@ -1,10 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { login } from '@/api/auth';
-import type { AuthResponse, LoginRequest } from '@/api/auth';
+import type { LoginRequest, LoginResponse } from '@/api/auth';
 
 export function useLogin() {
-  return useMutation<AuthResponse, Error, LoginRequest>({
+  return useMutation<LoginResponse, Error, LoginRequest>({
     mutationFn: login,
   });
 }

--- a/src/features/auth/hooks/use-register.ts
+++ b/src/features/auth/hooks/use-register.ts
@@ -1,10 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { register } from '@/api/auth';
-import type { AuthResponse, RegisterRequest } from '@/api/auth';
+import { signUp } from '@/api/auth';
+import type { SignUpRequest, SignUpResponse } from '@/api/auth';
 
 export function useRegister() {
-  return useMutation<AuthResponse, Error, RegisterRequest>({
-    mutationFn: register,
+  return useMutation<SignUpResponse, Error, SignUpRequest>({
+    mutationFn: signUp,
   });
 }

--- a/src/features/auth/hooks/use-reset-password.ts
+++ b/src/features/auth/hooks/use-reset-password.ts
@@ -1,10 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { resetPassword } from '@/api/auth';
-import type { ResetPasswordRequest, ResetPasswordResponse } from '@/api/auth';
+import type { ChangePasswordRequest, MessageResponse } from '@/api/auth';
 
 export function useResetPassword() {
-  return useMutation<ResetPasswordResponse, Error, ResetPasswordRequest>({
+  return useMutation<MessageResponse, Error, ChangePasswordRequest>({
     mutationFn: resetPassword,
   });
 }

--- a/src/features/auth/hooks/use-send-verification-code.ts
+++ b/src/features/auth/hooks/use-send-verification-code.ts
@@ -1,10 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { sendVerificationCode } from '@/api/auth';
-import type { SendVerificationCodeRequest, SendVerificationCodeResponse } from '@/api/auth';
+import type { MessageResponse, SendVerificationCodeRequest } from '@/api/auth';
 
 export function useSendVerificationCode() {
-  return useMutation<SendVerificationCodeResponse, Error, SendVerificationCodeRequest>({
+  return useMutation<MessageResponse, Error, SendVerificationCodeRequest>({
     mutationFn: sendVerificationCode,
   });
 }

--- a/src/features/auth/hooks/use-verification-code.ts
+++ b/src/features/auth/hooks/use-verification-code.ts
@@ -1,25 +1,61 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useSendVerificationCode } from './use-send-verification-code';
 import { useVerifyCode } from './use-verify-code';
 
+const RESEND_COOLDOWN_SECONDS = 30;
+
 /**
  * Manages the state and logic for sending and verifying verification codes during authentication.
- * @returns Object containing the code sent state, handlers, and mutation states
+ * Includes a 30-second resend cooldown and resets the code field on resend.
+ * @returns Object containing the code sent state, handlers, mutation states, and cooldown info
  */
 export function useVerificationCode() {
   const [isCodeSent, setIsCodeSent] = useState(false);
+  const [cooldownSeconds, setCooldownSeconds] = useState(0);
+  const cooldownTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const sendCodeMutation = useSendVerificationCode();
   const verifyCodeMutation = useVerifyCode();
 
-  const handleSendCode = (email: string) => {
+  const startCooldown = useCallback(() => {
+    setCooldownSeconds(RESEND_COOLDOWN_SECONDS);
+    if (cooldownTimerRef.current) {
+      clearInterval(cooldownTimerRef.current);
+    }
+    cooldownTimerRef.current = setInterval(() => {
+      setCooldownSeconds((prev) => {
+        if (prev <= 1) {
+          if (cooldownTimerRef.current) {
+            clearInterval(cooldownTimerRef.current);
+            cooldownTimerRef.current = null;
+          }
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (cooldownTimerRef.current) {
+        clearInterval(cooldownTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleSendCode = (email: string, onResend?: () => void) => {
     sendCodeMutation.mutate(
       { email },
       {
         onSuccess: () => {
+          if (isCodeSent && onResend) {
+            onResend();
+          }
           setIsCodeSent(true);
+          startCooldown();
         },
       },
     );
@@ -29,6 +65,8 @@ export function useVerificationCode() {
     return verifyCodeMutation.mutateAsync({ email, code });
   };
 
+  const isCooldownActive = cooldownSeconds > 0;
+
   return {
     isCodeSent,
     handleSendCode,
@@ -37,5 +75,7 @@ export function useVerificationCode() {
     isVerifyingCode: verifyCodeMutation.isPending,
     sendCodeError: sendCodeMutation.error,
     verifyCodeError: verifyCodeMutation.error,
+    cooldownSeconds,
+    isCooldownActive,
   };
 }

--- a/src/features/auth/hooks/use-verify-code.ts
+++ b/src/features/auth/hooks/use-verify-code.ts
@@ -1,10 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { verifyCode } from '@/api/auth';
-import type { VerifyCodeRequest, VerifyCodeResponse } from '@/api/auth';
+import type { MessageResponse, VerifyCodeRequest } from '@/api/auth';
 
 export function useVerifyCode() {
-  return useMutation<VerifyCodeResponse, Error, VerifyCodeRequest>({
+  return useMutation<MessageResponse, Error, VerifyCodeRequest>({
     mutationFn: verifyCode,
   });
 }

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -7,6 +7,9 @@ export { LoginForm } from './components/organisms/LoginForm';
 export { RegisterForm } from './components/organisms/RegisterForm';
 export { FindPasswordForm } from './components/organisms/FindPasswordForm';
 
+// Stores
+export { isAuthenticatedAtom, loginAtom, logoutAtom } from './stores/auth.atoms';
+
 export type { RegisterStep, FindPasswordStep } from './types/auth.types';
 export type {
   LoginSchema,

--- a/src/features/auth/schemas/auth.schema.ts
+++ b/src/features/auth/schemas/auth.schema.ts
@@ -11,6 +11,7 @@ export const registerStep1Schema = z.object({
     .string()
     .min(1, '비밀번호를 입력해주세요')
     .min(8, '8자 이상 영문, 숫자, 기호를 포함해야 합니다')
+    .max(128, '비밀번호는 128자 이하로 입력해주세요')
     .regex(/[a-zA-Z]/, '8자 이상 영문, 숫자, 기호를 포함해야 합니다')
     .regex(/[0-9]/, '8자 이상 영문, 숫자, 기호를 포함해야 합니다')
     .regex(/[^a-zA-Z0-9]/, '8자 이상 영문, 숫자, 기호를 포함해야 합니다'),
@@ -18,7 +19,11 @@ export const registerStep1Schema = z.object({
 });
 
 export const registerStep2Schema = z.object({
-  username: z.string().min(1, '이름을 입력해주세요'),
+  username: z
+    .string()
+    .min(1, '이름을 입력해주세요')
+    .transform((val) => val.trim())
+    .pipe(z.string().min(1, '이름을 입력해주세요')),
 });
 
 export const registerStep3Schema = z.object({
@@ -41,6 +46,7 @@ export const findPasswordStep2Schema = z
       .string()
       .min(1, '비밀번호를 입력해주세요')
       .min(8, '8자 이상 영문, 숫자, 기호를 포함해야 합니다')
+      .max(128, '비밀번호는 128자 이하로 입력해주세요')
       .regex(/[a-zA-Z]/, '8자 이상 영문, 숫자, 기호를 포함해야 합니다')
       .regex(/[0-9]/, '8자 이상 영문, 숫자, 기호를 포함해야 합니다')
       .regex(/[^a-zA-Z0-9]/, '8자 이상 영문, 숫자, 기호를 포함해야 합니다'),

--- a/src/features/auth/stores/auth.atoms.ts
+++ b/src/features/auth/stores/auth.atoms.ts
@@ -1,0 +1,26 @@
+import { atom } from 'jotai';
+
+import { setAccessToken, clearAccessToken } from '@/api/client';
+
+/** 현재 로그인 상태 (토큰 존재 여부 기반) */
+export const isAuthenticatedAtom = atom<boolean>((get) => {
+  const token = get(accessTokenAtom);
+  return token !== null;
+});
+
+/** 액세스 토큰 atom — localStorage와 동기화 */
+const accessTokenAtom = atom<string | null>(
+  typeof window !== 'undefined' ? localStorage.getItem('jagalchi-access-token') : null,
+);
+
+/** 로그인 시 토큰 저장 */
+export const loginAtom = atom(null, (_get, set, token: string) => {
+  set(accessTokenAtom, token);
+  setAccessToken(token);
+});
+
+/** 로그아웃 시 토큰 삭제 + 상태 초기화 */
+export const logoutAtom = atom(null, (_get, set) => {
+  set(accessTokenAtom, null);
+  clearAccessToken();
+});

--- a/src/features/auth/stores/auth.atoms.ts
+++ b/src/features/auth/stores/auth.atoms.ts
@@ -1,17 +1,16 @@
 import { atom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
 
-import { setAccessToken, clearAccessToken } from '@/api/client';
+import { ACCESS_TOKEN_KEY, setAccessToken, clearAccessToken } from '@/api/client';
+
+/** 액세스 토큰 atom — localStorage와 자동 동기화 (SSR 안전) */
+const accessTokenAtom = atomWithStorage<string | null>(ACCESS_TOKEN_KEY, null);
 
 /** 현재 로그인 상태 (토큰 존재 여부 기반) */
 export const isAuthenticatedAtom = atom<boolean>((get) => {
   const token = get(accessTokenAtom);
   return token !== null;
 });
-
-/** 액세스 토큰 atom — localStorage와 동기화 */
-const accessTokenAtom = atom<string | null>(
-  typeof window !== 'undefined' ? localStorage.getItem('jagalchi-access-token') : null,
-);
 
 /** 로그인 시 토큰 저장 */
 export const loginAtom = atom(null, (_get, set, token: string) => {

--- a/src/features/community/components/atoms/RoadmapCard/index.tsx
+++ b/src/features/community/components/atoms/RoadmapCard/index.tsx
@@ -18,7 +18,7 @@ export function RoadmapCard({ id, title, author, imageUrl, className }: RoadmapC
     <Link href={`/community/${id}`} className="block">
       <div
         className={cn(
-          'h-[200px] w-[304px] cursor-pointer overflow-hidden rounded-lg border border-[#e2e8f0] bg-[#f1f5f9]',
+          'h-full w-full cursor-pointer overflow-hidden rounded-lg border border-[#e2e8f0] bg-[#f1f5f9]',
           className,
         )}
       >

--- a/src/features/community/components/molecules/CommunityHero/index.tsx
+++ b/src/features/community/components/molecules/CommunityHero/index.tsx
@@ -67,9 +67,9 @@ export function CommunityHero() {
           어떤 로드맵을 찾고있나요?
         </h1>
 
-        <div className="relative w-[640px]">
+        <div className="relative w-full max-w-[640px] px-4">
           <div className="flex items-start gap-2 overflow-hidden rounded-xl border border-[#cbd5e1] bg-white p-2 shadow-md">
-            <div className="flex min-h-[32px] w-[580px] items-center gap-1.5 overflow-hidden rounded-lg bg-white px-2">
+            <div className="flex min-h-[32px] flex-1 items-center gap-1.5 overflow-hidden rounded-lg bg-white px-2">
               <Search className="h-5 w-5 shrink-0 text-[#64748b]" />
               <Input
                 type="text"

--- a/src/features/community/components/organisms/CommunityGrid/index.tsx
+++ b/src/features/community/components/organisms/CommunityGrid/index.tsx
@@ -18,9 +18,9 @@ export function CommunityGrid({ items }: CommunityGridProps) {
   }
 
   return (
-    <div className="grid w-full max-w-[960px] grid-cols-3 gap-x-6 gap-y-6">
+    <div className="grid w-full max-w-[960px] grid-cols-1 gap-x-6 gap-y-6 md:grid-cols-2 lg:grid-cols-3">
       {items.map((item) => (
-        <div key={item.id} className="h-[200px] w-[304px]">
+        <div key={item.id} className="h-auto w-full">
           <RoadmapCard
             id={item.id}
             title={item.title}

--- a/src/features/community/components/templates/RoadmapDetail/index.tsx
+++ b/src/features/community/components/templates/RoadmapDetail/index.tsx
@@ -22,16 +22,26 @@ interface RoadmapDetailProps {
 
 export function RoadmapDetail({ id }: RoadmapDetailProps) {
   const router = useRouter();
-  const [isLiked, setIsLiked] = useState(false);
   const item = MOCK_COMMUNITY_DATA.find((i) => i.id === id);
+
+  const [isLiked, setIsLiked] = useState(false);
+  const [likeCount, setLikeCount] = useState<number>(item?.likes ?? 0);
 
   if (!item) {
     return (
       <div className="flex h-screen items-center justify-center">
-        <p className="text-lg font-medium text-slate-500">로드맵을 찾을 수 없습니다.</p>
+        <p className="text-lg font-medium text-slate-500">{COMMUNITY_MESSAGES.NOT_FOUND}</p>
       </div>
     );
   }
+
+  const handleLikeToggle = () => {
+    setIsLiked((prev) => {
+      const nextLiked = !prev;
+      setLikeCount((count) => (nextLiked ? count + 1 : count - 1));
+      return nextLiked;
+    });
+  };
 
   return (
     <div className="flex min-h-screen flex-col items-center bg-white">
@@ -43,8 +53,8 @@ export function RoadmapDetail({ id }: RoadmapDetailProps) {
         )}
       </div>
 
-      <div className="flex w-full max-w-[960px] gap-6 px-6 py-10">
-        <div className="flex w-[696px] flex-col">
+      <div className="flex w-full max-w-[960px] flex-col gap-6 px-4 py-10 md:flex-row md:px-6">
+        <div className="flex w-full max-w-[696px] flex-col">
           <div className="mb-4 flex flex-col gap-[16px]">
             <div className="flex items-center justify-between">
               <h1 className="text-foreground text-[24px] leading-[28.8px] font-semibold tracking-[-1px]">
@@ -52,10 +62,10 @@ export function RoadmapDetail({ id }: RoadmapDetailProps) {
               </h1>
               <button
                 type="button"
-                onClick={() => setIsLiked(!isLiked)}
+                onClick={handleLikeToggle}
                 className="flex min-h-[36px] items-center gap-2 rounded-lg px-4 py-[7.5px] text-[14px] font-semibold text-[#334155] hover:bg-slate-50"
               >
-                {item.likes ?? 67}
+                {likeCount}
                 <Heart
                   className={cn('h-[13px] w-[13px]', isLiked && 'fill-red-500 text-red-500')}
                 />
@@ -82,21 +92,24 @@ export function RoadmapDetail({ id }: RoadmapDetailProps) {
           </div>
 
           <section className="flex flex-col gap-[16px]">
-            <h2 className="text-foreground text-[20px] leading-none font-semibold">About</h2>
-            <p className="text-[16px] leading-[24px] text-[#020617]">
-              이 로드맵은 프론트엔드 개발자로 성장하기 위한 학습 경로를 제공합니다. HTML, CSS,
-              JavaScript 기초부터 React, TypeScript, 그리고 최신 웹 개발 트렌드까지 체계적으로
-              학습할 수 있습니다. 단계별 커리큘럼과 실습 프로젝트를 통해 실무에 필요한 역량을
-              효과적으로 쌓을 수 있습니다.
-            </p>
+            <h2 className="text-foreground text-[20px] leading-none font-semibold">
+              {COMMUNITY_MESSAGES.ABOUT}
+            </h2>
+            <p className="text-[16px] leading-[24px] text-[#020617]">{item.description ?? ''}</p>
           </section>
         </div>
 
-        <Separator orientation="vertical" className="bg-border h-auto self-stretch" />
+        <Separator
+          orientation="vertical"
+          className="bg-border hidden h-auto self-stretch md:block"
+        />
+        <Separator className="bg-border md:hidden" />
 
-        <aside className="flex w-[134px] flex-col gap-4">
+        <aside className="flex w-full flex-col gap-4 md:w-[134px]">
           <div className="flex flex-col gap-[24px]">
-            <h3 className="text-foreground text-[20px] leading-none font-semibold">Made by</h3>
+            <h3 className="text-foreground text-[20px] leading-none font-semibold">
+              {COMMUNITY_MESSAGES.MADE_BY}
+            </h3>
             <div className="flex flex-col gap-[16px]">
               <ContributorItem name={item.author} />
               <ContributorItem name="Co-author" />
@@ -107,7 +120,9 @@ export function RoadmapDetail({ id }: RoadmapDetailProps) {
           <Separator className="bg-border" />
 
           <div className="flex flex-col gap-0">
-            <span className="text-xs font-normal text-[#737373]">마지막 업데이트</span>
+            <span className="text-xs font-normal text-[#737373]">
+              {COMMUNITY_MESSAGES.LAST_UPDATED}
+            </span>
             <span className="text-xs font-normal text-[#020617]">2달 전</span>
           </div>
         </aside>

--- a/src/features/community/constants/community.mock.ts
+++ b/src/features/community/constants/community.mock.ts
@@ -8,4 +8,5 @@ export const MOCK_COMMUNITY_DATA: CommunityItem[] = Array.from({ length: 15 }, (
   updatedAt: new Date(2024, 0, 1, 12, 0, 0, i * 1000).toISOString(),
   type: i % 3 === 0 ? 'directory' : 'roadmap',
   size: (i * 3) % 20,
+  description: `이 로드맵은 ${i % 2 === 0 ? `Roadmap ${i + 1}` : `Guide ${i + 1}`} 학습 경로를 제공합니다. 단계별 커리큘럼과 실습 프로젝트를 통해 실무에 필요한 역량을 효과적으로 쌓을 수 있습니다.`,
 }));

--- a/src/features/community/types/community.types.ts
+++ b/src/features/community/types/community.types.ts
@@ -11,4 +11,5 @@ export interface CommunityItem {
   updatedAt: string;
   type: 'roadmap' | 'directory';
   size?: number;
+  description?: string;
 }

--- a/src/features/my-roadmaps/components/atoms/RoadmapCard/index.tsx
+++ b/src/features/my-roadmaps/components/atoms/RoadmapCard/index.tsx
@@ -21,6 +21,7 @@ interface RoadmapCardProps {
   imageUrl?: string;
   isFavorite?: boolean;
   className?: string;
+  onClick?: () => void;
   onFavorite?: () => void;
   onRename?: () => void;
   onMove?: () => void;
@@ -35,6 +36,7 @@ export function RoadmapCard({
   imageUrl,
   isFavorite: _isFavorite,
   className,
+  onClick,
   onFavorite,
   onRename,
   onMove,
@@ -48,6 +50,7 @@ export function RoadmapCard({
         'group relative flex h-[200px] w-[304px] cursor-pointer flex-col gap-0 overflow-hidden rounded-lg border border-[#e2e8f0] bg-[#f1f5f9] p-0 shadow-none transition-all',
         className,
       )}
+      onClick={onClick}
     >
       {/* Thumbnail Area */}
       <div className="relative flex-1 bg-[#f1f5f9]">

--- a/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/index.tsx
+++ b/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/index.tsx
@@ -20,7 +20,11 @@ import { Input } from '@/components/ui/input';
 import { useClickOutside } from '@/hooks/use-click-outside';
 import { cn } from '@/lib/utils';
 
-import { breadcrumbPathAtom, myRoadmapItemsAtom } from '../../../stores/my-roadmaps.atoms';
+import {
+  breadcrumbPathAtom,
+  myRoadmapItemsAtom,
+  searchQueryAtom,
+} from '../../../stores/my-roadmaps.atoms';
 import { AddDirectoryModal } from '../AddDirectoryModal';
 import { AddRoadmapModal } from '../AddRoadmapModal';
 import { MyRoadmapsFilter } from '../MyRoadmapsFilter';
@@ -31,6 +35,7 @@ export function MyRoadmapsToolbar() {
   const router = useRouter();
   const setItems = useSetAtom(myRoadmapItemsAtom);
   const [breadcrumbPath, setBreadcrumbPath] = useAtom(breadcrumbPathAtom);
+  const [searchQuery, setSearchQuery] = useAtom(searchQueryAtom);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isRoadmapModalOpen, setIsRoadmapModalOpen] = useState(false);
   const [isDirectoryModalOpen, setIsDirectoryModalOpen] = useState(false);
@@ -107,6 +112,8 @@ export function MyRoadmapsToolbar() {
             type="search"
             placeholder="로드맵 검색"
             className="border-border h-9 w-[240px] bg-white pl-9 text-xs"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
           />
         </div>
         <div className="relative" ref={filterRef}>

--- a/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/index.tsx
+++ b/src/features/my-roadmaps/components/molecules/MyRoadmapsToolbar/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
+import { MY_ROADMAPS_MESSAGES } from '@/constants/messages';
 import { useClickOutside } from '@/hooks/use-click-outside';
 import { cn } from '@/lib/utils';
 
@@ -35,11 +36,20 @@ export function MyRoadmapsToolbar() {
   const router = useRouter();
   const setItems = useSetAtom(myRoadmapItemsAtom);
   const [breadcrumbPath, setBreadcrumbPath] = useAtom(breadcrumbPathAtom);
-  const [searchQuery, setSearchQuery] = useAtom(searchQueryAtom);
+  const setSearchQuery = useSetAtom(searchQueryAtom);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isRoadmapModalOpen, setIsRoadmapModalOpen] = useState(false);
   const [isDirectoryModalOpen, setIsDirectoryModalOpen] = useState(false);
+  const [localQuery, setLocalQuery] = useState('');
   const filterRef = useRef<HTMLDivElement>(null);
+
+  // Debounce search input by 300ms before updating the shared atom
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSearchQuery(localQuery);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [localQuery, setSearchQuery]);
 
   useClickOutside(filterRef, () => setIsFilterOpen(false));
 
@@ -110,10 +120,10 @@ export function MyRoadmapsToolbar() {
           <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
           <Input
             type="search"
-            placeholder="로드맵 검색"
+            placeholder={MY_ROADMAPS_MESSAGES.SEARCH_PLACEHOLDER}
             className="border-border h-9 w-[240px] bg-white pl-9 text-xs"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            value={localQuery}
+            onChange={(e) => setLocalQuery(e.target.value)}
           />
         </div>
         <div className="relative" ref={filterRef}>

--- a/src/features/my-roadmaps/components/organisms/MyRoadmapsGrid/index.tsx
+++ b/src/features/my-roadmaps/components/organisms/MyRoadmapsGrid/index.tsx
@@ -1,11 +1,70 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useAtom } from 'jotai';
+
+import { MY_ROADMAPS_MESSAGES } from '@/constants/messages';
+
+import { breadcrumbPathAtom, myRoadmapItemsAtom } from '../../../stores/my-roadmaps.atoms';
 import { RoadmapData } from '../../../types/my-roadmaps.types';
 import { RoadmapCard } from '../../atoms/RoadmapCard';
 
 interface MyRoadmapsGridProps {
   roadmaps: RoadmapData[];
+  isSearching?: boolean;
 }
 
-export function MyRoadmapsGrid({ roadmaps }: MyRoadmapsGridProps) {
+export function MyRoadmapsGrid({ roadmaps, isSearching = false }: MyRoadmapsGridProps) {
+  const router = useRouter();
+  const [, setBreadcrumbPath] = useAtom(breadcrumbPathAtom);
+  const [items, setItems] = useAtom(myRoadmapItemsAtom);
+
+  const handleCardClick = (roadmap: RoadmapData) => {
+    if (roadmap.type === 'Directory') {
+      // Enter directory by updating breadcrumb
+      setBreadcrumbPath((prev) => [...prev, { id: roadmap.id, name: roadmap.title }]);
+    } else {
+      // Navigate to editor for roadmaps
+      router.push(`/editor/${roadmap.id}`);
+    }
+  };
+
+  const handleRename = (id: string) => {
+    const newName = window.prompt(MY_ROADMAPS_MESSAGES.RENAME_PROMPT);
+    if (!newName || !newName.trim()) return;
+
+    setItems(items.map((item) => (item.id === id ? { ...item, title: newName.trim() } : item)));
+  };
+
+  const handleDelete = (id: string) => {
+    const confirmed = window.confirm(MY_ROADMAPS_MESSAGES.DELETE_CONFIRM);
+    if (!confirmed) return;
+
+    setItems(items.filter((item) => item.id !== id));
+  };
+
+  const handleFavorite = (id: string) => {
+    setItems(
+      items.map((item) => (item.id === id ? { ...item, isFavorite: !item.isFavorite } : item)),
+    );
+  };
+
+  if (roadmaps.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <p className="text-base font-semibold text-[#020617]">
+          {isSearching ? MY_ROADMAPS_MESSAGES.EMPTY_SEARCH : MY_ROADMAPS_MESSAGES.EMPTY_LIST}
+        </p>
+        <p className="mt-1 text-sm text-[#64748b]">
+          {isSearching
+            ? MY_ROADMAPS_MESSAGES.EMPTY_SEARCH_DESCRIPTION
+            : MY_ROADMAPS_MESSAGES.EMPTY_LIST_DESCRIPTION}
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="grid grid-cols-1 gap-x-14 gap-y-14 md:grid-cols-2 lg:grid-cols-3">
       {roadmaps.map((roadmap) => (
@@ -16,6 +75,11 @@ export function MyRoadmapsGrid({ roadmaps }: MyRoadmapsGridProps) {
           author={roadmap.author}
           fileCount={roadmap.fileCount}
           imageUrl={roadmap.imageUrl}
+          isFavorite={roadmap.isFavorite}
+          onClick={() => handleCardClick(roadmap)}
+          onRename={() => handleRename(roadmap.id)}
+          onDelete={() => handleDelete(roadmap.id)}
+          onFavorite={() => handleFavorite(roadmap.id)}
         />
       ))}
     </div>

--- a/src/features/my-roadmaps/components/organisms/MyRoadmapsGrid/index.tsx
+++ b/src/features/my-roadmaps/components/organisms/MyRoadmapsGrid/index.tsx
@@ -1,87 +1,160 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 
-import { useAtom } from 'jotai';
+import { useSetAtom } from 'jotai';
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { MY_ROADMAPS_MESSAGES } from '@/constants/messages';
 
-import { breadcrumbPathAtom, myRoadmapItemsAtom } from '../../../stores/my-roadmaps.atoms';
-import { RoadmapData } from '../../../types/my-roadmaps.types';
+import { myRoadmapItemsAtom } from '../../../stores/my-roadmaps.atoms';
 import { RoadmapCard } from '../../atoms/RoadmapCard';
+
+import type { RoadmapData } from '../../../types/my-roadmaps.types';
 
 interface MyRoadmapsGridProps {
   roadmaps: RoadmapData[];
-  isSearching?: boolean;
 }
 
-export function MyRoadmapsGrid({ roadmaps, isSearching = false }: MyRoadmapsGridProps) {
-  const router = useRouter();
-  const [, setBreadcrumbPath] = useAtom(breadcrumbPathAtom);
-  const [items, setItems] = useAtom(myRoadmapItemsAtom);
+export function MyRoadmapsGrid({ roadmaps }: MyRoadmapsGridProps) {
+  const setItems = useSetAtom(myRoadmapItemsAtom);
 
-  const handleCardClick = (roadmap: RoadmapData) => {
-    if (roadmap.type === 'Directory') {
-      // Enter directory by updating breadcrumb
-      setBreadcrumbPath((prev) => [...prev, { id: roadmap.id, name: roadmap.title }]);
-    } else {
-      // Navigate to editor for roadmaps
-      router.push(`/editor/${roadmap.id}`);
-    }
+  // Delete dialog state
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+
+  // Rename dialog state
+  const [renameTarget, setRenameTarget] = useState<{ id: string; title: string } | null>(null);
+  const [renameInput, setRenameInput] = useState('');
+
+  const handleDeleteConfirm = () => {
+    if (!deleteTarget) return;
+    setItems((prev) => prev.filter((item) => item.id !== deleteTarget));
+    setDeleteTarget(null);
   };
 
-  const handleRename = (id: string) => {
-    const newName = window.prompt(MY_ROADMAPS_MESSAGES.RENAME_PROMPT);
-    if (!newName || !newName.trim()) return;
-
-    setItems(items.map((item) => (item.id === id ? { ...item, title: newName.trim() } : item)));
+  const handleRenameOpen = (id: string, title: string) => {
+    setRenameTarget({ id, title });
+    setRenameInput(title);
   };
 
-  const handleDelete = (id: string) => {
-    const confirmed = window.confirm(MY_ROADMAPS_MESSAGES.DELETE_CONFIRM);
-    if (!confirmed) return;
-
-    setItems(items.filter((item) => item.id !== id));
-  };
-
-  const handleFavorite = (id: string) => {
-    setItems(
-      items.map((item) => (item.id === id ? { ...item, isFavorite: !item.isFavorite } : item)),
+  const handleRenameConfirm = () => {
+    if (!renameTarget || !renameInput.trim()) return;
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === renameTarget.id ? { ...item, title: renameInput.trim() } : item,
+      ),
     );
+    setRenameTarget(null);
+    setRenameInput('');
   };
-
-  if (roadmaps.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-20 text-center">
-        <p className="text-base font-semibold text-[#020617]">
-          {isSearching ? MY_ROADMAPS_MESSAGES.EMPTY_SEARCH : MY_ROADMAPS_MESSAGES.EMPTY_LIST}
-        </p>
-        <p className="mt-1 text-sm text-[#64748b]">
-          {isSearching
-            ? MY_ROADMAPS_MESSAGES.EMPTY_SEARCH_DESCRIPTION
-            : MY_ROADMAPS_MESSAGES.EMPTY_LIST_DESCRIPTION}
-        </p>
-      </div>
-    );
-  }
 
   return (
-    <div className="grid grid-cols-1 gap-x-14 gap-y-14 md:grid-cols-2 lg:grid-cols-3">
-      {roadmaps.map((roadmap) => (
-        <RoadmapCard
-          key={roadmap.id}
-          title={roadmap.title}
-          type={roadmap.type}
-          author={roadmap.author}
-          fileCount={roadmap.fileCount}
-          imageUrl={roadmap.imageUrl}
-          isFavorite={roadmap.isFavorite}
-          onClick={() => handleCardClick(roadmap)}
-          onRename={() => handleRename(roadmap.id)}
-          onDelete={() => handleDelete(roadmap.id)}
-          onFavorite={() => handleFavorite(roadmap.id)}
-        />
-      ))}
-    </div>
+    <>
+      <div className="grid grid-cols-1 gap-x-14 gap-y-14 md:grid-cols-2 lg:grid-cols-3">
+        {roadmaps.map((roadmap) => (
+          <RoadmapCard
+            key={roadmap.id}
+            id={roadmap.id}
+            title={roadmap.title}
+            type={roadmap.type}
+            author={roadmap.author}
+            fileCount={roadmap.fileCount}
+            imageUrl={roadmap.imageUrl}
+            isFavorite={roadmap.isFavorite}
+            onRename={() => handleRenameOpen(roadmap.id, roadmap.title)}
+            onDelete={() => setDeleteTarget(roadmap.id)}
+            onFavorite={() => {
+              setItems((prev) =>
+                prev.map((item) =>
+                  item.id === roadmap.id ? { ...item, isFavorite: !item.isFavorite } : item,
+                ),
+              );
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{MY_ROADMAPS_MESSAGES.DELETE_TITLE}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {MY_ROADMAPS_MESSAGES.DELETE_DESCRIPTION}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{MY_ROADMAPS_MESSAGES.DELETE_CANCEL}</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleDeleteConfirm}
+            >
+              {MY_ROADMAPS_MESSAGES.DELETE_CONFIRM}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Rename dialog */}
+      <Dialog
+        open={renameTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRenameTarget(null);
+            setRenameInput('');
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-[400px]">
+          <DialogHeader>
+            <DialogTitle>{MY_ROADMAPS_MESSAGES.RENAME_TITLE}</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={renameInput}
+            onChange={(e) => setRenameInput(e.target.value)}
+            placeholder={MY_ROADMAPS_MESSAGES.RENAME_PLACEHOLDER}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleRenameConfirm();
+            }}
+            autoFocus
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setRenameTarget(null);
+                setRenameInput('');
+              }}
+            >
+              {MY_ROADMAPS_MESSAGES.RENAME_CANCEL}
+            </Button>
+            <Button onClick={handleRenameConfirm} disabled={!renameInput.trim()}>
+              {MY_ROADMAPS_MESSAGES.RENAME_CONFIRM}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/features/my-roadmaps/components/organisms/MyRoadmapsSidebar/index.tsx
+++ b/src/features/my-roadmaps/components/organisms/MyRoadmapsSidebar/index.tsx
@@ -1,9 +1,10 @@
 import { useAtom } from 'jotai';
-import { BookOpen, ChevronDown, Clock, Files, Search, Star, Users } from 'lucide-react';
+import { BookOpen, ChevronDown, Clock, Files, LogOut, Search, Star, Users } from 'lucide-react';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
+import { AUTH_MESSAGES } from '@/constants/messages';
 import { cn } from '@/lib/utils';
 
 import { type SidebarCategory, sidebarCategoryAtom } from '../../../stores/my-roadmaps.atoms';
@@ -32,12 +33,14 @@ interface MyRoadmapsSidebarProps {
   className?: string;
   userName?: string;
   userEmail?: string;
+  onLogout?: () => void;
 }
 
 export function MyRoadmapsSidebar({
   className,
   userName = 'UserName',
   userEmail = 'user@example.com',
+  onLogout,
 }: MyRoadmapsSidebarProps) {
   const [activeCategory, setActiveCategory] = useAtom(sidebarCategoryAtom);
 
@@ -96,6 +99,21 @@ export function MyRoadmapsSidebar({
           </div>
         ))}
       </nav>
+
+      {/* Logout */}
+      {onLogout && (
+        <>
+          <Separator className="my-2 mt-auto" />
+          <button
+            type="button"
+            onClick={onLogout}
+            className="flex h-8 w-full items-center gap-2 rounded-md px-3 py-1 text-sm text-[#334155] transition-colors hover:bg-black/5"
+          >
+            <LogOut className="h-5 w-5" />
+            {AUTH_MESSAGES.LOGOUT}
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/src/features/my-roadmaps/components/templates/MyRoadmapsLayout/index.tsx
+++ b/src/features/my-roadmaps/components/templates/MyRoadmapsLayout/index.tsx
@@ -2,12 +2,13 @@ import { MyRoadmapsSidebar } from '../../organisms/MyRoadmapsSidebar';
 
 interface MyRoadmapsLayoutProps {
   children: React.ReactNode;
+  onLogout?: () => void;
 }
 
-export function MyRoadmapsLayout({ children }: MyRoadmapsLayoutProps) {
+export function MyRoadmapsLayout({ children, onLogout }: MyRoadmapsLayoutProps) {
   return (
     <div className="flex min-h-screen">
-      <MyRoadmapsSidebar />
+      <MyRoadmapsSidebar onLogout={onLogout} />
       <div className="flex flex-1 flex-col">{children}</div>
     </div>
   );

--- a/src/features/my-roadmaps/stores/my-roadmaps.atoms.ts
+++ b/src/features/my-roadmaps/stores/my-roadmaps.atoms.ts
@@ -16,6 +16,8 @@ export interface BreadcrumbSegment {
 
 export const breadcrumbPathAtom = atom<BreadcrumbSegment[]>([]);
 
+export const searchQueryAtom = atom<string>('');
+
 export const sortOrderAtom = atom<SortOrder>('desc');
 export const sortByAtom = atom<SortBy>('recent');
 export const filterCategoryAtom = atom<FilterCategory>('all');

--- a/src/features/my-roadmaps/types/my-roadmaps.types.ts
+++ b/src/features/my-roadmaps/types/my-roadmaps.types.ts
@@ -1,12 +1,4 @@
-export interface RoadmapData {
-  id: string;
-  title: string;
-  type?: 'Roadmap' | 'Directory';
-  author?: string;
-  fileCount?: number;
-  imageUrl?: string;
-  updatedAt?: string;
-  isFavorite?: boolean;
-  isShared?: boolean;
-  category?: 'my-roadmap' | 'community';
-}
+import type { RoadmapSummary } from '@/types/roadmap.types';
+
+/** @deprecated RoadmapSummary를 직접 사용하세요 */
+export type RoadmapData = RoadmapSummary;

--- a/src/features/profile/components/atoms/ProfilePicture/index.tsx
+++ b/src/features/profile/components/atoms/ProfilePicture/index.tsx
@@ -27,9 +27,17 @@ export function ProfilePicture({ src, userName, onUpload }: ProfilePictureProps)
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (file && onUpload) {
-      onUpload(file);
+    if (!file) return;
+
+    const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      alert('이미지 파일은 5MB 이하만 업로드할 수 있습니다.');
+      // Reset input so the same file can be re-selected after user chooses a smaller one
+      event.target.value = '';
+      return;
     }
+
+    onUpload?.(file);
   };
 
   const getInitials = (name?: string) => {

--- a/src/features/profile/components/atoms/ProfilePicture/index.tsx
+++ b/src/features/profile/components/atoms/ProfilePicture/index.tsx
@@ -29,10 +29,16 @@ export function ProfilePicture({ src, userName, onUpload }: ProfilePictureProps)
     const file = event.target.files?.[0];
     if (!file) return;
 
+    const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      alert('JPG, PNG, GIF, WEBP 형식만 업로드 가능합니다.');
+      event.target.value = '';
+      return;
+    }
+
     const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
     if (file.size > MAX_FILE_SIZE_BYTES) {
       alert('이미지 파일은 5MB 이하만 업로드할 수 있습니다.');
-      // Reset input so the same file can be re-selected after user chooses a smaller one
       event.target.value = '';
       return;
     }

--- a/src/features/profile/components/molecules/ProfileBio/ProfileBio.test.tsx
+++ b/src/features/profile/components/molecules/ProfileBio/ProfileBio.test.tsx
@@ -3,7 +3,7 @@ import { Provider, WritableAtom } from 'jotai';
 import { useHydrateAtoms } from 'jotai/utils';
 import { describe, it, expect } from 'vitest';
 
-import { profileModeAtom } from '../../../stores/profile-atoms';
+import { profileBioAtom, profileModeAtom } from '../../../stores/profile-atoms';
 
 import { ProfileBio } from './index';
 
@@ -28,8 +28,13 @@ describe('ProfileBio', () => {
 
   it('renders text in view mode', () => {
     render(
-      <Wrapper initialValues={[[profileModeAtom, 'show']]}>
-        <ProfileBio bio={defaultBio} />
+      <Wrapper
+        initialValues={[
+          [profileModeAtom, 'show'],
+          [profileBioAtom, defaultBio],
+        ]}
+      >
+        <ProfileBio />
       </Wrapper>,
     );
     expect(screen.getByText('자기소개')).toBeInTheDocument();
@@ -39,8 +44,13 @@ describe('ProfileBio', () => {
 
   it('renders textarea in edit mode', () => {
     render(
-      <Wrapper initialValues={[[profileModeAtom, 'edit']]}>
-        <ProfileBio bio={defaultBio} />
+      <Wrapper
+        initialValues={[
+          [profileModeAtom, 'edit'],
+          [profileBioAtom, defaultBio],
+        ]}
+      >
+        <ProfileBio />
       </Wrapper>,
     );
     expect(screen.getByText('자기소개')).toBeInTheDocument();
@@ -50,8 +60,13 @@ describe('ProfileBio', () => {
 
   it('updates input value in edit mode', () => {
     render(
-      <Wrapper initialValues={[[profileModeAtom, 'edit']]}>
-        <ProfileBio bio={defaultBio} />
+      <Wrapper
+        initialValues={[
+          [profileModeAtom, 'edit'],
+          [profileBioAtom, defaultBio],
+        ]}
+      >
+        <ProfileBio />
       </Wrapper>,
     );
 

--- a/src/features/profile/components/molecules/ProfileBio/ProfileBio.test.tsx
+++ b/src/features/profile/components/molecules/ProfileBio/ProfileBio.test.tsx
@@ -34,7 +34,7 @@ describe('ProfileBio', () => {
           [profileBioAtom, defaultBio],
         ]}
       >
-        <ProfileBio />
+        <ProfileBio bio={defaultBio} />
       </Wrapper>,
     );
     expect(screen.getByText('자기소개')).toBeInTheDocument();
@@ -50,7 +50,7 @@ describe('ProfileBio', () => {
           [profileBioAtom, defaultBio],
         ]}
       >
-        <ProfileBio />
+        <ProfileBio bio={defaultBio} />
       </Wrapper>,
     );
     expect(screen.getByText('자기소개')).toBeInTheDocument();
@@ -66,7 +66,7 @@ describe('ProfileBio', () => {
           [profileBioAtom, defaultBio],
         ]}
       >
-        <ProfileBio />
+        <ProfileBio bio={defaultBio} />
       </Wrapper>,
     );
 

--- a/src/features/profile/components/molecules/ProfileBio/index.tsx
+++ b/src/features/profile/components/molecules/ProfileBio/index.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 
@@ -12,35 +12,28 @@ import { Textarea } from '@/components/ui/textarea';
 import { PROFILE_MESSAGES } from '@/constants/messages';
 import { cn } from '@/lib/utils';
 
-import { profileBioAtom, profileModeAtom } from '../../../stores/profile-atoms';
+import { profileModeAtom } from '../../../stores/profile-atoms';
 
-export function ProfileBio() {
+interface ProfileBioProps {
+  bio: string;
+  onChange?: (bio: string) => void;
+}
+
+export function ProfileBio({ bio, onChange }: ProfileBioProps) {
   const mode = useAtomValue(profileModeAtom);
-  const [bio, setBio] = useAtom(profileBioAtom);
 
-  const { register, reset, watch } = useForm({
-    defaultValues: {
-      bio,
-    },
+  const { register, reset } = useForm({
+    defaultValues: { bio },
   });
-
-  const userBio = watch('bio');
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const bioRef = useRef<HTMLParagraphElement>(null);
 
-  // Reset form when atom value changes (e.g., cancel restoration)
+  // Sync form when prop value changes (e.g., on cancel/restore)
   useEffect(() => {
     reset({ bio });
   }, [bio, reset]);
-
-  // Sync local form value up to atom in real-time while editing
-  useEffect(() => {
-    if (mode === 'edit') {
-      setBio(userBio);
-    }
-  }, [userBio, mode, setBio]);
 
   useEffect(() => {
     const checkOverflow = () => {
@@ -52,13 +45,18 @@ export function ProfileBio() {
     checkOverflow();
     window.addEventListener('resize', checkOverflow);
     return () => window.removeEventListener('resize', checkOverflow);
-  }, [userBio]);
+  }, [bio]);
 
   if (mode === 'edit') {
     return (
       <div className="flex flex-col gap-4">
         <p className="text-muted-foreground text-sm font-semibold">{PROFILE_MESSAGES.BIO_TITLE}</p>
-        <Textarea className="h-[280px] w-full resize-none" {...register('bio')} />
+        <Textarea
+          className="h-[280px] w-full resize-none"
+          {...register('bio', {
+            onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => onChange?.(e.target.value),
+          })}
+        />
       </div>
     );
   }
@@ -76,11 +74,11 @@ export function ProfileBio() {
           ref={bioRef}
           className={cn(
             'text-justify text-sm leading-relaxed whitespace-pre-wrap',
-            userBio ? 'text-muted-foreground' : 'text-muted-foreground/50',
+            bio ? 'text-muted-foreground' : 'text-muted-foreground/50',
             !isExpanded && 'line-clamp-3',
           )}
         >
-          {userBio || `${PROFILE_MESSAGES.BIO_TITLE}가 없습니다.`}
+          {bio || `${PROFILE_MESSAGES.BIO_TITLE}가 없습니다.`}
         </p>
 
         {(isOverflowing || isExpanded) && (

--- a/src/features/profile/components/molecules/ProfileBio/index.tsx
+++ b/src/features/profile/components/molecules/ProfileBio/index.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-import { useAtomValue } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 
@@ -12,15 +12,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { PROFILE_MESSAGES } from '@/constants/messages';
 import { cn } from '@/lib/utils';
 
-import { profileModeAtom } from '../../../stores/profile-atoms';
+import { profileBioAtom, profileModeAtom } from '../../../stores/profile-atoms';
 
-interface ProfileBioProps {
-  bio: string;
-  onChange?: (bio: string) => void;
-}
-
-export function ProfileBio({ bio, onChange }: ProfileBioProps) {
+export function ProfileBio() {
   const mode = useAtomValue(profileModeAtom);
+  const [bio, setBio] = useAtom(profileBioAtom);
 
   const { register, reset, watch } = useForm({
     defaultValues: {
@@ -34,15 +30,17 @@ export function ProfileBio({ bio, onChange }: ProfileBioProps) {
   const [isOverflowing, setIsOverflowing] = useState(false);
   const bioRef = useRef<HTMLParagraphElement>(null);
 
-  // Update form when prop changes
+  // Reset form when atom value changes (e.g., cancel restoration)
   useEffect(() => {
     reset({ bio });
   }, [bio, reset]);
 
-  // Notify parent of changes
+  // Sync local form value up to atom in real-time while editing
   useEffect(() => {
-    onChange?.(userBio);
-  }, [userBio, onChange]);
+    if (mode === 'edit') {
+      setBio(userBio);
+    }
+  }, [userBio, mode, setBio]);
 
   useEffect(() => {
     const checkOverflow = () => {

--- a/src/features/profile/components/molecules/ProfileCustomBoxArea/index.tsx
+++ b/src/features/profile/components/molecules/ProfileCustomBoxArea/index.tsx
@@ -1,22 +1,20 @@
 'use client';
 
+import { useAtom } from 'jotai';
+
+import { profileLinksAtom, profileOrgAtom } from '../../../stores/profile-atoms';
 import { ProfileCustomLinks } from '../../organisms/ProfileCustomLinks';
 import { ProfileCustomOrganization } from '../ProfileCustomOrganization';
 
 export function ProfileCustomBoxArea() {
+  const [org, setOrg] = useAtom(profileOrgAtom);
+  const [links, setLinks] = useAtom(profileLinksAtom);
+
   return (
     <div className="flex w-full flex-col gap-2">
-      <ProfileCustomOrganization initialValue="부산소프트웨어마이스터고등학교" />
+      <ProfileCustomOrganization initialValue={org} onChange={setOrg} />
 
-      <ProfileCustomLinks
-        initialLinks={[
-          {
-            id: '1',
-            name: '포트폴리오',
-            url: 'https://github.com/jagalchi',
-          },
-        ]}
-      />
+      <ProfileCustomLinks initialLinks={links} onChange={setLinks} />
     </div>
   );
 }

--- a/src/features/profile/components/molecules/ProfileInfoForm/index.tsx
+++ b/src/features/profile/components/molecules/ProfileInfoForm/index.tsx
@@ -63,6 +63,7 @@ export function ProfileInfoForm({
     register,
     reset,
     watch,
+    trigger,
     formState: { errors },
   } = useForm({
     defaultValues: {
@@ -105,8 +106,10 @@ export function ProfileInfoForm({
     setMode('show');
   };
 
-  /** Save edit: persist current values (already synced via atoms) */
-  const handleSave = () => {
+  /** Save edit: validate then persist current values */
+  const handleSave = async () => {
+    const isValid = await trigger();
+    if (!isValid) return;
     if (!userName.trim() || !userEmail.trim()) return;
     setMode('show');
   };

--- a/src/features/profile/components/molecules/ProfileInfoForm/index.tsx
+++ b/src/features/profile/components/molecules/ProfileInfoForm/index.tsx
@@ -2,13 +2,21 @@
 
 import { useEffect } from 'react';
 
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { useForm } from 'react-hook-form';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
-import { profileModeAtom } from '../../../stores/profile-atoms';
+import {
+  profileBioAtom,
+  profileBioSnapshotAtom,
+  profileLinksAtom,
+  profileLinksSnapshotAtom,
+  profileModeAtom,
+  profileOrgAtom,
+  profileOrgSnapshotAtom,
+} from '../../../stores/profile-atoms';
 import { ProfileEditButton } from '../../atoms/ProfileEditButton';
 
 interface ProfileInfoFormProps {
@@ -37,11 +45,26 @@ export function ProfileInfoForm({
 }: ProfileInfoFormProps) {
   const [mode, setMode] = useAtom(profileModeAtom);
 
-  const toggleMode = () => {
-    setMode((prev) => (prev === 'show' ? 'edit' : 'show'));
-  };
+  // Atoms for bio / org / links (read current, set snapshot, restore from snapshot)
+  const [bio, setBio] = useAtom(profileBioAtom);
+  const setBioSnapshot = useSetAtom(profileBioSnapshotAtom);
 
-  const { register, reset, watch } = useForm({
+  const [org, setOrg] = useAtom(profileOrgAtom);
+  const setOrgSnapshot = useSetAtom(profileOrgSnapshotAtom);
+
+  const [links, setLinks] = useAtom(profileLinksAtom);
+  const setLinksSnapshot = useSetAtom(profileLinksSnapshotAtom);
+
+  const [bioSnapshot] = useAtom(profileBioSnapshotAtom);
+  const [orgSnapshot] = useAtom(profileOrgSnapshotAtom);
+  const [linksSnapshot] = useAtom(profileLinksSnapshotAtom);
+
+  const {
+    register,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm({
     defaultValues: {
       name,
       email,
@@ -64,6 +87,29 @@ export function ProfileInfoForm({
   useEffect(() => {
     onEmailChange?.(userEmail);
   }, [userEmail, onEmailChange]);
+
+  /** Enter edit mode: capture snapshot of bio / org / links */
+  const handleEnterEdit = () => {
+    setBioSnapshot(bio);
+    setOrgSnapshot(org);
+    setLinksSnapshot(links);
+    setMode('edit');
+  };
+
+  /** Cancel edit: restore snapshot values and return to show mode */
+  const handleCancel = () => {
+    reset({ name, email });
+    setBio(bioSnapshot);
+    setOrg(orgSnapshot);
+    setLinks(linksSnapshot);
+    setMode('show');
+  };
+
+  /** Save edit: persist current values (already synced via atoms) */
+  const handleSave = () => {
+    if (!userName.trim() || !userEmail.trim()) return;
+    setMode('show');
+  };
 
   return (
     <div>
@@ -88,15 +134,37 @@ export function ProfileInfoForm({
           </div>
 
           <div>
-            <ProfileEditButton variant="show" onClick={toggleMode} />
+            <ProfileEditButton variant="show" onClick={handleEnterEdit} />
           </div>
         </div>
       ) : (
         <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
           <div className="flex flex-col gap-2">
             <div className="flex flex-col gap-2 sm:flex-row">
-              <Input type="text" {...register('name')} aria-label="이름" />
-              <Input type="email" {...register('email')} aria-label="이메일" />
+              <div className="flex flex-col gap-1">
+                <Input
+                  type="text"
+                  {...register('name', { required: true, validate: (v) => v.trim().length > 0 })}
+                  aria-label="이름"
+                  aria-invalid={!!errors.name}
+                />
+                {errors.name && <p className="text-destructive text-xs">이름을 입력해주세요.</p>}
+              </div>
+              <div className="flex flex-col gap-1">
+                <Input
+                  type="email"
+                  {...register('email', {
+                    required: true,
+                    validate: (v) => v.trim().length > 0,
+                    pattern: { value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/, message: '' },
+                  })}
+                  aria-label="이메일"
+                  aria-invalid={!!errors.email}
+                />
+                {errors.email && (
+                  <p className="text-destructive text-xs">올바른 이메일을 입력해주세요.</p>
+                )}
+              </div>
             </div>
 
             <div className="flex flex-row gap-2 sm:gap-4">
@@ -116,14 +184,11 @@ export function ProfileInfoForm({
               type="button"
               variant="outline"
               className="font-semibold"
-              onClick={() => {
-                reset({ name, email });
-                setMode('show');
-              }}
+              onClick={handleCancel}
             >
               취소
             </Button>
-            <Button type="button" className="font-semibold" onClick={() => setMode('show')}>
+            <Button type="button" className="font-semibold" onClick={handleSave}>
               저장
             </Button>
           </div>

--- a/src/features/profile/components/templates/Profile/index.tsx
+++ b/src/features/profile/components/templates/Profile/index.tsx
@@ -4,10 +4,10 @@ import { useEffect } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { ArrowLeft, Pencil } from 'lucide-react';
 
-import { profileModeAtom } from '../../../stores/profile-atoms';
+import { profileBioAtom, profileModeAtom } from '../../../stores/profile-atoms';
 import { ProfileBio } from '../../molecules/ProfileBio';
 import { ProfileCustomBoxArea } from '../../molecules/ProfileCustomBoxArea';
 import { ProfileHeader } from '../../molecules/ProfileHeader';
@@ -26,6 +26,7 @@ const MOCK_USER_DATA = {
 export function Profile() {
   const router = useRouter();
   const mode = useAtomValue(profileModeAtom);
+  const setBio = useSetAtom(profileBioAtom);
 
   // Warn user before leaving the page while in edit mode
   useEffect(() => {
@@ -60,7 +61,7 @@ export function Profile() {
         />
         <div className="flex w-full flex-col gap-6 lg:flex-row lg:gap-[76px]">
           <div className="w-full lg:w-[500px] lg:shrink-0">
-            <ProfileBio />
+            <ProfileBio bio={MOCK_USER_DATA.bio} onChange={setBio} />
           </div>
           <div className="flex-1">
             <ProfileCustomBoxArea />

--- a/src/features/profile/components/templates/Profile/index.tsx
+++ b/src/features/profile/components/templates/Profile/index.tsx
@@ -21,6 +21,7 @@ const MOCK_USER_DATA = {
   email: 'john.doe@example.com',
   followerCount: 3000,
   followingCount: 100,
+  bio: '프론트엔드 개발자 | React, TypeScript 전문\n부산소프트웨어마이스터고등학교 출신',
 };
 
 export function Profile() {

--- a/src/features/profile/components/templates/Profile/index.tsx
+++ b/src/features/profile/components/templates/Profile/index.tsx
@@ -1,9 +1,13 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import { useRouter } from 'next/navigation';
 
+import { useAtomValue } from 'jotai';
 import { ArrowLeft, Pencil } from 'lucide-react';
 
+import { profileModeAtom } from '../../../stores/profile-atoms';
 import { ProfileBio } from '../../molecules/ProfileBio';
 import { ProfileCustomBoxArea } from '../../molecules/ProfileCustomBoxArea';
 import { ProfileHeader } from '../../molecules/ProfileHeader';
@@ -17,11 +21,23 @@ const MOCK_USER_DATA = {
   email: 'john.doe@example.com',
   followerCount: 3000,
   followingCount: 100,
-  bio: '안녕하세요! 새로운 기술을 배우고 공유하는 것을 좋아하는 개발자입니다. 현재 프론트엔드 개발에 집중하고 있으며, 보다 나은 사용자 경험을 제공하기 위해 노력하고 있습니다. React, Next.js, TypeScript를 주력으로 사용하며, 효율적인 컴포넌트 설계와 상태 관리에 관심이 많습니다. 오픈 소스 기여와 기술 블로그 운영을 통해 지식을 나누는 것을 즐깁니다. 함께 성장하는 개발 문화를 지향합니다. 안녕하세요! 새로운 기술을 배우고 공유하는 것을 좋아하는 개발자입니다. 현재 프론트엔드 개발에 집중하고 있으며, 보다 나은 사용자 경험을 제공하기 위해 노력하고 있습니다.',
 };
 
 export function Profile() {
   const router = useRouter();
+  const mode = useAtomValue(profileModeAtom);
+
+  // Warn user before leaving the page while in edit mode
+  useEffect(() => {
+    if (mode !== 'edit') return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [mode]);
 
   return (
     <div className="flex min-h-screen w-full flex-col items-center bg-white">
@@ -42,9 +58,9 @@ export function Profile() {
           followerCount={MOCK_USER_DATA.followerCount}
           followingCount={MOCK_USER_DATA.followingCount}
         />
-        <div className="flex w-full gap-[76px]">
-          <div className="w-[500px] shrink-0">
-            <ProfileBio bio={MOCK_USER_DATA.bio} />
+        <div className="flex w-full flex-col gap-6 lg:flex-row lg:gap-[76px]">
+          <div className="w-full lg:w-[500px] lg:shrink-0">
+            <ProfileBio />
           </div>
           <div className="flex-1">
             <ProfileCustomBoxArea />

--- a/src/features/profile/index.ts
+++ b/src/features/profile/index.ts
@@ -21,9 +21,13 @@ export {
   profileModeAtom,
   profileBioAtom,
   profileOrgAtom,
-  profileLinkAtom,
+  profileLinksAtom,
   profileImageAtom,
+  profileBioSnapshotAtom,
+  profileOrgSnapshotAtom,
+  profileLinksSnapshotAtom,
 } from './stores/profile-atoms';
+export type { ProfileLinkItem } from './stores/profile-atoms';
 export type { Contribution } from './utils/contribution-utils';
 export {
   COLORS,

--- a/src/features/profile/stores/profile-atoms.ts
+++ b/src/features/profile/stores/profile-atoms.ts
@@ -1,9 +1,22 @@
 import { atom } from 'jotai';
 
+export interface ProfileLinkItem {
+  id: string;
+  name: string;
+  url: string;
+}
+
 export const profileModeAtom = atom<'show' | 'edit'>('show');
 export const profileBioAtom = atom(
   '안녕하세요! 새로운 기술을 배우고 공유하는 것을 좋아하는 개발자입니다.',
 );
-export const profileOrgAtom = atom('');
-export const profileLinkAtom = atom('');
+export const profileOrgAtom = atom('부산소프트웨어마이스터고등학교');
+export const profileLinksAtom = atom<ProfileLinkItem[]>([
+  { id: '1', name: '포트폴리오', url: 'https://github.com/jagalchi' },
+]);
 export const profileImageAtom = atom('/profile.svg');
+
+/** Snapshot atoms — store values captured when entering edit mode for cancel restoration */
+export const profileBioSnapshotAtom = atom('');
+export const profileOrgSnapshotAtom = atom('');
+export const profileLinksSnapshotAtom = atom<ProfileLinkItem[]>([]);

--- a/src/features/roadmap-editor/canvas/components/DetailNode/index.tsx
+++ b/src/features/roadmap-editor/canvas/components/DetailNode/index.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { memo, useCallback } from 'react';
+
+import { useReactFlow } from '@xyflow/react';
+import { useSetAtom } from 'jotai';
+
+import { DetailNodeBase } from '@/components/roadmap/nodes/DetailNodeBase';
+import { nodesAtom } from '@/features/roadmap-editor/stores/editor-atoms';
+import { createDetailNode } from '@/features/roadmap-editor/utils/node-factory';
+import type { JagalchiNodeData } from '@/types/roadmap.types';
+
+import { PlusButtonHandle } from '../PlusButtonHandle';
+
+interface DetailNodeProps {
+  data: JagalchiNodeData;
+  selected?: boolean;
+  id: string;
+}
+
+const POSITION_OFFSET = 100;
+
+export const DetailNode = memo(function DetailNode({ data, selected, id }: DetailNodeProps) {
+  const setNodes = useSetAtom(nodesAtom);
+  const { getNode } = useReactFlow();
+
+  const handleCreateNode = useCallback(
+    (position: 'top' | 'right' | 'bottom' | 'left') => {
+      const currentNode = getNode(id);
+      if (!currentNode) return;
+
+      const offsets = {
+        top: { x: 0, y: -POSITION_OFFSET },
+        bottom: { x: 0, y: POSITION_OFFSET },
+      };
+
+      const offset = offsets[position as 'top' | 'bottom'];
+      if (!offset) return;
+
+      const newNode = createDetailNode({
+        position: {
+          x: currentNode.position.x + offset.x,
+          y: currentNode.position.y + offset.y,
+        },
+        variant: data.variant,
+      });
+
+      setNodes((prevNodes) => [...prevNodes, newNode]);
+    },
+    [id, data.variant, getNode, setNodes],
+  );
+
+  return (
+    <DetailNodeBase data={data} selected={selected}>
+      {selected && (
+        <>
+          <PlusButtonHandle position="top" onCreateNode={handleCreateNode} />
+          <PlusButtonHandle position="bottom" onCreateNode={handleCreateNode} />
+        </>
+      )}
+    </DetailNodeBase>
+  );
+});

--- a/src/features/roadmap-editor/canvas/components/DetailNode/index.tsx
+++ b/src/features/roadmap-editor/canvas/components/DetailNode/index.tsx
@@ -18,7 +18,7 @@ interface DetailNodeProps {
   id: string;
 }
 
-const POSITION_OFFSET = 100;
+const POSITION_OFFSET = 250;
 
 export const DetailNode = memo(function DetailNode({ data, selected, id }: DetailNodeProps) {
   const setNodes = useSetAtom(nodesAtom);

--- a/src/features/roadmap-editor/canvas/components/RoadmapCanvas/index.tsx
+++ b/src/features/roadmap-editor/canvas/components/RoadmapCanvas/index.tsx
@@ -16,6 +16,7 @@ import {
   type OnSelectionChangeFunc,
   type OnConnectEnd,
   type NodeTypes,
+  type IsValidConnection,
   ConnectionMode,
 } from '@xyflow/react';
 import { useAtom, useSetAtom } from 'jotai';
@@ -33,6 +34,7 @@ import { createId } from '@/features/roadmap-editor/utils/node-factory';
 
 import { useKeyboardShortcuts } from '../../../hooks/use-keyboard-shortcuts';
 import { ConnectionLine } from '../ConnectionLine';
+import { DetailNode } from '../DetailNode';
 import { JagalchiNode } from '../JagalchiNode';
 import { JagalchiSection } from '../JagalchiSection';
 import { JagalchiText } from '../JagalchiText';
@@ -41,6 +43,7 @@ const nodeTypes: NodeTypes = {
   'jagalchi-node': JagalchiNode,
   'jagalchi-section': JagalchiSection,
   'jagalchi-text': JagalchiText,
+  'detail-node': DetailNode,
 };
 
 export function RoadmapCanvas() {
@@ -66,6 +69,11 @@ export function RoadmapCanvas() {
     },
     [setEdges],
   );
+
+  const isValidConnection = useCallback<IsValidConnection>((connection) => {
+    // Prevent self-loops
+    return connection.source !== connection.target;
+  }, []);
 
   const onConnect: OnConnect = useCallback(
     (connection) => {
@@ -146,6 +154,7 @@ export function RoadmapCanvas() {
         onConnect={onConnect}
         onConnectEnd={onConnectEnd}
         onSelectionChange={onSelectionChange}
+        isValidConnection={isValidConnection}
         nodeTypes={nodeTypes}
         connectionLineComponent={ConnectionLine}
         multiSelectionKeyCode="Shift"

--- a/src/features/roadmap-editor/hooks/use-keyboard-shortcuts.ts
+++ b/src/features/roadmap-editor/hooks/use-keyboard-shortcuts.ts
@@ -12,6 +12,7 @@ import {
   selectedEdgeIdsAtom,
   undoAtom,
   redoAtom,
+  editorStateHistoryAtom,
 } from '../stores/editor-atoms';
 import { createId } from '../utils/node-factory';
 
@@ -79,6 +80,7 @@ export function useKeyboardShortcuts() {
   const [selectedEdgeIds, setSelectedEdgeIds] = useAtom(selectedEdgeIdsAtom);
   const undo = useSetAtom(undoAtom);
   const redo = useSetAtom(redoAtom);
+  const setEditorState = useSetAtom(editorStateHistoryAtom);
 
   // Use refs to access latest values without triggering effect re-runs
   const nodesRef = useRef<RoadmapNode[]>(nodes);
@@ -263,15 +265,39 @@ export function useKeyboardShortcuts() {
           selectedNodeIdsSet.has(node.id),
         );
         if (selectedNodes.length > 0) {
-          const duplicatedNodes = selectedNodes.map((node: RoadmapNode) => ({
-            ...node,
-            id: createId(),
-            position: {
-              x: node.position.x + 50,
-              y: node.position.y + 50,
-            },
-          }));
-          setNodes((nds) => [...nds, ...duplicatedNodes]);
+          // Build old→new ID mapping for edge remapping
+          const idMap = new Map<string, string>();
+          const duplicatedNodes = selectedNodes.map((node: RoadmapNode) => {
+            const newId = createId();
+            idMap.set(node.id, newId);
+            return {
+              ...node,
+              id: newId,
+              position: {
+                x: node.position.x + 50,
+                y: node.position.y + 50,
+              },
+            };
+          });
+
+          // Duplicate edges whose both endpoints are among the selected nodes
+          const duplicatedEdges = edgesRef.current
+            .filter(
+              (edge: Edge) =>
+                selectedNodeIdsSet.has(edge.source) && selectedNodeIdsSet.has(edge.target),
+            )
+            .map((edge: Edge) => ({
+              ...edge,
+              id: createId(),
+              source: idMap.get(edge.source) ?? edge.source,
+              target: idMap.get(edge.target) ?? edge.target,
+            }));
+
+          // Update nodes and edges atomically in a single history entry
+          setEditorState({
+            nodes: [...nodesRef.current, ...duplicatedNodes],
+            edges: [...edgesRef.current, ...duplicatedEdges],
+          });
           setSelectedNodeIds(duplicatedNodes.map((node: RoadmapNode) => node.id));
         }
         return;
@@ -283,5 +309,5 @@ export function useKeyboardShortcuts() {
       window.removeEventListener('keydown', handleKeyDown);
     };
     // Only depend on stable setters - refs handle value updates
-  }, [setNodes, setEdges, setSelectedNodeIds, setSelectedEdgeIds, undo, redo]);
+  }, [setNodes, setEdges, setSelectedNodeIds, setSelectedEdgeIds, undo, redo, setEditorState]);
 }

--- a/src/features/roadmap-editor/hooks/use-roadmap-loader.ts
+++ b/src/features/roadmap-editor/hooks/use-roadmap-loader.ts
@@ -13,6 +13,9 @@ import {
 import { nodesAtom, edgesAtom, roadmapTitleAtom } from '../stores/editor-atoms';
 import { hashNodes, hashEdges } from '../utils/fast-hash';
 
+import type { RoadmapNode } from '../types/editor.types';
+import type { Edge } from '@xyflow/react';
+
 interface UseRoadmapLoaderProps {
   roadmapId: string;
 }
@@ -24,6 +27,44 @@ interface UseRoadmapLoaderReturn {
   initialEdges: string;
   initialTitle: string;
   retry: () => void;
+}
+
+interface ApiRoadmap {
+  nodes: RoadmapNode[];
+  edges: Edge[];
+  title: string;
+}
+
+/**
+ * Attempt to fetch roadmap data from the API.
+ * Returns null when the API is unavailable — caller falls back to localStorage.
+ * TODO: Implement actual GET /api/roadmap/{id}/events call when API is ready.
+ */
+async function loadFromApi(_roadmapId: string): Promise<ApiRoadmap | null> {
+  // API not yet available — always return null so caller uses localStorage
+  return null;
+}
+
+/**
+ * Load roadmap from API first, then fall back to localStorage.
+ * Structured so replacing `loadFromApi` body is the only change needed
+ * once the real API is ready.
+ */
+async function loadRoadmapData(roadmapId: string): Promise<ApiRoadmap | null> {
+  const apiResult = await loadFromApi(roadmapId);
+  if (apiResult !== null) {
+    return apiResult;
+  }
+
+  // Fallback to localStorage
+  const local = loadRoadmapFromLocalStorage(roadmapId);
+  if (!local) return null;
+
+  return {
+    nodes: local.nodes,
+    edges: local.edges,
+    title: local.title,
+  };
 }
 
 export function useRoadmapLoader({ roadmapId }: UseRoadmapLoaderProps): UseRoadmapLoaderReturn {
@@ -55,8 +96,8 @@ export function useRoadmapLoader({ roadmapId }: UseRoadmapLoaderProps): UseRoadm
           return;
         }
 
-        // Load existing roadmap
-        const roadmap = loadRoadmapFromLocalStorage(roadmapId);
+        // Load roadmap: API first → localStorage fallback
+        const roadmap = await loadRoadmapData(roadmapId);
 
         if (!roadmap) {
           setError('로드맵을 찾을 수 없습니다.');
@@ -83,22 +124,26 @@ export function useRoadmapLoader({ roadmapId }: UseRoadmapLoaderProps): UseRoadm
     loadRoadmap();
   }, [roadmapId, router, setNodes, setEdges, setTitle]);
 
-  const retry = () => {
+  const retry = async () => {
     setError(null);
     setIsLoading(true);
 
-    // Re-trigger load
-    const roadmap = loadRoadmapFromLocalStorage(roadmapId);
-    if (roadmap) {
-      setNodes(roadmap.nodes);
-      setEdges(roadmap.edges);
-      setTitle(roadmap.title);
-      setInitialNodes(hashNodes(roadmap.nodes));
-      setInitialEdges(hashEdges(roadmap.edges));
-      setInitialTitle(roadmap.title);
-      setIsLoading(false);
-    } else {
-      setError('로드맵을 찾을 수 없습니다.');
+    try {
+      const roadmap = await loadRoadmapData(roadmapId);
+      if (roadmap) {
+        setNodes(roadmap.nodes);
+        setEdges(roadmap.edges);
+        setTitle(roadmap.title);
+        setInitialNodes(hashNodes(roadmap.nodes));
+        setInitialEdges(hashEdges(roadmap.edges));
+        setInitialTitle(roadmap.title);
+        setIsLoading(false);
+      } else {
+        setError('로드맵을 찾을 수 없습니다.');
+        setIsLoading(false);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '로드맵을 불러오는 중 오류가 발생했습니다.');
       setIsLoading(false);
     }
   };

--- a/src/features/roadmap-editor/hooks/use-roadmap-loader.ts
+++ b/src/features/roadmap-editor/hooks/use-roadmap-loader.ts
@@ -26,7 +26,7 @@ interface UseRoadmapLoaderReturn {
   initialNodes: string;
   initialEdges: string;
   initialTitle: string;
-  retry: () => void;
+  retry: () => Promise<void>;
 }
 
 interface ApiRoadmap {
@@ -93,6 +93,7 @@ export function useRoadmapLoader({ roadmapId }: UseRoadmapLoaderProps): UseRoadm
 
           // Redirect to new roadmap ID
           router.replace(`/editor/${newId}`);
+          setIsLoading(false);
           return;
         }
 
@@ -101,6 +102,7 @@ export function useRoadmapLoader({ roadmapId }: UseRoadmapLoaderProps): UseRoadm
 
         if (!roadmap) {
           setError('로드맵을 찾을 수 없습니다.');
+          setIsLoading(false);
           return;
         }
 

--- a/src/features/roadmap-editor/properties/components/ColorPicker/index.tsx
+++ b/src/features/roadmap-editor/properties/components/ColorPicker/index.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useState } from 'react';
 
-import { useAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { HexColorPicker } from 'react-colorful';
 
 import { Button } from '@/components/ui/button';
@@ -15,17 +15,57 @@ import {
 } from '@/components/ui/dialog';
 import { EDITOR_MESSAGES } from '@/constants/messages';
 
-import { isColorPickerOpenAtom, colorPickerTargetAtom } from '../../../stores/editor-atoms';
+import {
+  isColorPickerOpenAtom,
+  colorPickerTargetAtom,
+  nodesAtom,
+  edgesAtom,
+} from '../../../stores/editor-atoms';
 
 export const ColorPicker = memo(function ColorPicker() {
   const [isOpen, setIsOpen] = useAtom(isColorPickerOpenAtom);
-  const [, setTarget] = useAtom(colorPickerTargetAtom);
+  const [target, setTarget] = useAtom(colorPickerTargetAtom);
+  const setNodes = useSetAtom(nodesAtom);
+  const setEdges = useSetAtom(edgesAtom);
 
   const [tempColor, setTempColor] = useState<string>('#3b82f6');
 
   const handleApply = () => {
-    // TODO: Phase 2.1에서 customColor 필드 추가 후 구현
-    // 현재는 프리셋 색상만 지원
+    if (!target) {
+      handleClose();
+      return;
+    }
+
+    if (target.type === 'node' || target.type === 'text') {
+      // Apply custom color via style.backgroundColor on the node
+      setNodes((nds) =>
+        nds.map((node) => {
+          if (node.id !== target.nodeId) return node;
+          return {
+            ...node,
+            style: {
+              ...node.style,
+              backgroundColor: tempColor,
+            },
+          };
+        }),
+      );
+    } else {
+      // Edge target: apply color to stroke
+      setEdges((eds) =>
+        eds.map((edge) => {
+          if (edge.id !== target.nodeId) return edge;
+          return {
+            ...edge,
+            style: {
+              ...edge.style,
+              stroke: tempColor,
+            },
+          };
+        }),
+      );
+    }
+
     handleClose();
   };
 

--- a/src/features/roadmap-editor/properties/components/ColorPicker/index.tsx
+++ b/src/features/roadmap-editor/properties/components/ColorPicker/index.tsx
@@ -36,8 +36,13 @@ export const ColorPicker = memo(function ColorPicker() {
       return;
     }
 
+    // Validate hex color format
+    if (!/^#[0-9a-fA-F]{6}$/.test(tempColor)) {
+      handleClose();
+      return;
+    }
+
     if (target.type === 'node' || target.type === 'text') {
-      // Apply custom color via style.backgroundColor on the node
       setNodes((nds) =>
         nds.map((node) => {
           if (node.id !== target.nodeId) return node;
@@ -50,11 +55,10 @@ export const ColorPicker = memo(function ColorPicker() {
           };
         }),
       );
-    } else {
-      // Edge target: apply color to stroke
+    } else if (target.type === 'edge') {
       setEdges((eds) =>
         eds.map((edge) => {
-          if (edge.id !== target.nodeId) return edge;
+          if (edge.id !== target.edgeId) return edge;
           return {
             ...edge,
             style: {

--- a/src/features/roadmap-editor/stores/editor-atoms.ts
+++ b/src/features/roadmap-editor/stores/editor-atoms.ts
@@ -74,10 +74,9 @@ export const singleSelectedEdgeAtom = atom((get) => {
 
 // ColorPicker state
 export const isColorPickerOpenAtom = atom<boolean>(false);
-export const colorPickerTargetAtom = atom<{
-  type: 'node' | 'text';
-  nodeId: string;
-} | null>(null);
+export const colorPickerTargetAtom = atom<
+  { type: 'node' | 'text'; nodeId: string } | { type: 'edge'; edgeId: string } | null
+>(null);
 
 // Toolbar state
 export const activeToolAtom = atom<'select' | 'node' | 'line' | 'section' | 'text'>('select');

--- a/src/features/roadmap-editor/types/editor.types.ts
+++ b/src/features/roadmap-editor/types/editor.types.ts
@@ -5,8 +5,10 @@ export type {
   JagalchiNodeData,
   JagalchiSectionData,
   JagalchiTextData,
+  DetailNodeData,
   JagalchiNodeType,
   JagalchiSectionType,
   JagalchiTextType,
+  DetailNodeType,
   RoadmapNode,
 } from '@/types/roadmap.types';

--- a/src/features/roadmap-editor/utils/node-factory.ts
+++ b/src/features/roadmap-editor/utils/node-factory.ts
@@ -4,6 +4,7 @@ import type {
   JagalchiNodeType,
   JagalchiSectionType,
   JagalchiTextType,
+  DetailNodeType,
   NodeColorVariant,
   TextColorVariant,
 } from '../types/editor.types';
@@ -24,6 +25,13 @@ interface CreateTextOptions {
   position: { x: number; y: number };
   variant?: TextColorVariant;
   content?: string;
+}
+
+interface CreateDetailNodeOptions {
+  position: { x: number; y: number };
+  variant?: NodeColorVariant;
+  label?: string;
+  badge?: string;
 }
 
 /**
@@ -67,6 +75,29 @@ export function createJagalchiSection(options: CreateSectionOptions): JagalchiSe
       variant,
       title,
       isLocked: false,
+    },
+  };
+}
+
+export function createDetailNode(options: CreateDetailNodeOptions): DetailNodeType {
+  const {
+    position,
+    variant = 'white',
+    label = EDITOR_MESSAGES.FLOW_DETAIL_NODE_DEFAULT_LABEL,
+    badge,
+  } = options;
+
+  return {
+    id: createId(),
+    type: 'detail-node',
+    position,
+    data: {
+      variant,
+      label,
+      description: '',
+      resources: [],
+      isLocked: false,
+      ...(badge !== undefined && { badge }),
     },
   };
 }

--- a/src/features/roadmap-viewer/components/RoadmapViewer/index.tsx
+++ b/src/features/roadmap-viewer/components/RoadmapViewer/index.tsx
@@ -2,7 +2,7 @@
 
 import { ReactFlowProvider } from '@xyflow/react';
 import { useAtom, useAtomValue } from 'jotai';
-import { LayoutGrid, Map } from 'lucide-react';
+import { LayoutGrid, Map, PanelRight } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { VIEWER_MESSAGES } from '@/constants/messages';
@@ -79,6 +79,16 @@ function ViewerContent({ roadmapId }: RoadmapViewerProps) {
                 <LayoutGrid className="mr-1.5 h-4 w-4" />
                 {VIEWER_MESSAGES.VIEW_CARDS}
               </Button>
+              {!isSidebarOpen && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsSidebarOpen(true)}
+                  aria-label={VIEWER_MESSAGES.SIDEBAR_OPEN_BUTTON_LABEL}
+                >
+                  <PanelRight className="h-4 w-4" />
+                </Button>
+              )}
             </div>
           </div>
 

--- a/src/features/roadmap-viewer/hooks/use-viewer-roadmap-loader.ts
+++ b/src/features/roadmap-viewer/hooks/use-viewer-roadmap-loader.ts
@@ -5,8 +5,23 @@ import { useEffect } from 'react';
 import { useSetAtom } from 'jotai';
 
 import { loadRoadmapFromLocalStorage } from '@/lib/roadmap-storage';
+import type { Roadmap } from '@/types/roadmap.types';
 
 import { viewerErrorAtom, viewerLoadingAtom, viewerRoadmapAtom } from '../stores/viewer-atoms';
+
+/**
+ * Attempts to load a roadmap from the API.
+ * Currently returns null — real API integration is deferred.
+ * Replace this with an actual fetch call when the endpoint is ready.
+ */
+async function loadFromApi(_roadmapId: string): Promise<Roadmap | null> {
+  // TODO: Replace with actual API call
+  // Example:
+  //   const res = await fetch(`/api/roadmaps/${roadmapId}`);
+  //   if (!res.ok) return null;
+  //   return res.json() as Promise<Roadmap>;
+  return null;
+}
 
 export function useViewerRoadmapLoader(roadmapId: string) {
   const setRoadmap = useSetAtom(viewerRoadmapAtom);
@@ -14,15 +29,41 @@ export function useViewerRoadmapLoader(roadmapId: string) {
   const setError = useSetAtom(viewerErrorAtom);
 
   useEffect(() => {
-    const roadmap = loadRoadmapFromLocalStorage(roadmapId);
+    let isCancelled = false;
 
-    if (roadmap) {
-      setRoadmap(roadmap);
-      setLoading(false);
+    async function load() {
+      setLoading(true);
       setError(null);
-    } else {
-      setLoading(false);
-      setError(`Roadmap not found: ${roadmapId}`);
+
+      // 1. Try API first
+      const apiRoadmap = await loadFromApi(roadmapId);
+
+      if (isCancelled) return;
+
+      if (apiRoadmap) {
+        setRoadmap(apiRoadmap);
+        setLoading(false);
+        return;
+      }
+
+      // 2. Fallback to localStorage
+      const localRoadmap = loadRoadmapFromLocalStorage(roadmapId);
+
+      if (isCancelled) return;
+
+      if (localRoadmap) {
+        setRoadmap(localRoadmap);
+        setLoading(false);
+      } else {
+        setLoading(false);
+        setError(`Roadmap not found: ${roadmapId}`);
+      }
     }
+
+    load();
+
+    return () => {
+      isCancelled = true;
+    };
   }, [roadmapId, setRoadmap, setLoading, setError]);
 }

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -1,0 +1,32 @@
+/**
+ * TanStack Query key factory
+ * 일관된 쿼리 키 관리를 위한 중앙화된 키 팩토리
+ */
+
+export const queryKeys = {
+  auth: {
+    all: ['auth'] as const,
+    me: () => [...queryKeys.auth.all, 'me'] as const,
+  },
+
+  users: {
+    all: ['users'] as const,
+    detail: (name: string) => [...queryKeys.users.all, 'detail', name] as const,
+    followers: (name: string) => [...queryKeys.users.all, 'followers', name] as const,
+    followings: (name: string) => [...queryKeys.users.all, 'followings', name] as const,
+  },
+
+  roadmaps: {
+    all: ['roadmaps'] as const,
+    lists: () => [...queryKeys.roadmaps.all, 'list'] as const,
+    detail: (id: string) => [...queryKeys.roadmaps.all, 'detail', id] as const,
+    events: (id: string, since?: number) =>
+      [...queryKeys.roadmaps.all, 'events', id, since] as const,
+  },
+
+  community: {
+    all: ['community'] as const,
+    lists: () => [...queryKeys.community.all, 'list'] as const,
+    detail: (id: string) => [...queryKeys.community.all, 'detail', id] as const,
+  },
+} as const;

--- a/src/lib/roadmap-schema.ts
+++ b/src/lib/roadmap-schema.ts
@@ -20,6 +20,7 @@ const roadmapNodeDataSchema = z.object({
   content: z.string().optional(),
   fontSize: z.number().optional(),
   fontWeight: z.string().optional(),
+  badge: z.string().optional(),
 });
 
 const roadmapNodeSchema = z.object({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+/** 인증이 필요한 라우트 */
+const PROTECTED_ROUTES = ['/myroadmap', '/profile', '/editor'];
+
+/** 로그인 상태에서 접근 차단할 라우트 */
+const AUTH_ROUTES = ['/login', '/register', '/find-password'];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const token = request.cookies.get('jagalchi-access-token')?.value;
+
+  // 클라이언트에서 localStorage에 토큰을 저장하므로, 미들웨어에서는
+  // 쿠키 기반으로만 체크. 쿠키가 없으면 클라이언트 측 가드에 위임.
+  // TODO: HttpOnly refresh cookie 기반으로 전환 시 이 로직 활성화
+
+  const isProtectedRoute = PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
+  const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route));
+
+  // 로그인 상태에서 auth 페이지 접근 시 홈으로 리다이렉트
+  if (isAuthRoute && token) {
+    return NextResponse.redirect(new URL('/myroadmap', request.url));
+  }
+
+  // 비로그인 상태에서 보호 라우트 접근 시 로그인으로 리다이렉트
+  if (isProtectedRoute && !token) {
+    const loginUrl = new URL('/login', request.url);
+    loginUrl.searchParams.set('redirect', pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    '/myroadmap/:path*',
+    '/profile/:path*',
+    '/editor/:path*',
+    '/login',
+    '/register',
+    '/find-password',
+  ],
+};

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -14,16 +14,10 @@ interface LoginRequest {
   password: string;
 }
 
-interface LoginResponse {
-  token: string;
-  user: Omit<MockUser, 'password'>;
-}
-
-interface RegisterRequest {
+interface SignUpRequest {
   email: string;
+  name: string;
   password: string;
-  username: string;
-  links?: { name: string; url: string }[];
 }
 
 interface SendVerificationCodeRequest {
@@ -41,55 +35,67 @@ interface ResetPasswordRequest {
 }
 
 interface ErrorResponse {
+  timestamp: string;
+  status: number;
+  error: string;
+  code: string;
   message: string;
+  path: string;
 }
 
 // 가변 유저 저장소 (등록된 유저를 런타임에서 추적)
 const registeredUsers: MockUser[] = [...MOCK_USERS];
 
-/** 비밀번호를 제외한 사용자 정보 반환 */
-const sanitizeUser = (user: MockUser): Omit<MockUser, 'password'> => ({
-  id: user.id,
-  email: user.email,
-  username: user.username,
-  bio: user.bio,
-  links: user.links,
-  createdAt: user.createdAt,
+/** API 스펙 형식의 에러 응답 생성 */
+const createErrorResponse = (
+  status: number,
+  code: string,
+  message: string,
+  path: string,
+): ErrorResponse => ({
+  timestamp: new Date().toISOString(),
+  status,
+  error: status === 400 ? 'Bad Request' : status === 401 ? 'Unauthorized' : 'Not Found',
+  code,
+  message,
+  path,
 });
 
-/** Auth API 핸들러 */
+/** Auth API 핸들러 (endpoints aligned with docs/api.md) */
 export const authHandlers = [
-  // POST /api/auth/login
-  http.post<Record<string, never>, LoginRequest>('/api/auth/login', async ({ request }) => {
+  // POST /api/users/auth/login
+  http.post<Record<string, never>, LoginRequest>('/api/users/auth/login', async ({ request }) => {
     const body = await request.json();
     const { email, password } = body;
 
     const user = registeredUsers.find((u) => u.email === email);
 
     if (!user || user.password !== password) {
-      return HttpResponse.json<ErrorResponse>(
-        { message: '이메일 또는 비밀번호가 올바르지 않습니다' },
+      return HttpResponse.json(
+        createErrorResponse(
+          401,
+          'UNAUTHORIZED',
+          '이메일 또는 비밀번호가 올바르지 않습니다',
+          '/users/auth/login',
+        ),
         { status: 401 },
       );
     }
 
-    return HttpResponse.json<LoginResponse>({
-      token: createMockToken(user.id),
-      user: sanitizeUser(user),
-    });
+    return HttpResponse.json({ accessToken: createMockToken(user.id) });
   }),
 
-  // POST /api/auth/register
-  http.post<Record<string, never>, RegisterRequest>('/api/auth/register', async ({ request }) => {
+  // POST /api/users
+  http.post<Record<string, never>, SignUpRequest>('/api/users', async ({ request }) => {
     const body = await request.json();
-    const { email, password, username, links } = body;
+    const { email, name, password } = body;
 
     const existingUser = registeredUsers.find((u) => u.email === email);
 
     if (existingUser) {
-      return HttpResponse.json<ErrorResponse>(
-        { message: '이미 등록된 이메일입니다' },
-        { status: 409 },
+      return HttpResponse.json(
+        createErrorResponse(400, 'INVALID_INPUT', '이미 등록된 이메일입니다', '/users'),
+        { status: 400 },
       );
     }
 
@@ -97,72 +103,133 @@ export const authHandlers = [
       id: `user-${Date.now()}`,
       email,
       password,
-      username,
-      links: links ?? [],
+      username: name,
+      links: [],
       createdAt: new Date().toISOString(),
     };
 
     registeredUsers.push(newUser);
 
     return HttpResponse.json(
-      {
-        token: createMockToken(newUser.id),
-        user: sanitizeUser(newUser),
-      },
+      { id: registeredUsers.length, email: newUser.email, name: newUser.username },
       { status: 201 },
     );
   }),
 
-  // POST /api/auth/send-verification-code
+  // POST /api/users/verification — 인증코드 전송
   http.post<Record<string, never>, SendVerificationCodeRequest>(
-    '/api/auth/send-verification-code',
+    '/api/users/verification',
     async ({ request }) => {
       const body = await request.json();
       const { email } = body;
 
       if (!email) {
-        return HttpResponse.json<ErrorResponse>(
-          { message: '이메일을 입력해주세요' },
+        return HttpResponse.json(
+          createErrorResponse(400, 'INVALID_INPUT', '이메일을 입력해주세요', '/users/verification'),
           { status: 400 },
         );
       }
 
-      // Mock: 항상 성공 (실제로 코드를 보내지 않음)
-      return HttpResponse.json({
-        message: '인증 코드가 발송되었습니다',
-        expiresIn: 300, // 5분
-      });
+      return HttpResponse.json({ message: '인증 코드가 발송되었습니다' });
     },
   ),
 
-  // POST /api/auth/verify-code
-  http.post<Record<string, never>, VerifyCodeRequest>(
-    '/api/auth/verify-code',
+  // PATCH /api/users/verification — 인증코드 확인
+  http.patch<Record<string, never>, VerifyCodeRequest>(
+    '/api/users/verification',
     async ({ request }) => {
       const body = await request.json();
       const { email, code } = body;
 
       if (!email || !code) {
-        return HttpResponse.json<ErrorResponse>(
-          { message: '이메일과 인증 코드를 입력해주세요' },
+        return HttpResponse.json(
+          createErrorResponse(
+            400,
+            'INVALID_INPUT',
+            '이메일과 인증 코드를 입력해주세요',
+            '/users/verification',
+          ),
           { status: 400 },
         );
       }
 
       if (code !== MOCK_VERIFICATION_CODE) {
-        return HttpResponse.json<ErrorResponse>(
-          { message: '인증 코드가 올바르지 않습니다' },
-          { status: 401 },
+        return HttpResponse.json(
+          createErrorResponse(
+            400,
+            'VALIDATION_FAILED',
+            '인증 코드가 올바르지 않습니다',
+            '/users/verification',
+          ),
+          { status: 400 },
         );
       }
 
-      return HttpResponse.json({ isVerified: true });
+      return HttpResponse.json({ message: '인증 완료' });
     },
   ),
 
-  // POST /api/auth/reset-password
+  // PATCH /api/users/auth/password-reset — 비밀번호 리셋 코드 전송
+  http.patch<Record<string, never>, SendVerificationCodeRequest>(
+    '/api/users/auth/password-reset',
+    async ({ request }) => {
+      const body = await request.json();
+      const { email } = body;
+
+      if (!email) {
+        return HttpResponse.json(
+          createErrorResponse(
+            400,
+            'INVALID_INPUT',
+            '이메일을 입력해주세요',
+            '/users/auth/password-reset',
+          ),
+          { status: 400 },
+        );
+      }
+
+      return HttpResponse.json({ message: '비밀번호 리셋 코드가 발송되었습니다' });
+    },
+  ),
+
+  // PATCH /api/users/auth/password-reset/verify — 비밀번호 리셋 코드 확인
+  http.patch<Record<string, never>, VerifyCodeRequest>(
+    '/api/users/auth/password-reset/verify',
+    async ({ request }) => {
+      const body = await request.json();
+      const { email, code } = body;
+
+      if (!email || !code) {
+        return HttpResponse.json(
+          createErrorResponse(
+            400,
+            'INVALID_INPUT',
+            '이메일과 인증 코드를 입력해주세요',
+            '/users/auth/password-reset/verify',
+          ),
+          { status: 400 },
+        );
+      }
+
+      if (code !== MOCK_VERIFICATION_CODE) {
+        return HttpResponse.json(
+          createErrorResponse(
+            400,
+            'VALIDATION_FAILED',
+            '인증 코드가 올바르지 않습니다',
+            '/users/auth/password-reset/verify',
+          ),
+          { status: 400 },
+        );
+      }
+
+      return HttpResponse.json({ message: '인증 완료' });
+    },
+  ),
+
+  // POST /api/users/auth/reset-password — 비밀번호 변경
   http.post<Record<string, never>, ResetPasswordRequest>(
-    '/api/auth/reset-password',
+    '/api/users/auth/reset-password',
     async ({ request }) => {
       const body = await request.json();
       const { email, newPassword } = body;
@@ -170,18 +237,32 @@ export const authHandlers = [
       const user = registeredUsers.find((u) => u.email === email);
 
       if (!user) {
-        return HttpResponse.json<ErrorResponse>(
-          { message: '등록되지 않은 이메일입니다' },
+        return HttpResponse.json(
+          createErrorResponse(
+            404,
+            'NOT_FOUND',
+            '등록되지 않은 이메일입니다',
+            '/users/auth/reset-password',
+          ),
           { status: 404 },
         );
       }
 
-      // 비밀번호 업데이트
       user.password = newPassword;
 
       return HttpResponse.json({ message: '비밀번호가 변경되었습니다' });
     },
   ),
+
+  // PATCH /api/users/auth/refresh — 토큰 갱신
+  http.patch('/api/users/auth/refresh', () => {
+    return HttpResponse.json({ accessToken: createMockToken('refreshed') });
+  }),
+
+  // DELETE /api/users — 계정 삭제
+  http.delete('/api/users', () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
 ];
 
 // 테스트에서 사용자 목록 초기화할 때 사용

--- a/src/stories/FigmaTargetStories.stories.tsx
+++ b/src/stories/FigmaTargetStories.stories.tsx
@@ -371,7 +371,7 @@ export const ProfileComponents: Story = {
           followerCount={12}
           followingCount={3}
         />
-        <ProfileBio bio="빠르게 성장하는 프론트엔드 개발자입니다." />
+        <ProfileBio />
         <ProfileCustomOrganization initialValue="Jagalchi" />
         <ProfileCustomLinks
           initialLinks={[

--- a/src/stories/FigmaTargetStories.stories.tsx
+++ b/src/stories/FigmaTargetStories.stories.tsx
@@ -371,7 +371,7 @@ export const ProfileComponents: Story = {
           followerCount={12}
           followingCount={3}
         />
-        <ProfileBio />
+        <ProfileBio bio="프론트엔드 개발자 | React, TypeScript 전문" />
         <ProfileCustomOrganization initialValue="Jagalchi" />
         <ProfileCustomLinks
           initialLinks={[

--- a/src/types/roadmap.types.ts
+++ b/src/types/roadmap.types.ts
@@ -18,6 +18,14 @@ export interface JagalchiNodeData extends BaseNodeData {
   resources: string[]; // Phase 1에서는 간단히 URL 배열
 }
 
+export interface DetailNodeData extends BaseNodeData {
+  label: string;
+  description: string;
+  resources: string[];
+  /** Optional badge text shown below the label (e.g. estimated duration) */
+  badge?: string;
+}
+
 export interface JagalchiSectionData extends BaseNodeData {
   title?: string;
 }
@@ -36,8 +44,13 @@ export interface JagalchiTextData {
 export type JagalchiNodeType = Node<JagalchiNodeData, 'jagalchi-node'>;
 export type JagalchiSectionType = Node<JagalchiSectionData, 'jagalchi-section'>;
 export type JagalchiTextType = Node<JagalchiTextData, 'jagalchi-text'>;
+export type DetailNodeType = Node<DetailNodeData, 'detail-node'>;
 
-export type RoadmapNode = JagalchiNodeType | JagalchiSectionType | JagalchiTextType;
+export type RoadmapNode =
+  | JagalchiNodeType
+  | JagalchiSectionType
+  | JagalchiTextType
+  | DetailNodeType;
 
 // === Roadmap Entity Types ===
 

--- a/src/types/roadmap.types.ts
+++ b/src/types/roadmap.types.ts
@@ -71,3 +71,19 @@ export interface UpdateRoadmapInput {
   edges?: Edge[];
   isPublic?: boolean;
 }
+
+// === List/Summary Types ===
+
+/** 로드맵 목록에서 사용하는 경량 타입 (Roadmap에서 파생) */
+export interface RoadmapSummary {
+  id: string;
+  title: string;
+  type?: 'Roadmap' | 'Directory';
+  author?: string;
+  fileCount?: number;
+  imageUrl?: string;
+  updatedAt?: string;
+  isFavorite?: boolean;
+  isShared?: boolean;
+  category?: 'my-roadmap' | 'community';
+}


### PR DESCRIPTION
## Summary
- apiClient에 Bearer 토큰 자동 첨부, PATCH 메서드, 401 인터셉터 추가
- Auth API 엔드포인트를 `docs/api.md` 백엔드 스펙에 정렬
- MSW 핸들러를 새 엔드포인트 + API 스펙 에러 형식으로 업데이트
- `profile.ts`, `roadmap.ts` API 레이어 scaffolding + TanStack Query key factory
- `RoadmapSummary` 공유 타입 추가, `RoadmapData`를 alias로 유지

## 변경 파일 (14)
| 파일 | 변경 내용 |
|------|-----------|
| `src/api/client.ts` | PATCH, Bearer 토큰, 401 인터셉터, credentials |
| `src/api/auth.ts` | 엔드포인트 스펙 정렬, 타입명 정리 |
| `src/api/profile.ts` | 신규 — 프로필 조회/수정/팔로우 API |
| `src/api/roadmap.ts` | 신규 — 로드맵 이벤트 API |
| `src/lib/query-keys.ts` | 신규 — TanStack Query key factory |
| `src/types/roadmap.types.ts` | `RoadmapSummary` 추가 |
| `src/features/my-roadmaps/types/` | `RoadmapData` → `RoadmapSummary` alias |
| `src/mocks/handlers/auth.ts` | 엔드포인트 + 에러 형식 스펙 정렬 |
| `src/features/auth/hooks/*` (5) | 타입 변경 반영 |
| `RegisterForm.tsx` | `SignUpRequest { email, name, password }` 적용 |

## Test plan
- [x] `pnpm lint` — 기존 에러 외 신규 에러 0
- [x] `pnpm test` — 130파일 839테스트 전체 통과
- [ ] dev 서버에서 로그인/회원가입/비밀번호 찾기 플로우 수동 확인

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-up now uses full name; login returns an access token. Token refresh and account deletion available.
  * View/edit user profiles, manage links/org, follow/unfollow users, and fetch roadmap event history.
  * My Roadmaps: live search/filtering, rename/delete/favorite actions; responsive community layouts and clickable cards; immediate like count updates.

* **Bug Fixes**
  * Streamlined verification and password-reset flows; improved API error handling and auth redirect behavior.

* **Quality**
  * Client-side image type/size checks and stricter form validation (password length, trimmed inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->