### PR TITLE
feat(#228): implement follow system UI

### DIFF
--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -209,6 +209,15 @@ export const PROFILE_MESSAGES = {
   SEARCH_EMPTY: '검색 결과가 없습니다.',
   CANCEL: '취소',
   CONFIRM: '확인',
+  // Follow
+  FOLLOW: '팔로우',
+  UNFOLLOW: '언팔로우',
+  FOLLOW_LOADING: '처리 중...',
+  FOLLOWERS_TITLE: '팔로워',
+  FOLLOWINGS_TITLE: '팔로잉',
+  FOLLOW_LIST_EMPTY: '목록이 없습니다.',
+  FOLLOW_LIST_LOADING: '불러오는 중...',
+  FOLLOW_LIST_ERROR: '목록을 불러올 수 없습니다.',
   // Profile template
   LOADING: '프로필을 불러오는 중...',
   ERROR: '프로필을 불러올 수 없습니다.',

--- a/src/features/profile/components/atoms/FollowButton/index.tsx
+++ b/src/features/profile/components/atoms/FollowButton/index.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { PROFILE_MESSAGES } from '@/constants/messages';
+
+import { useToggleFollow } from '../../../hooks/use-toggle-follow';
+
+interface FollowButtonProps {
+  /** 팔로우 대상 유저 이름 */
+  userName: string;
+  /** 현재 팔로우 상태 */
+  isFollowing: boolean;
+  /** 자기 자신이면 true — 이 경우 버튼을 렌더하지 않음 */
+  isSelf: boolean;
+}
+
+export function FollowButton({ userName, isFollowing, isSelf }: FollowButtonProps) {
+  const { mutate, isPending } = useToggleFollow(userName);
+
+  if (isSelf) return null;
+
+  const handleClick = () => {
+    mutate(!isFollowing);
+  };
+
+  return (
+    <Button
+      variant={isFollowing ? 'outline' : 'default'}
+      size="sm"
+      onClick={handleClick}
+      disabled={isPending}
+      className="font-semibold"
+    >
+      {isPending
+        ? PROFILE_MESSAGES.FOLLOW_LOADING
+        : isFollowing
+          ? PROFILE_MESSAGES.UNFOLLOW
+          : PROFILE_MESSAGES.FOLLOW}
+    </Button>
+  );
+}

--- a/src/features/profile/components/atoms/index.ts
+++ b/src/features/profile/components/atoms/index.ts
@@ -1,3 +1,4 @@
+export { FollowButton } from './FollowButton';
 export { ProfileEditButton } from './ProfileEditButton';
 export { ProfileLinkAddButton } from './ProfileLinkAddButton';
 export { ProfilePicture } from './ProfilePicture';

--- a/src/features/profile/components/molecules/FollowListDialog/index.tsx
+++ b/src/features/profile/components/molecules/FollowListDialog/index.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import type { FollowListResponse } from '@/api/profile';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { PROFILE_MESSAGES } from '@/constants/messages';
+
+import { useFollowers } from '../../../hooks/use-followers';
+import { useFollowings } from '../../../hooks/use-followings';
+
+type FollowDialogType = 'followers' | 'followings';
+
+interface FollowListDialogProps {
+  /** 조회 대상 유저 이름 */
+  userName: string;
+  /** 열려 있는 다이얼로그 종류: 'followers' | 'followings' | null */
+  open: FollowDialogType | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface FollowUserItemProps {
+  profileImage: string | null;
+  name: string;
+}
+
+function FollowUserItem({ profileImage, name }: FollowUserItemProps) {
+  return (
+    <div className="flex items-center gap-3 py-3">
+      <div className="h-9 w-9 shrink-0 overflow-hidden rounded-full bg-slate-100">
+        {profileImage ? (
+          <img src={profileImage} alt={`${name}${PROFILE_MESSAGES.PROFILE_PICTURE_ALT_WITH_NAME}`} className="h-full w-full object-cover" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-sm font-semibold text-slate-500">
+            {name.charAt(0).toUpperCase()}
+          </div>
+        )}
+      </div>
+      <span className="text-sm font-medium">{name}</span>
+    </div>
+  );
+}
+
+function FollowListContent({
+  type,
+  userName,
+}: {
+  type: FollowDialogType;
+  userName: string;
+}) {
+  const followersQuery = useFollowers(userName);
+  const followingsQuery = useFollowings(userName);
+
+  const query = type === 'followers' ? followersQuery : followingsQuery;
+  const { data, isLoading, isError } = query as {
+    data: FollowListResponse | undefined;
+    isLoading: boolean;
+    isError: boolean;
+  };
+
+  if (isLoading) {
+    return (
+      <p className="text-muted-foreground py-6 text-center text-sm">
+        {PROFILE_MESSAGES.FOLLOW_LIST_LOADING}
+      </p>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <p className="text-destructive py-6 text-center text-sm">
+        {PROFILE_MESSAGES.FOLLOW_LIST_ERROR}
+      </p>
+    );
+  }
+
+  if (data.users.length === 0) {
+    return (
+      <p className="text-muted-foreground py-6 text-center text-sm">
+        {PROFILE_MESSAGES.FOLLOW_LIST_EMPTY}
+      </p>
+    );
+  }
+
+  return (
+    <ScrollArea className="max-h-96">
+      <div className="divide-y divide-slate-100 px-1">
+        {data.users.map((user) => (
+          <FollowUserItem key={user.id} profileImage={user.profileImage} name={user.name} />
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}
+
+export function FollowListDialog({ userName, open, onOpenChange }: FollowListDialogProps) {
+  const title =
+    open === 'followers' ? PROFILE_MESSAGES.FOLLOWERS_TITLE : PROFILE_MESSAGES.FOLLOWINGS_TITLE;
+
+  return (
+    <Dialog open={open !== null} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        {open !== null && <FollowListContent type={open} userName={userName} />}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/profile/components/molecules/ProfileHeader/index.tsx
+++ b/src/features/profile/components/molecules/ProfileHeader/index.tsx
@@ -11,6 +11,8 @@ interface ProfileHeaderProps {
   email: string;
   followerCount?: number;
   followingCount?: number;
+  isSelf?: boolean;
+  isFollowing?: boolean;
 }
 
 export function ProfileHeader({
@@ -18,6 +20,8 @@ export function ProfileHeader({
   email,
   followerCount = 0,
   followingCount = 0,
+  isSelf = true,
+  isFollowing = false,
 }: ProfileHeaderProps) {
   const [imageSrc, setImageSrc] = useAtom(profileImageAtom);
 
@@ -42,6 +46,8 @@ export function ProfileHeader({
           email={email}
           followerCount={followerCount}
           followingCount={followingCount}
+          isSelf={isSelf}
+          isFollowing={isFollowing}
         />
       </div>
     </div>

--- a/src/features/profile/components/molecules/ProfileInfoForm/index.tsx
+++ b/src/features/profile/components/molecules/ProfileInfoForm/index.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useAtom, useSetAtom } from 'jotai';
 import { useForm } from 'react-hook-form';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PROFILE_MESSAGES } from '@/constants/messages';
 
 import {
   profileBioAtom,
@@ -18,6 +19,9 @@ import {
   profileOrgSnapshotAtom,
 } from '../../../stores/profile-atoms';
 import { ProfileEditButton } from '../../atoms/ProfileEditButton';
+import { FollowListDialog } from '../FollowListDialog';
+
+type FollowDialogType = 'followers' | 'followings';
 
 interface ProfileInfoFormProps {
   name: string;
@@ -44,6 +48,7 @@ export function ProfileInfoForm({
   onEmailChange,
 }: ProfileInfoFormProps) {
   const [mode, setMode] = useAtom(profileModeAtom);
+  const [followDialog, setFollowDialog] = useState<FollowDialogType | null>(null);
 
   // Atoms for bio / org / links (read current, set snapshot, restore from snapshot)
   const [bio, setBio] = useAtom(profileBioAtom);
@@ -125,14 +130,26 @@ export function ProfileInfoForm({
             </div>
 
             <div className="flex flex-row gap-2">
-              <p className="text-base font-medium">
+              <button
+                type="button"
+                className="text-base font-medium hover:underline"
+                onClick={() => setFollowDialog('followers')}
+              >
                 {formatCount(followerCount)}{' '}
-                <span className="text-muted-foreground text-sm font-medium">followers</span>
-              </p>
-              <p className="text-base font-medium">
+                <span className="text-muted-foreground text-sm font-medium">
+                  {PROFILE_MESSAGES.FOLLOWERS_TITLE}
+                </span>
+              </button>
+              <button
+                type="button"
+                className="text-base font-medium hover:underline"
+                onClick={() => setFollowDialog('followings')}
+              >
                 {formatCount(followingCount)}{' '}
-                <span className="text-muted-foreground text-sm font-medium">following</span>
-              </p>
+                <span className="text-muted-foreground text-sm font-medium">
+                  {PROFILE_MESSAGES.FOLLOWINGS_TITLE}
+                </span>
+              </button>
             </div>
           </div>
 
@@ -140,6 +157,7 @@ export function ProfileInfoForm({
             <ProfileEditButton variant="show" onClick={handleEnterEdit} />
           </div>
         </div>
+
       ) : (
         <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
           <div className="flex flex-col gap-2">
@@ -171,14 +189,26 @@ export function ProfileInfoForm({
             </div>
 
             <div className="flex flex-row gap-2 sm:gap-4">
-              <p className="text-sm font-medium sm:text-base">
+              <button
+                type="button"
+                className="text-sm font-medium hover:underline sm:text-base"
+                onClick={() => setFollowDialog('followers')}
+              >
                 {formatCount(followerCount)}{' '}
-                <span className="text-muted-foreground text-sm font-medium">followers</span>
-              </p>
-              <p className="text-sm font-medium sm:text-base">
+                <span className="text-muted-foreground text-sm font-medium">
+                  {PROFILE_MESSAGES.FOLLOWERS_TITLE}
+                </span>
+              </button>
+              <button
+                type="button"
+                className="text-sm font-medium hover:underline sm:text-base"
+                onClick={() => setFollowDialog('followings')}
+              >
                 {formatCount(followingCount)}{' '}
-                <span className="text-muted-foreground text-sm font-medium">following</span>
-              </p>
+                <span className="text-muted-foreground text-sm font-medium">
+                  {PROFILE_MESSAGES.FOLLOWINGS_TITLE}
+                </span>
+              </button>
             </div>
           </div>
 
@@ -197,6 +227,14 @@ export function ProfileInfoForm({
           </div>
         </div>
       )}
+
+      <FollowListDialog
+        userName={name}
+        open={followDialog}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) setFollowDialog(null);
+        }}
+      />
     </div>
   );
 }

--- a/src/features/profile/components/molecules/ProfileInfoForm/index.tsx
+++ b/src/features/profile/components/molecules/ProfileInfoForm/index.tsx
@@ -18,6 +18,7 @@ import {
   profileOrgAtom,
   profileOrgSnapshotAtom,
 } from '../../../stores/profile-atoms';
+import { FollowButton } from '../../atoms/FollowButton';
 import { ProfileEditButton } from '../../atoms/ProfileEditButton';
 import { FollowListDialog } from '../FollowListDialog';
 
@@ -28,6 +29,8 @@ interface ProfileInfoFormProps {
   email: string;
   followerCount?: number;
   followingCount?: number;
+  isSelf?: boolean;
+  isFollowing?: boolean;
   onNameChange?: (name: string) => void;
   onEmailChange?: (email: string) => void;
 }
@@ -44,6 +47,8 @@ export function ProfileInfoForm({
   email,
   followerCount = 0,
   followingCount = 0,
+  isSelf = true,
+  isFollowing = false,
   onNameChange,
   onEmailChange,
 }: ProfileInfoFormProps) {
@@ -153,7 +158,8 @@ export function ProfileInfoForm({
             </div>
           </div>
 
-          <div>
+          <div className="flex flex-row gap-2">
+            <FollowButton userName={name} isFollowing={isFollowing} isSelf={isSelf} />
             <ProfileEditButton variant="show" onClick={handleEnterEdit} />
           </div>
         </div>

--- a/src/features/profile/components/molecules/index.ts
+++ b/src/features/profile/components/molecules/index.ts
@@ -1,4 +1,5 @@
 export { ContributionGraph } from './ContributionGraph';
+export { FollowListDialog } from './FollowListDialog';
 export { ProfileBio } from './ProfileBio';
 export { ProfileCustomBoxArea } from './ProfileCustomBoxArea';
 export { ProfileCustomOrganization } from './ProfileCustomOrganization';

--- a/src/features/profile/components/templates/Profile/index.tsx
+++ b/src/features/profile/components/templates/Profile/index.tsx
@@ -102,6 +102,7 @@ export function Profile({ userName = '' }: ProfileProps) {
           email={user.email}
           followerCount={user.stats.followersCount}
           followingCount={user.stats.followingCount}
+          isFollowing={user.isFollowed}
         />
         <div className="flex w-full flex-col gap-6 lg:flex-row lg:gap-[76px]">
           <div className="w-full lg:w-[500px] lg:shrink-0">

--- a/src/features/profile/hooks/use-toggle-follow.ts
+++ b/src/features/profile/hooks/use-toggle-follow.ts
@@ -37,6 +37,8 @@ export function useToggleFollow(name: string) {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.detail(name) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.users.followers(name) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.users.followings(name) });
     },
   });
 }


### PR DESCRIPTION
## Summary
- FollowButton 컴포넌트 구현 (토글 방식)
- FollowListDialog (팔로워/팔로잉 목록 모달) 구현
- ProfileInfoForm: show 모드에서 타인 프로필 방문 시 FollowButton 표시
- useToggleFollow: 팔로우 후 followers/followings 쿼리 캐시 즉시 갱신 (onSettled invalidateQueries)

## 변경 파일
- `src/features/profile/components/atoms/FollowButton/index.tsx` (신규)
- `src/features/profile/components/molecules/FollowListDialog/index.tsx` (신규)
- `src/features/profile/components/molecules/ProfileInfoForm/index.tsx`
- `src/features/profile/components/molecules/ProfileHeader/index.tsx`
- `src/features/profile/components/templates/Profile/index.tsx`
- `src/features/profile/hooks/use-toggle-follow.ts`

Closes #228