### PR TITLE
refactor(#203): double-guard MSW + prod env verify script

### DIFF
--- a/scripts/verify-prod-env.mjs
+++ b/scripts/verify-prod-env.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * 프로덕션 배포 전 환경변수 안전성 검증.
+ * Vercel/Netlify 프로덕션 빌드 파이프라인에서 호출하여 실수로 mocking 이 켜지지 않도록 막는다.
+ */
+const errors = [];
+
+if (process.env.NEXT_PUBLIC_API_MOCKING === 'true') {
+  errors.push(
+    'NEXT_PUBLIC_API_MOCKING must not be "true" in production — MSW should never intercept real users.',
+  );
+}
+
+if (!process.env.NEXT_PUBLIC_API_URL) {
+  errors.push('NEXT_PUBLIC_API_URL is required in production.');
+}
+
+if (errors.length > 0) {
+  console.error('[verify-prod-env] production env checks failed:');
+  for (const err of errors) {
+    console.error(` - ${err}`);
+  }
+  process.exit(1);
+}
+
+console.log('[verify-prod-env] OK');

--- a/src/components/MswProvider.tsx
+++ b/src/components/MswProvider.tsx
@@ -2,7 +2,16 @@
 
 import { useEffect, useState } from 'react';
 
-const isMockingEnabled = process.env.NEXT_PUBLIC_API_MOCKING === 'true';
+/**
+ * MSW는 개발/프리뷰 환경에서만 허용. 프로덕션 번들 유입을 막기 위해
+ * 두 조건을 모두 만족해야 동작한다:
+ *   1) NEXT_PUBLIC_API_MOCKING === 'true'
+ *   2) NODE_ENV !== 'production'
+ * 프로덕션 배포에서 실수로 NEXT_PUBLIC_API_MOCKING 가 true 로 설정되더라도
+ * NODE_ENV 가 production 이므로 MSW 가 로드되지 않는다.
+ */
+const isMockingEnabled =
+  process.env.NEXT_PUBLIC_API_MOCKING === 'true' && process.env.NODE_ENV !== 'production';
 
 export function MSWProvider({ children }: { children: React.ReactNode }) {
   const [isReady, setIsReady] = useState(!isMockingEnabled);

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,6 +1,7 @@
-/** 브라우저 환경에서 MSW를 조건부로 초기화 */
+/** 브라우저 환경에서 MSW를 조건부로 초기화 (프로덕션 차단 이중 가드) */
 export async function initMocks() {
   if (process.env.NEXT_PUBLIC_API_MOCKING !== 'true') return;
+  if (process.env.NODE_ENV === 'production') return;
 
   if (typeof window !== 'undefined') {
     const { worker } = await import('./browser');


### PR DESCRIPTION
## Summary

#203 해결. MSW 가 프로덕션 유저에게 영향 주지 않도록 **이중 가드 + 배포 전 검증 스크립트** 도입.

### 런타임 이중 가드
`NEXT_PUBLIC_API_MOCKING === 'true' && NODE_ENV !== 'production'` 양쪽이 모두 만족해야 MSW가 동작. 실수로 프로덕션 환경변수에 `true` 를 넣어도 `NODE_ENV=production` 이라 차단된다.

- `src/components/MswProvider.tsx`
- `src/mocks/index.ts`

### 파이프라인 검증
- `scripts/verify-prod-env.mjs` — Vercel/Netlify/CI 프로덕션 빌드 전에 호출.
  - `NEXT_PUBLIC_API_MOCKING=true` → exit 1
  - `NEXT_PUBLIC_API_URL` 누락 → exit 1
  - Vercel 프로젝트 설정에서 `Build Command` 앞에 `node scripts/verify-prod-env.mjs &&` prefix 권장 (별도 PR 로 파이프라인 지정).

## Test plan

- [x] `pnpm build` 통과
- [x] `NEXT_PUBLIC_API_MOCKING=true node scripts/verify-prod-env.mjs` → exit 1
- [x] `NEXT_PUBLIC_API_URL=... node scripts/verify-prod-env.mjs` → exit 0
- [ ] Vercel 프로젝트 설정에서 Build Command prefix 적용

## Follow-ups

- 번들 webpack/turbopack alias 로 프로덕션에서 `msw`, `src/mocks/*` 를 빈 모듈로 치환 (#210 환경변수 표준화 묶어 진행 가능)
- `public/mockServiceWorker.js` 배포 스크립트에서 제외

Closes #203

https://claude.ai/code/session_01PgpctCVveAx3FGT21pKFCw