### PR TITLE
chore(#232): add pnpm audit CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,28 @@ jobs:
       - name: Build
         run: pnpm build
 
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit production dependencies
+        run: pnpm audit --prod --audit-level=high
+        continue-on-error: true
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary

#232 부분 해결. 조사 결과 `.github/dependabot.yml` 은 이미 npm + github-actions 로 구성되어 있어 누락된 **`pnpm audit` CI 게이트만** 추가.

- `.github/workflows/ci.yml` — `audit` 잡 추가: `pnpm audit --prod --audit-level=high` 실행, 초기에는 `continue-on-error: true` 로 경고 수준에서 시작.

## Why continue-on-error

현재 `pnpm audit --prod` 실행 시 기존 의존성에서 high 이상 취약점이 존재할 가능성이 있음(push 시 GitHub이 52건 알림). 먼저 가시성만 확보하고, 기준치를 낮춘 뒤 `continue-on-error` 를 제거하는 후속 PR 로 진행.

## Test plan

- [x] 로컬 `pnpm audit --prod --audit-level=high` 동작 확인
- [ ] PR CI 에서 `audit` 잡 실행 결과 확인
- [ ] 취약점 정리 후 `continue-on-error` 제거

## Follow-ups

- 현재 dependabot 알림 52건 분류 및 처리
- `pnpm.overrides` 5건 정기 점검 문서화

Closes #232

https://claude.ai/code/session_01PgpctCVveAx3FGT21pKFCw