### PR TITLE
chore(#233): version localStorage key to v1

### DIFF
--- a/src/features/roadmap-editor/hooks/use-auto-save.test.ts
+++ b/src/features/roadmap-editor/hooks/use-auto-save.test.ts
@@ -18,12 +18,12 @@ vi.mock('../schemas/roadmap.schema', () => ({
 
 // Mock STORAGE_KEY
 vi.mock('../services/roadmap-storage', () => ({
-  STORAGE_KEY: 'jagalchi-roadmaps',
+  STORAGE_KEY: 'jagalchi-roadmaps-v1',
 }));
 
 import { useAutoSave } from './use-auto-save';
 
-const STORAGE_KEY = 'jagalchi-roadmaps';
+const STORAGE_KEY = 'jagalchi-roadmaps-v1';
 
 const makeNode = (id: string, label: string): RoadmapNode =>
   ({

--- a/src/lib/roadmap-storage.ts
+++ b/src/lib/roadmap-storage.ts
@@ -2,7 +2,7 @@ import type { Roadmap, CreateRoadmapInput } from '@/types/roadmap.types';
 
 import { parseRoadmaps } from './roadmap-schema';
 
-export const STORAGE_KEY = 'jagalchi-roadmaps';
+export const STORAGE_KEY = 'jagalchi-roadmaps-v1';
 
 export function createEmptyRoadmap(id: number, input?: CreateRoadmapInput): Roadmap {
   const now = new Date().toISOString();


### PR DESCRIPTION
## Summary
- `STORAGE_KEY` : `'jagalchi-roadmaps'` → `'jagalchi-roadmaps-v1'`
- 향후 스키마 변경 시 `v2`로 bump해 기존 데이터와 충돌 방지

## Note
서버 저장 마이그레이션 (localStorage → API bulk upload)은 백엔드에 snapshot 엔드포인트가 생기면 별도 이슈로 진행.

Closes #233