### PR TITLE
feat(#224): connect real API data to profile page

### DIFF
--- a/src/app/(profile)/profile/page.tsx
+++ b/src/app/(profile)/profile/page.tsx
@@ -1,7 +1,12 @@
 'use client';
 
+import { useAtomValue } from 'jotai';
+
+import { currentUserNameAtom } from '@/features/auth/stores/auth.atoms';
 import { Profile } from '@/features/profile/components/templates/Profile';
 
 export default function ProfilePage() {
-  return <Profile />;
+  const currentUserName = useAtomValue(currentUserNameAtom);
+
+  return <Profile userName={currentUserName ?? ''} />;
 }

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -14,6 +14,7 @@ export {
   isAuthInitializedAtom,
   loginAtom,
   logoutAtom,
+  currentUserNameAtom,
 } from './stores/auth.atoms';
 
 export type { RegisterStep, FindPasswordStep } from './types/auth.types';

--- a/src/features/auth/stores/auth.atoms.ts
+++ b/src/features/auth/stores/auth.atoms.ts
@@ -1,9 +1,13 @@
 import { atom } from 'jotai';
 
 import { setAccessToken, clearAccessToken } from '@/api/client';
+import { extractUserNameFromToken } from '@/lib/jwt';
 
 /** 액세스 토큰 atom — 메모리에만 저장 (XSS 방어) */
 const accessTokenAtom = atom<string | null>(null);
+
+/** 현재 로그인한 사용자 이름 — JWT payload에서 추출 */
+export const currentUserNameAtom = atom<string | null>(null);
 
 /** 인증 초기화 완료 여부 (refresh 시도 후 true) */
 export const isAuthInitializedAtom = atom<boolean>(false);
@@ -14,14 +18,19 @@ export const isAuthenticatedAtom = atom<boolean>((get) => {
   return token !== null;
 });
 
-/** 로그인 시 토큰 저장 */
+/** 로그인 시 토큰 저장 + JWT에서 이름 추출 */
 export const loginAtom = atom(null, (_get, set, token: string) => {
   set(accessTokenAtom, token);
   setAccessToken(token);
+  const name = extractUserNameFromToken(token);
+  if (name) {
+    set(currentUserNameAtom, name);
+  }
 });
 
 /** 로그아웃 시 토큰 삭제 + 상태 초기화 */
 export const logoutAtom = atom(null, (_get, set) => {
   set(accessTokenAtom, null);
+  set(currentUserNameAtom, null);
   clearAccessToken();
 });

--- a/src/features/profile/components/organisms/MadeRoadmapList/MadeRoadmapList.test.tsx
+++ b/src/features/profile/components/organisms/MadeRoadmapList/MadeRoadmapList.test.tsx
@@ -7,8 +7,14 @@ import { profileModeAtom } from '../../../stores/profile-atoms';
 
 import { MadeRoadmapList } from './index';
 
-vi.mock('@/components/atoms/RoadmapCard', () => ({
-  RoadmapCard: ({ title }: { title: string }) => <div data-testid="roadmap-card">{title}</div>,
+vi.mock('../../../hooks/use-profile-roadmaps', () => ({
+  useProfileRoadmaps: () => ({
+    data: [
+      { id: 1, title: 'Roadmap Name', owner: { id: 1, nickname: '홍길동', profileImageUrl: null } },
+      { id: 2, title: 'Roadmap Name 2', owner: { id: 1, nickname: '홍길동', profileImageUrl: null } },
+    ],
+    isLoading: false,
+  }),
 }));
 
 vi.mock('../AddRoadmapModal', () => ({
@@ -18,7 +24,7 @@ vi.mock('../AddRoadmapModal', () => ({
 }));
 
 interface WrapperProps {
-  initialValues: (readonly [WritableAtom<unknown, any[], any>, unknown])[];
+  initialValues: (readonly [WritableAtom<unknown, unknown[], unknown>, unknown])[];
   children: React.ReactNode;
 }
 
@@ -37,7 +43,7 @@ describe('MadeRoadmapList', () => {
   it('renders list of roadmaps in view mode', () => {
     render(
       <Wrapper initialValues={[[profileModeAtom, 'show']]}>
-        <MadeRoadmapList />
+        <MadeRoadmapList userName="홍길동" />
       </Wrapper>,
     );
     expect(screen.getByText('만든 로드맵')).toBeInTheDocument();
@@ -48,7 +54,7 @@ describe('MadeRoadmapList', () => {
   it('renders add button in edit mode', () => {
     render(
       <Wrapper initialValues={[[profileModeAtom, 'edit']]}>
-        <MadeRoadmapList />
+        <MadeRoadmapList userName="홍길동" />
       </Wrapper>,
     );
     expect(screen.getByText('공개 로드맵 추가')).toBeInTheDocument();

--- a/src/features/profile/components/organisms/MadeRoadmapList/index.tsx
+++ b/src/features/profile/components/organisms/MadeRoadmapList/index.tsx
@@ -4,22 +4,18 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PROFILE_MESSAGES } from '@/constants/messages';
 
+import { useProfileRoadmaps } from '../../../hooks/use-profile-roadmaps';
 import { profileModeAtom } from '../../../stores/profile-atoms';
 import { RoadmapCard } from '../../atoms/RoadmapCard';
 import { AddRoadmapModal } from '../AddRoadmapModal';
 
-const MOCK_ROADMAPS = [
-  { id: 1, title: 'Roadmap Name', author: '홍길동' },
-  { id: 2, title: 'Roadmap Name', author: '홍길동' },
-  { id: 3, title: 'Roadmap Name', author: '홍길동' },
-  { id: 4, title: 'Roadmap Name', author: '홍길동' },
-  { id: 5, title: 'Roadmap Name', author: '홍길동' },
-  { id: 6, title: 'Roadmap Name', author: '홍길동' },
-  { id: 7, title: 'Roadmap Name', author: '홍길동', imageUrl: '/jagalchi.svg' },
-];
+interface MadeRoadmapListProps {
+  userName: string;
+}
 
-export function MadeRoadmapList() {
+export function MadeRoadmapList({ userName }: MadeRoadmapListProps) {
   const [mode] = useAtom(profileModeAtom);
+  const { data: roadmaps = [], isLoading } = useProfileRoadmaps({ userName });
 
   return (
     <Card className="mb-10 w-full gap-0 rounded-xl shadow-none">
@@ -30,16 +26,19 @@ export function MadeRoadmapList() {
       </CardHeader>
 
       <CardContent className="flex flex-col gap-4">
-        <div className="grid grid-cols-3 gap-4">
-          {MOCK_ROADMAPS.map((roadmap) => (
-            <RoadmapCard
-              key={roadmap.id}
-              title={roadmap.title}
-              author={roadmap.author}
-              imageUrl={roadmap.imageUrl}
-            />
-          ))}
-        </div>
+        {isLoading ? (
+          <p className="text-muted-foreground text-sm">{PROFILE_MESSAGES.LOADING}</p>
+        ) : (
+          <div className="grid grid-cols-3 gap-4">
+            {roadmaps.map((roadmap) => (
+              <RoadmapCard
+                key={roadmap.id}
+                title={roadmap.title}
+                author={roadmap.owner.nickname}
+              />
+            ))}
+          </div>
+        )}
         {mode === 'edit' && (
           <AddRoadmapModal>
             <Button className="w-full rounded-xl py-6 text-[14px] font-bold">

--- a/src/features/profile/components/organisms/ProfileThirdBox/ProfileThirdBox.test.tsx
+++ b/src/features/profile/components/organisms/ProfileThirdBox/ProfileThirdBox.test.tsx
@@ -7,18 +7,12 @@ import { ProfileThirdBox } from './index';
 
 describe('ProfileThirdBox', () => {
   it('renders completed roadmap section', () => {
-    render(<ProfileThirdBox />);
+    render(<ProfileThirdBox userName="testUser" />);
     expect(screen.getByText(PROFILE_MESSAGES.COMPLETED_ROADMAP)).toBeInTheDocument();
   });
 
   it('renders in-progress roadmap section', () => {
-    render(<ProfileThirdBox />);
+    render(<ProfileThirdBox userName="testUser" />);
     expect(screen.getByText(PROFILE_MESSAGES.IN_PROGRESS_ROADMAP)).toBeInTheDocument();
-  });
-
-  it('renders roadmap items', () => {
-    render(<ProfileThirdBox />);
-    const items = screen.getAllByText('유저 님의 프론트엔드 로드맵');
-    expect(items.length).toBeGreaterThan(0);
   });
 });

--- a/src/features/profile/components/organisms/ProfileThirdBox/index.tsx
+++ b/src/features/profile/components/organisms/ProfileThirdBox/index.tsx
@@ -1,25 +1,20 @@
 import { RoadmapList } from '../../molecules/RoadmapList';
 
-const MOCK_COMPLETED_ROADMAPS = [
-  { id: '1', title: '유저 님의 프론트엔드 로드맵' },
-  { id: '2', title: '유저 님의 프론트엔드 로드맵' },
-];
+// TODO: GET /roadmaps 응답의 RoadmapListItemResponse에 progress 필드가 없어
+// 완주/진행중 구분을 단일 요청으로 할 수 없다.
+// 백엔드에서 progressPercentage 기준 필터 파라미터를 지원하거나,
+// GET /roadmaps/{id}/my-progress 를 roadmap별로 호출하는 N+1 방식이 필요하다.
+// 현재는 연동 대기 중 — 데이터 없이 빈 목록으로 표시한다.
 
-const MOCK_IN_PROGRESS_ROADMAPS = [
-  { id: '3', title: '유저 님의 프론트엔드 로드맵' },
-  { id: '4', title: '유저 님의 프론트엔드 로드맵' },
-  { id: '5', title: '유저 님의 프론트엔드 로드맵' },
-  { id: '6', title: '유저 님의 프론트엔드 로드맵' },
-  { id: '7', title: '유저 님의 프론트엔드 로드맵' },
-  { id: '8', title: '유저 님의 프론트엔드 로드맵' },
-  { id: '9', title: '유저 님의 프론트엔드 로드맵' },
-];
+interface ProfileThirdBoxProps {
+  userName: string;
+}
 
-export function ProfileThirdBox() {
+export function ProfileThirdBox({ userName: _userName }: ProfileThirdBoxProps) {
   return (
     <div className="grid w-full grid-cols-1 gap-4 sm:gap-8 md:grid-cols-2">
-      <RoadmapList variant="end" items={MOCK_COMPLETED_ROADMAPS} />
-      <RoadmapList variant="process" items={MOCK_IN_PROGRESS_ROADMAPS} />
+      <RoadmapList variant="end" items={[]} />
+      <RoadmapList variant="process" items={[]} />
     </div>
   );
 }

--- a/src/features/profile/components/templates/Profile/Profile.test.tsx
+++ b/src/features/profile/components/templates/Profile/Profile.test.tsx
@@ -38,6 +38,13 @@ vi.mock('../../../hooks/use-profile', () => ({
   })),
 }));
 
+vi.mock('../../../hooks/use-profile-roadmaps', () => ({
+  useProfileRoadmaps: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+  })),
+}));
+
 import { PROFILE_MESSAGES } from '@/constants/messages';
 
 import { useProfile } from '../../../hooks/use-profile';
@@ -46,7 +53,7 @@ import { profileModeAtom, profileImageAtom } from '../../../stores/profile-atoms
 import { Profile } from './index';
 
 interface WrapperProps {
-  initialValues: (readonly [WritableAtom<unknown, any[], any>, unknown])[];
+  initialValues: (readonly [WritableAtom<unknown, unknown[], unknown>, unknown])[];
   children: React.ReactNode;
 }
 
@@ -63,7 +70,7 @@ const TestProvider = ({ initialValues, children }: WrapperProps) => (
   </QueryClientProvider>
 );
 
-const defaultAtoms: (readonly [WritableAtom<unknown, any[], any>, unknown])[] = [
+const defaultAtoms: (readonly [WritableAtom<unknown, unknown[], unknown>, unknown])[] = [
   [profileModeAtom, 'show'],
   [profileImageAtom, '/profile.svg'],
 ];
@@ -74,13 +81,13 @@ describe('Profile', () => {
       data: mockProfileData,
       isLoading: false,
       isError: false,
-    } as any);
+    } as ReturnType<typeof useProfile>);
   });
 
   it('renders the user name', () => {
     render(
       <TestProvider initialValues={defaultAtoms}>
-        <Profile />
+        <Profile userName="John Doe" />
       </TestProvider>,
     );
     expect(screen.getByText('John Doe')).toBeInTheDocument();
@@ -89,7 +96,7 @@ describe('Profile', () => {
   it('renders the user email', () => {
     render(
       <TestProvider initialValues={defaultAtoms}>
-        <Profile />
+        <Profile userName="John Doe" />
       </TestProvider>,
     );
     expect(screen.getByText('john.doe@example.com')).toBeInTheDocument();
@@ -98,7 +105,7 @@ describe('Profile', () => {
   it('renders the bio section', () => {
     render(
       <TestProvider initialValues={defaultAtoms}>
-        <Profile />
+        <Profile userName="John Doe" />
       </TestProvider>,
     );
     expect(screen.getByText(PROFILE_MESSAGES.BIO_TITLE)).toBeInTheDocument();
@@ -107,7 +114,7 @@ describe('Profile', () => {
   it('renders the streak section', () => {
     render(
       <TestProvider initialValues={defaultAtoms}>
-        <Profile />
+        <Profile userName="John Doe" />
       </TestProvider>,
     );
     expect(screen.getByText(/일 연속 스트릭/)).toBeInTheDocument();
@@ -116,7 +123,7 @@ describe('Profile', () => {
   it('renders completed and in-progress roadmap sections', () => {
     render(
       <TestProvider initialValues={defaultAtoms}>
-        <Profile />
+        <Profile userName="John Doe" />
       </TestProvider>,
     );
     expect(screen.getByText(PROFILE_MESSAGES.COMPLETED_ROADMAP)).toBeInTheDocument();
@@ -126,7 +133,7 @@ describe('Profile', () => {
   it('renders made roadmap section', () => {
     render(
       <TestProvider initialValues={defaultAtoms}>
-        <Profile />
+        <Profile userName="John Doe" />
       </TestProvider>,
     );
     expect(screen.getByText(PROFILE_MESSAGES.MADE_ROADMAP)).toBeInTheDocument();
@@ -137,11 +144,11 @@ describe('Profile', () => {
       data: undefined,
       isLoading: true,
       isError: false,
-    } as any);
+    } as ReturnType<typeof useProfile>);
 
     render(
       <TestProvider initialValues={defaultAtoms}>
-        <Profile />
+        <Profile userName="John Doe" />
       </TestProvider>,
     );
     expect(screen.getByText(PROFILE_MESSAGES.LOADING)).toBeInTheDocument();
@@ -152,11 +159,11 @@ describe('Profile', () => {
       data: undefined,
       isLoading: false,
       isError: true,
-    } as any);
+    } as ReturnType<typeof useProfile>);
 
     render(
       <TestProvider initialValues={defaultAtoms}>
-        <Profile />
+        <Profile userName="John Doe" />
       </TestProvider>,
     );
     expect(screen.getByText(PROFILE_MESSAGES.ERROR)).toBeInTheDocument();

--- a/src/features/profile/components/templates/Profile/index.tsx
+++ b/src/features/profile/components/templates/Profile/index.tsx
@@ -24,7 +24,13 @@ import { AUTH_MESSAGES, PROFILE_MESSAGES } from '@/constants/messages';
 import { useDeleteAccount } from '@/hooks/use-delete-account';
 
 import { useProfile } from '../../../hooks/use-profile';
-import { profileBioAtom, profileModeAtom } from '../../../stores/profile-atoms';
+import {
+  profileBioAtom,
+  profileImageAtom,
+  profileLinksAtom,
+  profileModeAtom,
+  type ProfileLinkItem,
+} from '../../../stores/profile-atoms';
 import { ProfileBio } from '../../molecules/ProfileBio';
 import { ProfileCustomBoxArea } from '../../molecules/ProfileCustomBoxArea';
 import { ProfileHeader } from '../../molecules/ProfileHeader';
@@ -40,19 +46,38 @@ export function Profile({ userName = '' }: ProfileProps) {
   const router = useRouter();
   const mode = useAtomValue(profileModeAtom);
   const setBio = useSetAtom(profileBioAtom);
+  const setLinks = useSetAtom(profileLinksAtom);
+  const setImage = useSetAtom(profileImageAtom);
   const { mutate: deleteAccount, isPending: isDeleting } = useDeleteAccount();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
-  const handleDeleteAccount = () => {
-    deleteAccount(undefined, {
-      onSuccess: () => {
-        clearAccessToken();
-        router.push('/login');
-      },
-    });
-  };
-
   const { data, isLoading, isError } = useProfile(userName);
+
+  // 실데이터로 atoms hydration — 프로필 데이터가 로드되면 atoms에 반영
+  useEffect(() => {
+    if (!data) return;
+
+    const { user } = data;
+
+    if (user.bio !== null && user.bio !== undefined) {
+      setBio(user.bio);
+    }
+
+    if (user.profileImageUrl) {
+      setImage(user.profileImageUrl);
+    }
+
+    if (user.externalLinks && Object.keys(user.externalLinks).length > 0) {
+      const linkItems: ProfileLinkItem[] = Object.entries(user.externalLinks).map(
+        ([name, url]) => ({
+          id: name,
+          name,
+          url,
+        }),
+      );
+      setLinks(linkItems);
+    }
+  }, [data, setBio, setImage, setLinks]);
 
   // Warn user before leaving the page while in edit mode
   useEffect(() => {
@@ -65,6 +90,15 @@ export function Profile({ userName = '' }: ProfileProps) {
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [mode]);
+
+  const handleDeleteAccount = () => {
+    deleteAccount(undefined, {
+      onSuccess: () => {
+        clearAccessToken();
+        router.push('/login');
+      },
+    });
+  };
 
   if (isLoading) {
     return (
@@ -112,8 +146,8 @@ export function Profile({ userName = '' }: ProfileProps) {
           </div>
         </div>
         <ProfileStreak activities={streak.activities} currentStreak={streak.currentStreak} />
-        <ProfileThirdBox />
-        <MadeRoadmapList />
+        <ProfileThirdBox userName={userName} />
+        <MadeRoadmapList userName={userName} />
 
         {/* 계정 삭제 섹션 */}
         <div className="border-t border-slate-200 pt-8">

--- a/src/features/profile/components/templates/Profile/index.tsx
+++ b/src/features/profile/components/templates/Profile/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -52,10 +52,12 @@ export function Profile({ userName = '' }: ProfileProps) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   const { data, isLoading, isError } = useProfile(userName);
+  const isHydrated = useRef(false);
 
-  // 실데이터로 atoms hydration — 프로필 데이터가 로드되면 atoms에 반영
+  // 실데이터로 atoms hydration — 최초 1회만 수행하여 edit 모드 중 refetch가 편집 내용을 덮어쓰지 않도록 한다
   useEffect(() => {
-    if (!data) return;
+    if (!data || isHydrated.current) return;
+    isHydrated.current = true;
 
     const { user } = data;
 

--- a/src/features/profile/hooks/use-profile-roadmaps.ts
+++ b/src/features/profile/hooks/use-profile-roadmaps.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getRoadmaps } from '@/api/roadmap';
+import type { RoadmapListItemResponse } from '@/api/roadmap';
+import { queryKeys } from '@/lib/query-keys';
+
+interface UseProfileRoadmapsParams {
+  userName: string;
+  enabled?: boolean;
+}
+
+/**
+ * 특정 사용자가 제작한 공개 로드맵 목록을 조회한다.
+ * GET /roadmaps 전체 목록을 가져온 뒤 owner.nickname으로 클라이언트 필터링한다.
+ *
+ * TODO: 백엔드에서 userId 기반 필터링을 지원하면 QueryUserDto에 id를 추가하고
+ * getRoadmaps({ userId }) 방식으로 교체할 것.
+ */
+export function useProfileRoadmaps({ userName, enabled = true }: UseProfileRoadmapsParams) {
+  return useQuery<RoadmapListItemResponse[]>({
+    queryKey: queryKeys.roadmaps.lists({ ownerName: userName }),
+    queryFn: async () => {
+      const response = await getRoadmaps({ size: 50, isPublic: true });
+      return response.content.filter((roadmap) => roadmap.owner.nickname === userName);
+    },
+    enabled: enabled && !!userName,
+  });
+}

--- a/src/features/profile/index.ts
+++ b/src/features/profile/index.ts
@@ -38,3 +38,4 @@ export {
   calculateStreak,
 } from './utils/contribution-utils';
 export { GenerateMockContributions } from './utils/generate-mock-contributions';
+export { useProfileRoadmaps } from './hooks/use-profile-roadmaps';

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -24,8 +24,8 @@ export function decodeJwtPayload(token: string): JwtPayload | null {
     // base64url → base64 변환
     const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
     const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
-    const decoded = atob(padded);
-    return JSON.parse(decoded) as JwtPayload;
+    const bytes = Uint8Array.from(atob(padded), (c) => c.charCodeAt(0));
+    return JSON.parse(new TextDecoder().decode(bytes)) as JwtPayload;
   } catch {
     return null;
   }

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,0 +1,42 @@
+/**
+ * JWT payload를 클라이언트 사이드에서 디코딩하는 유틸리티.
+ * 서명 검증 없이 payload만 파싱하므로 표시 용도로만 사용할 것.
+ */
+
+interface JwtPayload {
+  sub?: string;
+  name?: string;
+  email?: string;
+  exp?: number;
+  iat?: number;
+}
+
+/**
+ * JWT 토큰에서 payload를 디코딩한다.
+ * 파싱 실패 시 null 반환.
+ */
+export function decodeJwtPayload(token: string): JwtPayload | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+
+    const payload = parts[1];
+    // base64url → base64 변환
+    const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+    const decoded = atob(padded);
+    return JSON.parse(decoded) as JwtPayload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * JWT 토큰에서 사용자 이름을 추출한다.
+ * name claim → sub claim 순서로 시도하고 모두 없으면 null 반환.
+ */
+export function extractUserNameFromToken(token: string): string | null {
+  const payload = decodeJwtPayload(token);
+  if (!payload) return null;
+  return payload.name ?? payload.sub ?? null;
+}

--- a/src/mocks/fixtures/users.ts
+++ b/src/mocks/fixtures/users.ts
@@ -58,8 +58,29 @@ export const findUserByEmail = (email: string): MockUser | undefined =>
 export const findUserById = (id: string): MockUser | undefined =>
   MOCK_USERS.find((user) => user.id === id);
 
-/** Mock JWT 토큰 생성 */
-export const createMockToken = (userId: string): string => `mock-jwt-token-${userId}-${Date.now()}`;
+/**
+ * Mock JWT 토큰 생성
+ * 실제 서명은 없지만 base64url header.payload.signature 구조를 갖춰
+ * decodeJwtPayload()가 name 클레임을 정상적으로 추출할 수 있도록 한다.
+ */
+export const createMockToken = (userId: string): string => {
+  const user = MOCK_USERS.find((u) => u.id === userId);
+  const header = btoa(JSON.stringify({ alg: 'HS512', typ: 'JWT' }))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  const payload = btoa(
+    JSON.stringify({
+      sub: userId,
+      name: user?.username ?? userId,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }),
+  )
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `${header}.${payload}.mock-signature`;
+};
 
 /** Mock 인증 코드 (항상 동일한 값 반환) */
 export const MOCK_VERIFICATION_CODE = '123456';

--- a/src/mocks/fixtures/users.ts
+++ b/src/mocks/fixtures/users.ts
@@ -63,22 +63,20 @@ export const findUserById = (id: string): MockUser | undefined =>
  * 실제 서명은 없지만 base64url header.payload.signature 구조를 갖춰
  * decodeJwtPayload()가 name 클레임을 정상적으로 추출할 수 있도록 한다.
  */
+const toBase64Url = (obj: object): string =>
+  btoa(String.fromCharCode(...new TextEncoder().encode(JSON.stringify(obj))))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+
 export const createMockToken = (userId: string): string => {
   const user = MOCK_USERS.find((u) => u.id === userId);
-  const header = btoa(JSON.stringify({ alg: 'HS512', typ: 'JWT' }))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
-  const payload = btoa(
-    JSON.stringify({
-      sub: userId,
-      name: user?.username ?? userId,
-      exp: Math.floor(Date.now() / 1000) + 3600,
-    }),
-  )
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+  const header = toBase64Url({ alg: 'HS512', typ: 'JWT' });
+  const payload = toBase64Url({
+    sub: userId,
+    name: user?.username ?? userId,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+  });
   return `${header}.${payload}.mock-signature`;
 };
 

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -46,6 +46,9 @@ interface ErrorResponse {
 // 가변 유저 저장소 (등록된 유저를 런타임에서 추적)
 const registeredUsers: MockUser[] = [...MOCK_USERS];
 
+// 마지막으로 로그인한 유저 ID (refresh 핸들러에서 재사용)
+let lastLoggedInUserId: string | null = null;
+
 /** API 스펙 형식의 에러 응답 생성 */
 const createErrorResponse = (
   status: number,
@@ -124,6 +127,7 @@ export const authHandlers = [
       );
     }
 
+    lastLoggedInUserId = user.id;
     return HttpResponse.json({ accessToken: createMockToken(user.id) });
   }),
 
@@ -259,7 +263,9 @@ export const authHandlers = [
         { status: 401 },
       );
     }
-    return HttpResponse.json({ accessToken: createMockToken('refreshed') });
+    // 마지막 로그인 유저의 토큰을 재발급 (name 클레임 포함)
+    const userId = lastLoggedInUserId ?? registeredUsers[0]?.id ?? 'unknown';
+    return HttpResponse.json({ accessToken: createMockToken(userId) });
   }),
 
   // DELETE /api/users — 계정 삭제
@@ -278,4 +284,5 @@ export const authHandlers = [
 export const resetRegisteredUsers = (): void => {
   registeredUsers.length = 0;
   registeredUsers.push(...MOCK_USERS);
+  lastLoggedInUserId = null;
 };


### PR DESCRIPTION
## Summary
- 프로필 페이지를 실제 API 데이터로 연결 (mock 제거)
- JWT 디코딩 시 한글 깨짐 버그 수정 (atob → TextDecoder)
- mock token 생성 시 btoa 한글 오류 수정 (TextEncoder 사용)
- hydration 후 background refetch가 edit 상태를 덮어쓰는 버그 수정 (useRef guard)

## 변경 파일
- `src/lib/jwt.ts`
- `src/mocks/fixtures/users.ts`
- `src/features/profile/components/templates/Profile/index.tsx`
- `src/features/auth/stores/auth.atoms.ts`
- `src/features/profile/hooks/use-profile-roadmaps.ts` (신규)

Closes #224