### PR TITLE
feat(#215): PWA / site webmanifest

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,7 @@ export const metadata: Metadata = {
   icons: {
     icon: '/jagalchi.svg',
   },
+  manifest: '/manifest.webmanifest',
   openGraph: {
     title: '자갈치 — 개발자 학습 로드맵 플랫폼',
     description: '개발자의 학습 경로를 노드 기반 에디터로 생성하고, 포크·공유하는 플랫폼.',

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: '자갈치 — 개발자 학습 로드맵 플랫폼',
+    short_name: '자갈치',
+    description: '개발자의 학습 경로를 노드 기반 에디터로 생성하고, 포크·공유하는 플랫폼.',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#ffffff',
+    theme_color: '#ffffff',
+    lang: 'ko',
+    orientation: 'portrait',
+    icons: [
+      {
+        src: '/jagalchi.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+        purpose: 'any',
+      },
+      {
+        src: '/favicon.ico',
+        sizes: '32x32',
+        type: 'image/x-icon',
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

#215 해결. PWA 기본 수준의 `manifest.webmanifest` 를 Next.js App Router 규약(`app/manifest.ts`)으로 추가.

- `src/app/manifest.ts` — name, short_name, description, icons 등록
- `src/app/layout.tsx` — `metadata.manifest: '/manifest.webmanifest'` 추가
- 아이콘은 임시로 `public/jagalchi.svg` + `favicon.ico` 재사용

## Test plan

- [x] `pnpm build` — `○ /manifest.webmanifest` 정적 라우트 생성 확인
- [ ] 모바일(iOS/Android) 홈화면 추가 UX 검증
- [ ] 192x192 / 512x512 PNG 아이콘 디자인 팀에서 수령 → 교체

## Follow-ups

- 디자인 정해지면 `theme_color` 를 브랜드 컬러로 변경
- 192/512 PNG 아이콘 추가 (maskable 아이콘 포함)
- (선택) next-pwa 도입으로 offline 캐싱

Closes #215

https://claude.ai/code/session_01PgpctCVveAx3FGT21pKFCw