### PR TITLE
chore(#210): standardize production env + deployment docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,28 @@
+# ─── Public (client-side) ───────────────────────────────────────────────
+# Same-origin proxy target. `/api/*` 는 이 origin 으로 포워딩된다.
 NEXT_PUBLIC_API_URL=https://api.jagalchi.dev
+
+# WebSocket upstream (STOMP). #226 실시간 협업에서 사용.
+NEXT_PUBLIC_WS_URL=wss://api.jagalchi.dev/ws
+
+# 사이트 절대 URL. robots/sitemap/JSON-LD/OpenGraph 에서 사용.
+NEXT_PUBLIC_SITE_URL=https://jagalchi.dev
+
+# 환경 이름 ("production" | "staging" | "preview" | "development").
+# production 이외 환경에서는 robots 가 noindex 응답한다.
+NEXT_PUBLIC_ENV=production
+
+# Feature flags
 NEXT_PUBLIC_API_MOCKING=false
 NEXT_PUBLIC_REALTIME_ENABLED=false
-NEXT_PUBLIC_WS_URL=wss://api.jagalchi.dev/ws
+
+# ─── Server-only (client 번들에 노출되지 않음) ──────────────────────────
+# API 프록시(`src/app/api/[...path]/route.ts`) 의 upstream origin.
+# NEXT_PUBLIC_API_URL 과 동일하게 두되, 서버 전용 변수로 교체 가능.
+API_ORIGIN=https://api.jagalchi.dev
+
+# Sentry (#204) — 프로덕션 배포에서 주입
+# SENTRY_DSN=
+# SENTRY_ORG=
+# SENTRY_PROJECT=
+# SENTRY_AUTH_TOKEN=

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,57 @@
+# Deployment
+
+Jagalchi Client 의 프로덕션 배포 가이드. 운영 타깃은 **Vercel** 을 단일 표준으로 본다. `Dockerfile`, `docker-compose.yml`, `netlify.toml` 은 자체 호스팅/백업 용도로 유지.
+
+## 환경변수 매트릭스
+
+| 변수                            | 필수 | Production                  | Preview / Staging              | Development              |
+| ------------------------------- | ---- | --------------------------- | ------------------------------ | ------------------------ |
+| `NEXT_PUBLIC_API_URL`           | ✅   | `https://api.jagalchi.dev`  | staging 백엔드                 | `http://localhost:8080`  |
+| `NEXT_PUBLIC_WS_URL`            | ✅   | `wss://api.jagalchi.dev/ws` | staging                        | `ws://localhost:8080/ws` |
+| `NEXT_PUBLIC_SITE_URL`          | ✅   | `https://jagalchi.dev`      | `https://staging.jagalchi.dev` | `http://localhost:3000`  |
+| `NEXT_PUBLIC_ENV`               | ✅   | `production`                | `staging` / `preview`          | `development`            |
+| `NEXT_PUBLIC_API_MOCKING`       | ⚠️   | **반드시 `false`**          | `false`                        | `true` 가능              |
+| `NEXT_PUBLIC_REALTIME_ENABLED`  | ❌   | 플래그                      | 플래그                         | 플래그                   |
+| `API_ORIGIN`                    | ✅   | 백엔드 내부 origin          | 동일                           | `http://localhost:8080`  |
+| `SENTRY_DSN`                    | ⚠️   | 설정 필수(#204)             | 설정                           | (선택)                   |
+| `SENTRY_ORG` / `SENTRY_PROJECT` | ⚠️   | Source Map 업로드용         | 동일                           | 불필요                   |
+| `SENTRY_AUTH_TOKEN`             | ⚠️   | Secret (CI only)            | Secret                         | 불필요                   |
+
+⚠️ 표시는 프로덕션에서 실수 시 장애 직결.
+
+## 배포 전 사전 검증
+
+`scripts/verify-prod-env.mjs` 를 Vercel Build Command 에 prefix 한다.
+
+```
+node scripts/verify-prod-env.mjs && pnpm build
+```
+
+검증 내용:
+
+- `NEXT_PUBLIC_API_MOCKING` 이 `true` 면 exit 1 (MSW 유입 차단)
+- `NEXT_PUBLIC_API_URL` 미설정 시 exit 1
+
+## 시크릿 관리
+
+- **Vercel**: Project Settings → Environment Variables 에서 `Production` / `Preview` / `Development` 로 분리.
+- **GitHub Actions**: Repository Settings → Secrets and variables → Actions.
+- **로컬**: `.env.local` (gitignored) 에 개인 값. `.env.development` 는 commit 된 기본값이며 실제 시크릿 금지.
+
+## 롤백
+
+Vercel 배포판은 commit 단위로 보존. 장애 발생 시 Dashboard → Deployments → 이전 deployment 에서 **"Promote to Production"**. 별도 CI 재실행 불필요.
+
+## 배포 대상 단일화 사유
+
+세 후보 비교:
+
+|                       | Vercel             | Netlify                   | Docker 셀프호스팅 |
+| --------------------- | ------------------ | ------------------------- | ----------------- |
+| Next.js 16 App Router | 퍼스트파티         | 지원(edge/functions 제약) | 직접 관리         |
+| Preview URL           | 자동               | 자동                      | 미지원            |
+| Edge runtime          | ✅                 | 제한적                    | 직접 관리         |
+| 비용                  | 무료 tier + 사용량 | 무료 tier + 사용량        | 인프라 비용 전체  |
+| 롤백 UX               | 원클릭             | 원클릭                    | 수동              |
+
+→ **Vercel** 을 기본으로 고정. 셀프호스팅이 필요해지면 Docker 경로로 선택적으로 전환.


### PR DESCRIPTION
## Summary

#210 해결. 프로덕션 환경변수 전수 정리와 배포 표준화 문서화.

### 변경
- `.env.example` 섹션/주석 정리, `NEXT_PUBLIC_SITE_URL`, `NEXT_PUBLIC_ENV`, `API_ORIGIN`, `SENTRY_*` 플레이스홀더 추가.
- `docs/deployment.md` 신규:
  - 환경변수 매트릭스 (Production/Preview/Development)
  - `scripts/verify-prod-env.mjs` (#203) 연계 Vercel Build Command 안내
  - 시크릿 관리 (Vercel / GitHub Actions / 로컬)
  - 롤백 가이드
  - **Vercel 단일화** 사유 (Netlify/Docker 대비표) — `Dockerfile`, `netlify.toml` 는 자체호스팅 대비로 유지

### 의도적 제외
- Vercel 프로젝트 설정 자체 변경 (Build Command prefix 등)은 리포 외 작업 — README 지시로만 반영
- 기존 `Dockerfile`, `netlify.toml` 파일 삭제하지 않음

## Test plan

- [x] `.env.example` 파싱 확인
- [ ] Vercel Project Settings 에서 매트릭스 기준 값 주입
- [ ] Build Command prefix 적용 후 `NEXT_PUBLIC_API_MOCKING=true` 실수 방지 검증

Closes #210

https://claude.ai/code/session_01PgpctCVveAx3FGT21pKFCw