### PR TITLE
test: expand production e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,5 +101,8 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
-          path: playwright-report/
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
           retention-days: 14

--- a/e2e/community.spec.ts
+++ b/e2e/community.spec.ts
@@ -41,6 +41,29 @@ test.describe('Community E2E', () => {
       await page.waitForURL(`**${href}`, { timeout: 30000 });
       expect(page.url()).toContain('/community/');
     });
+
+    test('searches latest roadmaps, opens result, and forks it', async ({ page }) => {
+      await page.getByRole('button', { name: '최신' }).click();
+      await expect(page.getByRole('link', { name: /프론트엔드 개발자 로드맵/ })).toBeVisible({
+        timeout: 10000,
+      });
+
+      await page.getByLabel('로드맵 검색').fill('백엔드');
+      await page.getByLabel('로드맵 검색').press('Enter');
+
+      await expect(page.getByRole('link', { name: /백엔드 개발자 로드맵/ })).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(page.getByRole('link', { name: /프론트엔드 개발자 로드맵/ })).toHaveCount(0);
+
+      await page.getByRole('link', { name: /백엔드 개발자 로드맵/ }).click();
+      await expect(page).toHaveURL(/\/community\/2/, { timeout: 10000 });
+
+      await page.getByRole('button', { name: '내 로드맵에 추가' }).click();
+      await expect(page.getByText('로드맵을 내 로드맵에 추가했습니다.')).toBeVisible({
+        timeout: 10000,
+      });
+    });
   });
 
   test.describe('Community Detail Page', () => {

--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -6,8 +6,12 @@ import { loginAsTestUser } from './helpers/auth';
 const TEST_ROADMAP_ID = '1';
 
 test.describe('Editor E2E', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
     await loginAsTestUser(page);
+    if (testInfo.title === 'node edits are auto-saved and visible in viewer') {
+      return;
+    }
+
     await page.goto(`/editor/${TEST_ROADMAP_ID}`);
   });
 
@@ -41,6 +45,72 @@ test.describe('Editor E2E', () => {
       await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
     }
     await expect(page.getByTestId('properties-panel-header')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('node edits are auto-saved and visible in viewer', async ({ page }) => {
+    await page.goto('/myroadmap');
+    await expect(page.getByRole('heading', { name: '내 로드맵' })).toBeVisible({ timeout: 30000 });
+
+    await page.getByRole('button', { name: /New/ }).click();
+    await page.getByRole('menuitem', { name: '로드맵' }).click();
+    await page.getByPlaceholder('로드맵 이름을 입력하세요').fill('E2E 저장 검증 로드맵');
+    await page.getByRole('button', { name: '확인' }).click();
+
+    await expect(page).toHaveURL(/\/editor\/\d+/, { timeout: 10000 });
+    const roadmapId = page.url().match(/\/editor\/(\d+)/)?.[1];
+    expect(roadmapId).toBeTruthy();
+
+    await page.waitForSelector('.react-flow', { timeout: 30000 });
+    const nodes = page.locator('.react-flow__node');
+    const initialNodeCount = await nodes.count();
+
+    await page.getByTestId('toolbar-add-node').click();
+    await expect(nodes).toHaveCount(initialNodeCount + 1, { timeout: 10000 });
+
+    const addedNode = nodes.nth(initialNodeCount);
+    await addedNode.waitFor({ state: 'visible', timeout: 10000 });
+    const box = await addedNode.boundingBox();
+    if (!box) {
+      throw new Error('Added node is not clickable');
+    }
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+
+    const nameInput = page.getByLabel('노드 이름');
+    await expect(nameInput).toBeVisible({ timeout: 10000 });
+    await nameInput.fill('수정된 E2E 노드');
+
+    const descriptionInput = page.getByLabel('노드 설명');
+    await descriptionInput.fill('뷰어 저장 확인용 설명');
+
+    await expect(
+      page.locator('.react-flow__node').filter({ hasText: '수정된 E2E 노드' }),
+    ).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page.waitForFunction(
+      ({ roadmapId }) => {
+        const stored = localStorage.getItem('jagalchi-roadmaps-v1');
+        if (!stored) return false;
+        const roadmaps = JSON.parse(stored) as Array<{
+          id: number | string;
+          nodes: Array<{ data?: { label?: string; description?: string } }>;
+        }>;
+        const roadmap = roadmaps.find((item) => String(item.id) === roadmapId);
+        return roadmap?.nodes.some(
+          (node) =>
+            node.data?.label === '수정된 E2E 노드' &&
+            node.data.description === '뷰어 저장 확인용 설명',
+        );
+      },
+      { roadmapId },
+      { timeout: 10000 },
+    );
+
+    await page.goto(`/viewer/${roadmapId}`);
+    await expect(
+      page.locator('.react-flow__node').filter({ hasText: '수정된 E2E 노드' }),
+    ).toBeVisible({ timeout: 30000 });
   });
 
   test('share button opens viewer for roadmap', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add an editor E2E path for roadmap creation, node add/edit, auto-save verification, and viewer rendering.
- Add a community E2E path for latest-roadmap search, result navigation, and fork success.
- Upload raw Playwright `test-results/` in CI so failure screenshots and traces are available even when the HTML report is absent.

## Validation
- `pnpm lint` (0 errors, existing warnings only)
- `pnpm build`
- `pnpm exec playwright test e2e/community.spec.ts e2e/editor.spec.ts --project=chromium`
- `pnpm test:e2e`
- `pnpm test:run`

Closes #225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the Community List Page, including filtering latest roadmaps, searching by keyword, navigating to roadmap details, and adding roadmaps to your collection.
  * Added comprehensive test coverage for the editor, verifying node auto-saving functionality and confirming changes are visible in the viewer.
  * Improved CI workflow to capture comprehensive test reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->