### PR TITLE
fix: fail CI on test timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Unit Test
-        run: |
-          RC=0
-          timeout 300 pnpm test:run || RC=$?
-          [ $RC -eq 124 ] && { echo "::notice::vitest hung after tests — timeout (exit 0)"; exit 0; }
-          exit $RC
+        run: timeout 300 pnpm test:run
 
   e2e:
     runs-on: ubuntu-latest
@@ -90,11 +86,7 @@ jobs:
           NEXT_PUBLIC_REALTIME_ENABLED: 'true'
 
       - name: Run E2E tests
-        run: |
-          RC=0
-          timeout 600 pnpm test:e2e || RC=$?
-          [ $RC -eq 124 ] && { echo "::notice::playwright hung after tests — timeout (exit 0)"; exit 0; }
-          exit $RC
+        run: timeout 600 pnpm test:e2e
         env:
           NEXT_PUBLIC_API_MOCKING: 'true'
           NEXT_PUBLIC_E2E_MOCKING: 'true'


### PR DESCRIPTION
## Summary
- Stop converting Vitest and Playwright timeout exit code `124` into success.
- Keep the timeout guard, but let timeout failures fail the CI job.

## Why
PR #278 showed that a timed-out E2E run could appear green because the workflow exited 0 after `timeout 600`. For production readiness, a hung or timed-out test suite must block merge instead of being reported as pass.

## Validation
- Workflow-only change; #279 already verified the production-start E2E path now completes normally with `70 passed, 1 skipped` in CI.