### PR TITLE
chore(#217): define images.remotePatterns for OAuth avatars + CDN

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,16 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   reactCompiler: true,
 
+  images: {
+    remotePatterns: [
+      { protocol: 'https', hostname: 'avatars.githubusercontent.com' },
+      { protocol: 'https', hostname: 'lh3.googleusercontent.com' },
+      { protocol: 'https', hostname: 'cdn.jagalchi.dev' },
+      { protocol: 'https', hostname: '*.r2.dev' },
+      { protocol: 'https', hostname: '*.s3.amazonaws.com' },
+    ],
+  },
+
   // Security headers to protect against common vulnerabilities
   async headers() {
     return [


### PR DESCRIPTION
## Summary

#217 해결. `next/image` 가 외부 도메인 이미지를 최적화할 수 있도록 `images.remotePatterns` 등록.

허용 호스트:
- `avatars.githubusercontent.com` — GitHub OAuth 프로필 (#200)
- `lh3.googleusercontent.com` — Google OAuth 프로필 (#200)
- `cdn.jagalchi.dev` — 예상 자체 CDN
- `*.r2.dev`, `*.s3.amazonaws.com` — 업로드 스토리지 후보

## Test plan

- [x] `pnpm build` 통과
- [ ] OAuth 로그인 후 GitHub/Google 아바타가 `next/image` 로 렌더되는지 검증 (#200 이후)
- [ ] 실제 운영 CDN 도메인이 결정되면 값 갱신

## Follow-ups

- 업로드 스토리지(S3/R2/자체 CDN) 확정 시 호스트 정리
- `*.r2.dev`, `*.s3.amazonaws.com` 와일드카드는 보안상 실제 버킷 도메인으로 좁힐 것

Closes #217

https://claude.ai/code/session_01PgpctCVveAx3FGT21pKFCw