### PR TITLE
fix(#review): resolve HIGH severity code review findings

### DIFF
--- a/src/features/auth/stores/auth.atoms.ts
+++ b/src/features/auth/stores/auth.atoms.ts
@@ -1,22 +1,16 @@
 import { atom } from 'jotai';
 
 import { setAccessToken, clearAccessToken } from '@/api/client';
+import { accessTokenAtom } from '@/lib/auth-atoms';
 import { extractUserNameFromToken } from '@/lib/jwt';
 
-/** 액세스 토큰 atom — 메모리에만 저장 (XSS 방어) */
-const accessTokenAtom = atom<string | null>(null);
+export { isAuthenticatedAtom } from '@/lib/auth-atoms';
 
 /** 현재 로그인한 사용자 이름 — JWT payload에서 추출 */
 export const currentUserNameAtom = atom<string | null>(null);
 
 /** 인증 초기화 완료 여부 (refresh 시도 후 true) */
 export const isAuthInitializedAtom = atom<boolean>(false);
-
-/** 현재 로그인 상태 (토큰 존재 여부 기반) */
-export const isAuthenticatedAtom = atom<boolean>((get) => {
-  const token = get(accessTokenAtom);
-  return token !== null;
-});
 
 /** 로그인 시 토큰 저장 + JWT에서 이름 추출 */
 export const loginAtom = atom(null, (_get, set, token: string) => {

--- a/src/features/auth/stores/auth.atoms.ts
+++ b/src/features/auth/stores/auth.atoms.ts
@@ -23,9 +23,7 @@ export const loginAtom = atom(null, (_get, set, token: string) => {
   set(accessTokenAtom, token);
   setAccessToken(token);
   const name = extractUserNameFromToken(token);
-  if (name) {
-    set(currentUserNameAtom, name);
-  }
+  set(currentUserNameAtom, name);
 });
 
 /** 로그아웃 시 토큰 삭제 + 상태 초기화 */

--- a/src/features/notifications/hooks/use-notifications.ts
+++ b/src/features/notifications/hooks/use-notifications.ts
@@ -1,12 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
+import { useAtomValue } from 'jotai';
 
-import { getAccessToken } from '@/api/client';
 import { getNotifications } from '@/api/notifications';
 import type { NotificationListParams, NotificationListResponse } from '@/api/notifications';
+import { isAuthenticatedAtom } from '@/lib/auth-atoms';
 import { queryKeys } from '@/lib/query-keys';
 
 export function useNotifications(params?: NotificationListParams) {
-  const isAuthenticated = !!getAccessToken();
+  const isAuthenticated = useAtomValue(isAuthenticatedAtom);
 
   return useQuery<NotificationListResponse>({
     queryKey: queryKeys.notifications.lists(params),

--- a/src/features/notifications/hooks/use-notifications.ts
+++ b/src/features/notifications/hooks/use-notifications.ts
@@ -1,14 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { getAccessToken } from '@/api/client';
 import { getNotifications } from '@/api/notifications';
 import type { NotificationListParams, NotificationListResponse } from '@/api/notifications';
 import { queryKeys } from '@/lib/query-keys';
 
 export function useNotifications(params?: NotificationListParams) {
+  const isAuthenticated = !!getAccessToken();
+
   return useQuery<NotificationListResponse>({
     queryKey: queryKeys.notifications.lists(params),
     queryFn: () => getNotifications(params),
-    refetchInterval: 30_000,
-    refetchOnWindowFocus: true,
+    enabled: isAuthenticated,
+    refetchInterval: isAuthenticated ? 30_000 : false,
+    refetchOnWindowFocus: isAuthenticated,
   });
 }

--- a/src/features/roadmap-editor/canvas/components/RoadmapCanvas/index.tsx
+++ b/src/features/roadmap-editor/canvas/components/RoadmapCanvas/index.tsx
@@ -152,7 +152,9 @@ export function RoadmapCanvas({ roadmapId, userName = 'Unknown' }: RoadmapCanvas
       const targetIsPane = (event.target as HTMLElement).classList.contains('react-flow__pane');
       if (!targetIsPane) return;
 
-      const { clientX, clientY } = 'changedTouches' in event ? event.changedTouches[0] : event;
+      const touch = 'changedTouches' in event ? event.changedTouches[0] : null;
+      if (!touch && !('clientX' in event)) return;
+      const { clientX, clientY } = touch ?? (event as MouseEvent);
       const position = screenToFlowPosition({ x: clientX, y: clientY });
 
       // Create new node at drop position

--- a/src/features/roadmap-editor/hooks/use-auto-save.ts
+++ b/src/features/roadmap-editor/hooks/use-auto-save.ts
@@ -6,6 +6,7 @@ import { isEnabled } from '@/lib/feature-flags';
 import { parseRoadmaps } from '../schemas/roadmap.schema';
 import { dispatchAction } from '../services/action-dispatcher';
 import { STORAGE_KEY } from '../services/roadmap-storage';
+import { hashNodes, hashEdges } from '../utils/fast-hash';
 
 import type { RoadmapNode } from '../types/editor.types';
 import type { Roadmap } from '../types/roadmap.types';
@@ -63,9 +64,8 @@ export function useAutoSave({
   useEffect(() => {
     if (!isEnabled || typeof window === 'undefined') return;
 
-    // Use JSON.stringify for accurate change detection (debounced, so performance is fine)
-    const currentNodesHash = JSON.stringify(debouncedNodes);
-    const currentEdgesHash = JSON.stringify(debouncedEdges);
+    const currentNodesHash = hashNodes(debouncedNodes);
+    const currentEdgesHash = hashEdges(debouncedEdges);
     const currentTitle = debouncedTitle;
 
     // Detect changes
@@ -77,17 +77,13 @@ export function useAutoSave({
       return;
     }
 
-    // Realtime mode: send STOMP action instead of localStorage
-    if (isRealtimeEnabled) {
+    // Realtime mode: dispatch title change via STOMP, always persist to localStorage as local cache
+    if (isRealtimeEnabled && titleChanged) {
       dispatchAction(roadmapId, 'EDIT', {
         type: 'INFO',
         target: { type: 'NODE', object: roadmapId },
         data: { title: debouncedTitle },
       });
-      prevNodesRef.current = currentNodesHash;
-      prevEdgesRef.current = currentEdgesHash;
-      prevTitleRef.current = currentTitle;
-      return;
     }
 
     try {

--- a/src/features/roadmap-editor/services/action-dispatcher.ts
+++ b/src/features/roadmap-editor/services/action-dispatcher.ts
@@ -65,10 +65,17 @@ export function dispatchAction(
     payload,
   };
 
-  // 대기 큐 오버플로우 방지 — 가장 오래된 액션 제거
+  // 대기 큐 오버플로우 방지 — 가장 오래된 액션 제거 (NACK 롤백 불가 경고)
   if (pendingActions.size >= MAX_PENDING_ACTIONS) {
     const oldestKey = pendingActions.keys().next().value;
-    if (oldestKey) pendingActions.delete(oldestKey);
+    if (oldestKey) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[action-dispatcher] pendingActions overflow: dropping actionId=${oldestKey}. ` +
+          'NACK rollback for this action will be silently skipped.',
+      );
+      pendingActions.delete(oldestKey);
+    }
   }
 
   pendingActions.set(actionId, stompAction);

--- a/src/features/roadmap-editor/utils/fast-hash.ts
+++ b/src/features/roadmap-editor/utils/fast-hash.ts
@@ -27,18 +27,19 @@ export function fastArrayHash<T extends Record<string, unknown>>(
 ): string {
   if (!arr.length) return '0';
 
-  let combined = arr.length; // Include array length in hash
+  let combined = arr.length;
 
-  for (const item of arr) {
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
     for (const key of keys) {
       const value = item[key];
-      // Hash the value - use JSON.stringify for complex objects
       const str = typeof value === 'object' ? JSON.stringify(value) : String(value);
-      combined ^= hashString(str);
+      // Mix in index to make hash order-sensitive (prevents swap false-negatives)
+      combined = Math.imul(combined, 31) ^ hashString(`${i}:${String(key)}:${str}`);
     }
   }
 
-  return combined.toString(36); // Base36 for shorter strings
+  return (combined >>> 0).toString(36);
 }
 
 /**

--- a/src/features/roadmap-viewer/components/ViewerSidebar/index.tsx
+++ b/src/features/roadmap-viewer/components/ViewerSidebar/index.tsx
@@ -7,6 +7,7 @@ import { CheckCircle2, Circle, Search, X } from 'lucide-react';
 
 import { VIEWER_MESSAGES } from '@/constants/messages';
 import { useCompleteNode, useRoadmapProgress } from '@/hooks/use-roadmap-progress';
+import { sanitizeUrl } from '@/lib/url-validation';
 import type { JagalchiNodeData } from '@/types/roadmap.types';
 
 import {
@@ -183,7 +184,7 @@ export function ViewerSidebar({ isOpen = true, onClose, roadmapId }: ViewerSideb
                   {(selectedNode.data as JagalchiNodeData).resources.map((url) => (
                     <li key={url}>
                       <a
-                        href={url}
+                        href={sanitizeUrl(url)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-primary block truncate text-sm hover:underline"

--- a/src/lib/auth-atoms.ts
+++ b/src/lib/auth-atoms.ts
@@ -1,0 +1,10 @@
+import { atom } from 'jotai';
+
+/** 액세스 토큰 atom — 메모리에만 저장 (XSS 방어) */
+export const accessTokenAtom = atom<string | null>(null);
+
+/** 현재 로그인 상태 (토큰 존재 여부 기반) */
+export const isAuthenticatedAtom = atom<boolean>((get) => {
+  const token = get(accessTokenAtom);
+  return token !== null;
+});

--- a/src/lib/stomp-client.ts
+++ b/src/lib/stomp-client.ts
@@ -15,6 +15,7 @@ if (!WS_URL && typeof window !== 'undefined') {
 
 let client: Client | null = null;
 let isConnecting = false;
+let consumerCount = 0;
 
 type MessageHandler = (message: IMessage) => void;
 type ErrorHandler = (frame: IFrame) => void;
@@ -76,14 +77,18 @@ export function getStompClient(options?: StompClientOptions): Client {
 
 /** STOMP 연결 활성화 */
 export function connectStomp(options?: StompClientOptions): void {
+  consumerCount++;
   const c = getStompClient(options);
   if (!c.active) {
     c.activate();
   }
 }
 
-/** STOMP 연결 해제 */
+/** STOMP 연결 해제 — 마지막 소비자가 해제할 때만 실제 disconnect */
 export async function disconnectStomp(): Promise<void> {
+  consumerCount = Math.max(0, consumerCount - 1);
+  if (consumerCount > 0) return;
+
   if (client?.active) {
     await client.deactivate();
   }

--- a/src/lib/stomp-client.ts
+++ b/src/lib/stomp-client.ts
@@ -16,6 +16,7 @@ if (!WS_URL && typeof window !== 'undefined') {
 let client: Client | null = null;
 let isConnecting = false;
 let consumerCount = 0;
+let disconnectingPromise: Promise<void> | null = null;
 
 type MessageHandler = (message: IMessage) => void;
 type ErrorHandler = (frame: IFrame) => void;
@@ -75,8 +76,11 @@ export function getStompClient(options?: StompClientOptions): Client {
   return client;
 }
 
-/** STOMP 연결 활성화 */
-export function connectStomp(options?: StompClientOptions): void {
+/** STOMP 연결 활성화 — 진행 중인 disconnect가 있으면 완료 후 연결 */
+export async function connectStomp(options?: StompClientOptions): Promise<void> {
+  if (disconnectingPromise) {
+    await disconnectingPromise;
+  }
   consumerCount++;
   const c = getStompClient(options);
   if (!c.active) {
@@ -85,15 +89,20 @@ export function connectStomp(options?: StompClientOptions): void {
 }
 
 /** STOMP 연결 해제 — 마지막 소비자가 해제할 때만 실제 disconnect */
-export async function disconnectStomp(): Promise<void> {
+export function disconnectStomp(): Promise<void> {
   consumerCount = Math.max(0, consumerCount - 1);
-  if (consumerCount > 0) return;
+  if (consumerCount > 0) return Promise.resolve();
 
-  if (client?.active) {
-    await client.deactivate();
-  }
-  client = null;
-  isConnecting = false;
+  disconnectingPromise = (async () => {
+    if (client?.active) {
+      await client.deactivate();
+    }
+    client = null;
+    isConnecting = false;
+    disconnectingPromise = null;
+  })();
+
+  return disconnectingPromise;
 }
 
 /** 토픽 구독 */


### PR DESCRIPTION
## Summary

- **fast-hash**: `fastArrayHash`를 order-sensitive하게 수정 — index를 hash에 mix-in해 swap false-negative 방지
- **stomp-client**: `disconnectingPromise` 직렬화로 `connectStomp`/`disconnectStomp` async 레이스 컨디션 수정
- **auth-atoms**: `accessTokenAtom`/`isAuthenticatedAtom`을 `src/lib/auth-atoms.ts`로 추출해 cross-feature import 없이 반응형 인증 상태 공유
- **use-notifications**: `getAccessToken()` 스냅샷 → `useAtomValue(isAuthenticatedAtom)` 반응형으로 교체 (로그인 후 알림 enabled 고착 버그 수정)
- **use-auto-save**: 리얼타임 브랜치에서 `return` 제거 — STOMP dispatch 후 localStorage 저장도 병행
- **action-dispatcher**: pending queue overflow 시 `console.warn` 추가 (NACK 롤백 불가 경고)
- **RoadmapCanvas**: `changedTouches` 길이 체크 추가 — `touchcancel` 이벤트 TypeError 방지
- **ViewerSidebar**: 리소스 URL에 `sanitizeUrl()` 적용 — `javascript:` / `data:` XSS 방어

## Test plan

- [ ] `pnpm lint` 통과
- [ ] `pnpm build` 성공
- [ ] 로그인 후 알림 폴링 즉시 활성화 확인
- [ ] 로드맵 편집 후 노드 swap 시 hash 변경 확인 (false-save 방지)
- [ ] STOMP 연결/해제 반복 시 레이스 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed touch input handling on the roadmap canvas for better mobile usability.

* **Improvements**
  * Notification queries now respect authentication status, eliminating unnecessary data requests when you're logged out.
  * Enhanced real-time connection management for improved synchronization reliability.
  * Optimized change detection algorithm for the auto-save functionality.

* **Security**
  * Added URL sanitization for sidebar resource links to prevent potential security risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->