### PR TITLE
feat(#216): add schema.org Course JSON-LD to roadmap pages

### DIFF
--- a/src/app/(community)/community/[id]/page.tsx
+++ b/src/app/(community)/community/[id]/page.tsx
@@ -1,4 +1,6 @@
+import { JsonLd } from '@/components/JsonLd';
 import { RoadmapDetail } from '@/features/community';
+import { buildRoadmapJsonLd } from '@/lib/json-ld';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -6,5 +8,14 @@ interface PageProps {
 
 export default async function RoadmapDetailPage({ params }: PageProps) {
   const { id } = await params;
-  return <RoadmapDetail id={Number(id)} />;
+
+  // TODO(#224): 백엔드 로드맵 메타 조회 후 JSON-LD 에 실데이터 주입
+  const jsonLd = buildRoadmapJsonLd({ id, title: `자갈치 로드맵 #${id}` });
+
+  return (
+    <>
+      {jsonLd ? <JsonLd data={jsonLd} /> : null}
+      <RoadmapDetail id={Number(id)} />
+    </>
+  );
 }

--- a/src/app/viewer/[id]/page.tsx
+++ b/src/app/viewer/[id]/page.tsx
@@ -1,4 +1,6 @@
+import { JsonLd } from '@/components/JsonLd';
 import { RoadmapViewer } from '@/features/roadmap-viewer';
+import { buildRoadmapJsonLd } from '@/lib/json-ld';
 
 interface ViewerPageProps {
   params: Promise<{ id: string }>;
@@ -7,5 +9,13 @@ interface ViewerPageProps {
 export default async function ViewerPage({ params }: ViewerPageProps) {
   const { id } = await params;
 
-  return <RoadmapViewer roadmapId={id} />;
+  // TODO(#224): 백엔드 로드맵 메타 조회 후 JSON-LD 에 실데이터 주입
+  const jsonLd = buildRoadmapJsonLd({ id, title: `자갈치 로드맵 #${id}` });
+
+  return (
+    <>
+      {jsonLd ? <JsonLd data={jsonLd} /> : null}
+      <RoadmapViewer roadmapId={id} />
+    </>
+  );
 }

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,13 @@
+interface JsonLdProps {
+  data: Record<string, unknown>;
+}
+
+/**
+ * 구조화 데이터(schema.org)를 <script type="application/ld+json"> 로 주입한다.
+ * XSS 방지를 위해 `<` 을 유니코드 escape 한다.
+ */
+export function JsonLd({ data }: JsonLdProps) {
+  const json = JSON.stringify(data).replace(/</g, '\\u003c');
+
+  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: json }} />;
+}

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,0 +1,46 @@
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://jagalchi.dev';
+
+export interface RoadmapJsonLdInput {
+  id: string | number;
+  title: string;
+  description?: string;
+  authorName?: string;
+  authorUrl?: string;
+  imageUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/**
+ * 로드맵 상세 페이지용 schema.org Course 구조화 데이터.
+ * 데이터가 없을 때는 null 을 반환해 script 주입을 건너뛰도록 한다.
+ */
+export function buildRoadmapJsonLd(
+  input: RoadmapJsonLdInput | null,
+): Record<string, unknown> | null {
+  if (!input) return null;
+
+  const url = `${SITE_URL}/viewer/${input.id}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Course',
+    name: input.title,
+    description: input.description,
+    url,
+    ...(input.imageUrl ? { image: input.imageUrl } : {}),
+    ...(input.authorName
+      ? {
+          provider: {
+            '@type': 'Person',
+            name: input.authorName,
+            ...(input.authorUrl ? { url: input.authorUrl } : {}),
+          },
+        }
+      : {}),
+    ...(input.createdAt ? { dateCreated: input.createdAt } : {}),
+    ...(input.updatedAt ? { dateModified: input.updatedAt } : {}),
+    inLanguage: 'ko',
+    isAccessibleForFree: true,
+  };
+}


### PR DESCRIPTION
## Summary

#216 해결. 로드맵 상세/뷰어 페이지에 schema.org `Course` JSON-LD 주입.

- `src/components/JsonLd.tsx` — XSS 방어를 위한 `<` 이스케이프 포함 `<script type="application/ld+json">` 공용 컴포넌트
- `src/lib/json-ld.ts` — `buildRoadmapJsonLd()` 로 Course 스키마 생성 (Person provider, dateCreated/Modified 등)
- `src/app/viewer/[id]/page.tsx`, `src/app/(community)/community/[id]/page.tsx` — 서버 컴포넌트에서 JSON-LD 주입

현재는 `params.id` 만 있으므로 플레이스홀더 제목을 사용. 백엔드 로드맵 메타 API 연동되는 #224 에서 실데이터로 교체.

## Test plan

- [x] `pnpm build` 통과
- [ ] `/viewer/:id` 응답 HTML 에 `<script type="application/ld+json">` 포함 확인
- [ ] Google Rich Results Test 검증
- [ ] 실데이터 연동 후(#224) Course 필드 완성도 점검

Closes #216

https://claude.ai/code/session_01PgpctCVveAx3FGT21pKFCw