### PR TITLE
feat(#226): wire realtime sync, nack rollback, and connection indicator

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -407,4 +407,6 @@ export const EDITOR_MESSAGES = {
 export const REALTIME_MESSAGES = {
   NACK_TITLE: '변경 사항을 저장하지 못했습니다',
   NACK_DESCRIPTION: '잠시 후 다시 시도해주세요.',
+  CONNECTION_CONNECTED: '실시간 협업 중',
+  CONNECTION_DISCONNECTED: '연결 끊김',
 } as const;

--- a/src/features/roadmap-editor/core/components/EditorHeader/index.tsx
+++ b/src/features/roadmap-editor/core/components/EditorHeader/index.tsx
@@ -8,14 +8,16 @@ import { useAtomValue } from 'jotai';
 import { ChevronLeft, Ellipsis } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
+import { REALTIME_MESSAGES } from '@/constants/messages';
 
 import { roadmapTitleAtom } from '../../../stores/editor-atoms';
 
 interface EditorHeaderProps {
   onBack?: () => void;
+  isConnected?: boolean;
 }
 
-export const EditorHeader = memo(function EditorHeader({ onBack }: EditorHeaderProps) {
+export const EditorHeader = memo(function EditorHeader({ onBack, isConnected }: EditorHeaderProps) {
   const router = useRouter();
   const title = useAtomValue(roadmapTitleAtom);
 
@@ -46,6 +48,28 @@ export const EditorHeader = memo(function EditorHeader({ onBack }: EditorHeaderP
         <span className="text-xs leading-4 font-medium tracking-[0.18px] text-slate-500">
           (수정중)
         </span>
+
+        {isConnected !== undefined && (
+          <span
+            className="flex items-center gap-1 text-xs leading-4 font-medium"
+            aria-label={
+              isConnected
+                ? REALTIME_MESSAGES.CONNECTION_CONNECTED
+                : REALTIME_MESSAGES.CONNECTION_DISCONNECTED
+            }
+          >
+            <span
+              className={`inline-block h-2 w-2 rounded-full ${
+                isConnected ? 'bg-green-500' : 'bg-slate-400'
+              }`}
+            />
+            <span className={isConnected ? 'text-green-600' : 'text-slate-400'}>
+              {isConnected
+                ? REALTIME_MESSAGES.CONNECTION_CONNECTED
+                : REALTIME_MESSAGES.CONNECTION_DISCONNECTED}
+            </span>
+          </span>
+        )}
 
         <button
           type="button"

--- a/src/features/roadmap-editor/core/components/RoadmapEditor/index.tsx
+++ b/src/features/roadmap-editor/core/components/RoadmapEditor/index.tsx
@@ -3,6 +3,8 @@
 import { ReactFlowProvider } from '@xyflow/react';
 
 import { RoadmapCanvas } from '../../../canvas/components';
+import { useNackRollback } from '../../../hooks/use-nack-rollback';
+import { useRealtimeSync } from '../../../hooks/use-realtime-sync';
 import { ColorPicker } from '../../../properties/components';
 import { EditorSidebar } from '../../../sidebar/components';
 import { EditorToolbar } from '../../../toolbar/components';
@@ -14,9 +16,16 @@ interface EditorContentProps {
 }
 
 function EditorContent({ onBack, roadmapId }: EditorContentProps) {
+  const { isConnected } = useRealtimeSync({
+    roadmapId: roadmapId ?? '',
+    isEnabled: !!roadmapId,
+  });
+
+  useNackRollback();
+
   return (
     <div className="relative flex h-screen w-screen">
-      <EditorHeader onBack={onBack} />
+      <EditorHeader onBack={onBack} isConnected={isConnected} />
 
       <div className="relative flex flex-1 overflow-hidden">
         <div className="flex-1">

--- a/src/features/roadmap-editor/hooks/index.ts
+++ b/src/features/roadmap-editor/hooks/index.ts
@@ -1,3 +1,5 @@
 export { useAutoSave } from './use-auto-save';
 export { useCanvasCenter } from './use-canvas-center';
 export { useKeyboardShortcuts } from './use-keyboard-shortcuts';
+export { useNackRollback } from './use-nack-rollback';
+export { useRealtimeSync } from './use-realtime-sync';

--- a/src/features/roadmap-editor/hooks/use-nack-rollback.ts
+++ b/src/features/roadmap-editor/hooks/use-nack-rollback.ts
@@ -57,7 +57,7 @@ export function useNackRollback() {
         setEdges((edges) =>
           edges.map((edge) => {
             if (edge.id !== targetId) return edge;
-            return { ...edge } as Edge;
+            return { ...edge, ...prev } as Edge;
           }),
         );
       }

--- a/src/features/roadmap-editor/hooks/use-nack-rollback.ts
+++ b/src/features/roadmap-editor/hooks/use-nack-rollback.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useSetAtom } from 'jotai';
+
+import { nodesAtom, edgesAtom } from '../stores/editor-atoms';
+
+import type { StompAction } from '../services/action-dispatcher';
+import type { RoadmapNode } from '../types/editor.types';
+import type { Edge } from '@xyflow/react';
+
+interface NackDetail {
+  actionId: string;
+  actionType: string;
+  errorCode: string;
+  errorMessage: string;
+  action: StompAction | undefined;
+}
+
+/**
+ * NACK 롤백 훅.
+ * `jagalchi:realtime-nack` CustomEvent를 수신하여
+ * 거부된 액션의 이전 상태(prev)로 노드/엣지를 복원.
+ */
+export function useNackRollback() {
+  const setNodes = useSetAtom(nodesAtom);
+  const setEdges = useSetAtom(edgesAtom);
+
+  useEffect(() => {
+    const handleNack = (event: Event) => {
+      const { action } = (event as CustomEvent<NackDetail>).detail;
+      if (!action?.payload) return;
+
+      const { payload } = action;
+      const targetType = payload.target?.type;
+      const targetId = payload.target?.object;
+      const prev = payload.prev;
+
+      if (!targetId || !prev) return;
+
+      if (targetType === 'NODE' || targetType === 'SECTION' || targetType === 'TEXT') {
+        setNodes((nodes) =>
+          nodes.map((node) => {
+            if (node.id !== targetId) return node;
+            return {
+              ...node,
+              position:
+                prev.x !== undefined && prev.y !== undefined
+                  ? { x: prev.x, y: prev.y }
+                  : node.position,
+              data: prev.label !== undefined ? { ...node.data, label: prev.label } : node.data,
+            } as RoadmapNode;
+          }),
+        );
+      } else if (targetType === 'EDGE') {
+        setEdges((edges) =>
+          edges.map((edge) => {
+            if (edge.id !== targetId) return edge;
+            return { ...edge } as Edge;
+          }),
+        );
+      }
+    };
+
+    window.addEventListener('jagalchi:realtime-nack', handleNack);
+    return () => {
+      window.removeEventListener('jagalchi:realtime-nack', handleNack);
+    };
+  }, [setNodes, setEdges]);
+}

--- a/src/features/roadmap-editor/hooks/use-realtime-sync.ts
+++ b/src/features/roadmap-editor/hooks/use-realtime-sync.ts
@@ -189,25 +189,41 @@ export function useRealtimeSync({
           // 삭제 이벤트
           setNodes((prev) => prev.filter((node) => node.id !== targetId));
         } else {
-          setNodes((prev) =>
-            prev.map((node) => {
+          setNodes((prev) => {
+            const existingNode = prev.find((n) => n.id === targetId);
+            if (!existingNode) {
+              // CREATE: payload.state를 새 노드로 추가
+              const state = payload.state as RoadmapNode | undefined;
+              if (state) return [...prev, state];
+              return prev;
+            }
+            // UPDATE
+            return prev.map((node) => {
               if (node.id !== targetId) return node;
               const state = payload.state as Record<string, unknown> | undefined;
               return state ? ({ ...node, ...state } as RoadmapNode) : node;
-            }),
-          );
+            });
+          });
         }
       } else if (targetType === 'EDGE') {
         if (payload.deletedNode) {
           setEdges((prev) => prev.filter((edge) => edge.id !== targetId));
         } else {
-          setEdges((prev) =>
-            prev.map((edge) => {
+          setEdges((prev) => {
+            const existingEdge = prev.find((e) => e.id === targetId);
+            if (!existingEdge) {
+              // CREATE: payload.state를 새 엣지로 추가
+              const state = payload.state as Edge | undefined;
+              if (state) return [...prev, state];
+              return prev;
+            }
+            // UPDATE
+            return prev.map((edge) => {
               if (edge.id !== targetId) return edge;
               const state = payload.state as Record<string, unknown> | undefined;
               return state ? ({ ...edge, ...state } as Edge) : edge;
-            }),
-          );
+            });
+          });
         }
       }
     },


### PR DESCRIPTION
## Summary
- STOMP WebSocket 기반 실시간 협업 동기화 연결
- NACK 롤백 훅: edge NACK 시 이전 상태 복원 버그 수정 (`...prev` spread 누락)
- CREATE 이벤트 처리 추가 (기존 UPDATE map만 있어 신규 노드/엣지 무시됨)
- 에디터 헤더에 연결 상태 인디케이터 추가

## 변경 파일
- `src/features/roadmap-editor/hooks/use-nack-rollback.ts` (신규)
- `src/features/roadmap-editor/hooks/use-realtime-sync.ts` (수정)
- `src/features/roadmap-editor/core/components/RoadmapEditor/index.tsx`
- `src/features/roadmap-editor/core/components/EditorHeader/index.tsx`

Closes #226