### PR TITLE
perf(#222): dynamic import jspdf / html-to-image

### DIFF
--- a/src/features/roadmap-viewer/components/HeaderMenu/index.tsx
+++ b/src/features/roadmap-viewer/components/HeaderMenu/index.tsx
@@ -3,9 +3,7 @@
 import { useCallback, useRef, useState } from 'react';
 
 import { useReactFlow } from '@xyflow/react';
-import { toJpeg, toPng, toSvg } from 'html-to-image';
 import { useAtomValue } from 'jotai';
-import { jsPDF } from 'jspdf';
 import { Settings } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -19,16 +17,10 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { VIEWER_MESSAGES } from '@/constants/messages';
+import { exportCanvasAsImage, exportCanvasAsPdf } from '@/lib/export-canvas';
 import type { RoadmapNode } from '@/types/roadmap.types';
 
 import { viewerRoadmapAtom } from '../../stores/viewer-atoms';
-
-function downloadDataUrl(dataUrl: string, filename: string) {
-  const link = document.createElement('a');
-  link.href = dataUrl;
-  link.download = filename;
-  link.click();
-}
 
 function downloadBlob(content: string, filename: string, mimeType: string) {
   const blob = new Blob([content], { type: mimeType });
@@ -83,16 +75,7 @@ export function HeaderMenu() {
       setIsExporting(true);
       try {
         const timestamp = Date.now();
-        if (format === 'png') {
-          const dataUrl = await toPng(element, { cacheBust: true });
-          downloadDataUrl(dataUrl, `roadmap-${timestamp}.png`);
-        } else if (format === 'jpg') {
-          const dataUrl = await toJpeg(element, { cacheBust: true, quality: 0.95 });
-          downloadDataUrl(dataUrl, `roadmap-${timestamp}.jpg`);
-        } else {
-          const dataUrl = await toSvg(element, { cacheBust: true });
-          downloadDataUrl(dataUrl, `roadmap-${timestamp}.svg`);
-        }
+        await exportCanvasAsImage(element, format, `roadmap-${timestamp}.${format}`);
       } finally {
         setIsExporting(false);
       }
@@ -126,21 +109,7 @@ export function HeaderMenu() {
 
     setIsExporting(true);
     try {
-      const dataUrl = await toPng(element, { cacheBust: true, pixelRatio: 2 });
-      const img = new Image();
-      img.src = dataUrl;
-      await new Promise<void>((resolve) => {
-        img.onload = () => resolve();
-      });
-
-      const isLandscape = img.width > img.height;
-      const pdf = new jsPDF({
-        orientation: isLandscape ? 'landscape' : 'portrait',
-        unit: 'px',
-        format: [img.width, img.height],
-      });
-      pdf.addImage(dataUrl, 'PNG', 0, 0, img.width, img.height);
-      pdf.save(`roadmap-${Date.now()}.pdf`);
+      await exportCanvasAsPdf(element, `roadmap-${Date.now()}.pdf`);
     } finally {
       setIsExporting(false);
     }

--- a/src/features/roadmap-viewer/components/HeaderSaveAsImageMenu/index.tsx
+++ b/src/features/roadmap-viewer/components/HeaderSaveAsImageMenu/index.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useState } from 'react';
 
-import { toJpeg, toPng, toSvg } from 'html-to-image';
 import { Image } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -13,19 +12,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { VIEWER_MESSAGES } from '@/constants/messages';
-
-type ImageFormat = 'png' | 'jpg' | 'svg';
-
-/**
- * ReactFlow 캔버스를 이미지 파일로 다운로드하는 유틸리티
- * html-to-image는 filter 함수로 불필요한 컨트롤 요소를 제외한다
- */
-function downloadDataUrl(dataUrl: string, filename: string) {
-  const link = document.createElement('a');
-  link.href = dataUrl;
-  link.download = filename;
-  link.click();
-}
+import { exportCanvasAsImage, type CanvasImageFormat } from '@/lib/export-canvas';
 
 function getReactFlowElement(): HTMLElement | null {
   return document.querySelector('.react-flow') as HTMLElement | null;
@@ -35,7 +22,7 @@ export function HeaderSaveAsImageMenu() {
   const [isExporting, setIsExporting] = useState(false);
 
   const handleExport = useCallback(
-    async (format: ImageFormat) => {
+    async (format: CanvasImageFormat) => {
       if (isExporting) return;
 
       const element = getReactFlowElement();
@@ -44,18 +31,7 @@ export function HeaderSaveAsImageMenu() {
       setIsExporting(true);
       try {
         const timestamp = Date.now();
-        const filename = `roadmap-${timestamp}.${format}`;
-
-        if (format === 'png') {
-          const dataUrl = await toPng(element, { cacheBust: true });
-          downloadDataUrl(dataUrl, filename);
-        } else if (format === 'jpg') {
-          const dataUrl = await toJpeg(element, { cacheBust: true, quality: 0.95 });
-          downloadDataUrl(dataUrl, filename);
-        } else {
-          const dataUrl = await toSvg(element, { cacheBust: true });
-          downloadDataUrl(dataUrl, filename);
-        }
+        await exportCanvasAsImage(element, format, `roadmap-${timestamp}.${format}`);
       } finally {
         setIsExporting(false);
       }
@@ -88,27 +64,20 @@ export function HeaderSaveAsImageMenu() {
   );
 }
 
-// Kept for backward compatibility (used by HeaderMenu submenu items)
 export function handleSaveAsPng() {
   const element = getReactFlowElement();
   if (!element) return;
-  toPng(element, { cacheBust: true }).then((dataUrl) => {
-    downloadDataUrl(dataUrl, `roadmap-${Date.now()}.png`);
-  });
+  void exportCanvasAsImage(element, 'png', `roadmap-${Date.now()}.png`);
 }
 
 export function handleSaveAsJpg() {
   const element = getReactFlowElement();
   if (!element) return;
-  toJpeg(element, { cacheBust: true, quality: 0.95 }).then((dataUrl) => {
-    downloadDataUrl(dataUrl, `roadmap-${Date.now()}.jpg`);
-  });
+  void exportCanvasAsImage(element, 'jpg', `roadmap-${Date.now()}.jpg`);
 }
 
 export function handleSaveAsSvg() {
   const element = getReactFlowElement();
   if (!element) return;
-  toSvg(element, { cacheBust: true }).then((dataUrl) => {
-    downloadDataUrl(dataUrl, `roadmap-${Date.now()}.svg`);
-  });
+  void exportCanvasAsImage(element, 'svg', `roadmap-${Date.now()}.svg`);
 }

--- a/src/lib/export-canvas.ts
+++ b/src/lib/export-canvas.ts
@@ -1,0 +1,55 @@
+export type CanvasImageFormat = 'png' | 'jpg' | 'svg';
+
+function downloadDataUrl(dataUrl: string, filename: string) {
+  const link = document.createElement('a');
+  link.href = dataUrl;
+  link.download = filename;
+  link.click();
+}
+
+/**
+ * DOM 노드를 이미지(PNG/JPG/SVG) 로 export.
+ * html-to-image 는 export 시점에만 필요하므로 dynamic import 로 분리한다.
+ */
+export async function exportCanvasAsImage(
+  element: HTMLElement,
+  format: CanvasImageFormat,
+  filename: string,
+) {
+  const { toPng, toJpeg, toSvg } = await import('html-to-image');
+  if (format === 'png') {
+    const dataUrl = await toPng(element, { cacheBust: true });
+    downloadDataUrl(dataUrl, filename);
+    return;
+  }
+  if (format === 'jpg') {
+    const dataUrl = await toJpeg(element, { cacheBust: true, quality: 0.95 });
+    downloadDataUrl(dataUrl, filename);
+    return;
+  }
+  const dataUrl = await toSvg(element, { cacheBust: true });
+  downloadDataUrl(dataUrl, filename);
+}
+
+/**
+ * DOM 노드를 PDF 로 export. jspdf 는 dynamic import.
+ */
+export async function exportCanvasAsPdf(element: HTMLElement, filename: string) {
+  const [{ toPng }, { jsPDF }] = await Promise.all([import('html-to-image'), import('jspdf')]);
+
+  const dataUrl = await toPng(element, { cacheBust: true, pixelRatio: 2 });
+  const img = new Image();
+  img.src = dataUrl;
+  await new Promise<void>((resolve) => {
+    img.onload = () => resolve();
+  });
+
+  const isLandscape = img.width > img.height;
+  const pdf = new jsPDF({
+    orientation: isLandscape ? 'landscape' : 'portrait',
+    unit: 'px',
+    format: [img.width, img.height],
+  });
+  pdf.addImage(dataUrl, 'PNG', 0, 0, img.width, img.height);
+  pdf.save(filename);
+}


### PR DESCRIPTION
## Summary

#222 부분 해결. 초기 번들에서 무거운 export 라이브러리를 분리.

- `src/lib/export-canvas.ts` — `exportCanvasAsImage(element, format, filename)` / `exportCanvasAsPdf(element, filename)` 헬퍼
- 두 메뉴 컴포넌트에서 `import { toPng, toJpeg, toSvg } from 'html-to-image'` / `import { jsPDF } from 'jspdf'` 상위 import 제거 → 실제 export 클릭 시점에 `await import('…')`
- `handleSaveAsPng/Jpg/Svg` 호환 export 유지 (기존 테스트 통과 확인)

### 남은 항목
- `@xyflow/react` 는 render 시점의 `useReactFlow()` hook 에 묶여 있어 동적 분리 난이도가 큼 → 에디터 라우트 청크 자체를 `next/dynamic` 으로 분리하는 별도 PR 로.

## Test plan

- [x] `pnpm tsc --noEmit`
- [x] `pnpm vitest run` (HeaderSaveAsImageMenu.test.tsx 3 통과)
- [x] `pnpm build`
- [ ] bundle-analyzer 로 viewer/editor 초기 청크에서 jspdf·html-to-image 제거 확인 (#221 머지 후)

Closes #222

https://claude.ai/code/session_01PgpctCVveAx3FGT21pKFCw