### PR TITLE
feat(#214): SEO — add robots.ts / sitemap.ts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ NEXT_PUBLIC_API_URL=https://api.jagalchi.dev
 NEXT_PUBLIC_API_MOCKING=false
 NEXT_PUBLIC_REALTIME_ENABLED=false
 NEXT_PUBLIC_WS_URL=wss://api.jagalchi.dev/ws
+NEXT_PUBLIC_SITE_URL=https://jagalchi.dev
+NEXT_PUBLIC_ENV=production

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from 'next';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://jagalchi.dev';
+const IS_PRODUCTION = process.env.NEXT_PUBLIC_ENV === 'production';
+
+export default function robots(): MetadataRoute.Robots {
+  if (!IS_PRODUCTION) {
+    return {
+      rules: [{ userAgent: '*', disallow: '/' }],
+    };
+  }
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: ['/api/', '/editor/', '/myroadmap/', '/profile/'],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from 'next';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://jagalchi.dev';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  return [
+    {
+      url: SITE_URL,
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${SITE_URL}/community`,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/login`,
+      lastModified: now,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
+    {
+      url: `${SITE_URL}/register`,
+      lastModified: now,
+      changeFrequency: 'yearly',
+      priority: 0.3,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

#214 해결. 검색엔진용 `robots.txt` / `sitemap.xml` 를 Next.js 16 App Router 규약으로 추가.

- `src/app/robots.ts` — 프로덕션만 인덱싱 허용, 그 외(staging/dev)는 전체 차단. `/api`, `/editor`, `/myroadmap`, `/profile` 은 프라이빗/서버 라우트라 disallow.
- `src/app/sitemap.ts` — 공개 정적 경로(`/`, `/community`, `/login`, `/register`) 등록. 공개 로드맵 목록 동적 생성은 백엔드 연동 후 별도 PR.
- `.env.example` — `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_ENV` 추가. 미정의 시 `https://jagalchi.dev` 로 폴백.

## Test plan

- [x] `pnpm build` 성공 — 빌드 결과에 `○ /robots.txt`, `○ /sitemap.xml` 정적 라우트 생성 확인
- [x] `pnpm lint` 에러 0 (기존 경고 3건은 무관)
- [ ] staging 배포에서 `/robots.txt` 가 `Disallow: /` 로 응답하는지 검증
- [ ] 프로덕션 배포 후 Search Console 에 sitemap 제출

## Follow-ups

- #216 JSON-LD 구조화 데이터
- #215 webmanifest
- 공개 로드맵 sitemap 동적 생성 (백엔드 `GET /roadmaps/public` 의존)

Closes #214

https://claude.ai/code/session_01PgpctCVveAx3FGT21pKFCw