### PR TITLE
fix: enable MSW for production E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
         run: pnpm build
         env:
           NEXT_PUBLIC_API_MOCKING: 'true'
+          NEXT_PUBLIC_E2E_MOCKING: 'true'
+          NEXT_PUBLIC_REALTIME_ENABLED: 'true'
 
       - name: Run E2E tests
         run: |
@@ -95,6 +97,8 @@ jobs:
           exit $RC
         env:
           NEXT_PUBLIC_API_MOCKING: 'true'
+          NEXT_PUBLIC_E2E_MOCKING: 'true'
+          NEXT_PUBLIC_REALTIME_ENABLED: 'true'
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,7 @@ import { defineConfig, devices } from '@playwright/test';
 const e2eEnv = {
   NEXT_PUBLIC_API_URL: '/api',
   NEXT_PUBLIC_API_MOCKING: 'true',
+  NEXT_PUBLIC_E2E_MOCKING: 'true',
   NEXT_PUBLIC_REALTIME_ENABLED: 'true',
   NEXT_PUBLIC_SITE_URL: 'http://localhost:3100',
 };

--- a/src/components/MswProvider.tsx
+++ b/src/components/MswProvider.tsx
@@ -3,15 +3,17 @@
 import { useEffect, useState } from 'react';
 
 /**
- * MSW는 개발/프리뷰 환경에서만 허용. 프로덕션 번들 유입을 막기 위해
- * 두 조건을 모두 만족해야 동작한다:
+ * MSW는 개발/프리뷰 환경과 E2E 전용 production build 에서만 허용한다.
+ * 프로덕션 번들 유입을 막기 위해 아래 조건을 모두 만족해야 동작한다:
  *   1) NEXT_PUBLIC_API_MOCKING === 'true'
- *   2) NODE_ENV !== 'production'
+ *   2) NODE_ENV !== 'production' 또는 NEXT_PUBLIC_E2E_MOCKING === 'true'
  * 프로덕션 배포에서 실수로 NEXT_PUBLIC_API_MOCKING 가 true 로 설정되더라도
- * NODE_ENV 가 production 이므로 MSW 가 로드되지 않는다.
+ * E2E 전용 플래그가 없으면 MSW 가 로드되지 않는다.
  */
+const isE2EMockingEnabled = process.env.NEXT_PUBLIC_E2E_MOCKING === 'true';
 const isMockingEnabled =
-  process.env.NEXT_PUBLIC_API_MOCKING === 'true' && process.env.NODE_ENV !== 'production';
+  process.env.NEXT_PUBLIC_API_MOCKING === 'true' &&
+  (process.env.NODE_ENV !== 'production' || isE2EMockingEnabled);
 
 export function MSWProvider({ children }: { children: React.ReactNode }) {
   const [isReady, setIsReady] = useState(!isMockingEnabled);

--- a/src/features/roadmap-editor/hooks/use-realtime-sync.ts
+++ b/src/features/roadmap-editor/hooks/use-realtime-sync.ts
@@ -14,8 +14,10 @@ import type { RoadmapNode } from '../types/editor.types';
 import type { Edge } from '@xyflow/react';
 
 const isRealtimeEnabled = isEnabled('REALTIME_ENABLED');
+const isE2EMockingEnabled = process.env.NEXT_PUBLIC_E2E_MOCKING === 'true';
 const isApiMockingEnabled =
-  process.env.NEXT_PUBLIC_API_MOCKING === 'true' && process.env.NODE_ENV !== 'production';
+  process.env.NEXT_PUBLIC_API_MOCKING === 'true' &&
+  (process.env.NODE_ENV !== 'production' || isE2EMockingEnabled);
 const shouldUseRealtime = isRealtimeEnabled && !isApiMockingEnabled;
 
 interface UseRealtimeSyncOptions {

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,7 +1,9 @@
 /** 브라우저 환경에서 MSW를 조건부로 초기화 (프로덕션 차단 이중 가드) */
 export async function initMocks() {
   if (process.env.NEXT_PUBLIC_API_MOCKING !== 'true') return;
-  if (process.env.NODE_ENV === 'production') return;
+  if (process.env.NODE_ENV === 'production' && process.env.NEXT_PUBLIC_E2E_MOCKING !== 'true') {
+    return;
+  }
 
   if (typeof window !== 'undefined') {
     const { worker } = await import('./browser');


### PR DESCRIPTION
## Summary
- Allow MSW to initialize in production builds only when the E2E-only `NEXT_PUBLIC_E2E_MOCKING` flag is present.
- Keep regular production protected from accidental mock activation.
- Align CI E2E build/runtime env with Playwright config so mocked API and event-loading paths are baked into `next build`.
- Keep realtime disabled while API mocking is active in E2E.

## Root Cause
PR #278 exposed the raw Playwright artifact, which showed CI E2E was not genuinely green. The CI job passed because the workflow converts a 10-minute Playwright timeout into exit 0. In `next build && next start`, `NODE_ENV=production` disabled `initMocks()`, and the CI build also missed `NEXT_PUBLIC_REALTIME_ENABLED`, so mocked auth/editor data was unavailable.

## Validation
- `NEXT_PUBLIC_API_MOCKING=true NEXT_PUBLIC_E2E_MOCKING=true NEXT_PUBLIC_REALTIME_ENABLED=true pnpm build`
- `CI=true pnpm exec playwright test e2e/a11y.spec.ts e2e/auth.spec.ts e2e/community.spec.ts --project=chromium --retries=0` (33 passed)
- `CI=true pnpm exec playwright test --project=chromium --retries=0` (70 passed, 1 skipped)
- `pnpm lint` (0 errors, existing warnings only)
- `pnpm build`
- `pnpm test:run`