### PR TITLE
chore: add dependency audit gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # npm dependencies
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -15,11 +16,17 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
       dev-dependencies:
+        applies-to: version-updates
         dependency-type: "development"
         patterns:
           - "*"
       production-dependencies:
+        applies-to: version-updates
         dependency-type: "production"
         patterns:
           - "*"
@@ -27,8 +34,21 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Asia/Seoul"
+    groups:
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "action"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,41 @@ jobs:
       - name: Build
         run: pnpm build
 
+  dependency-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Production dependency audit
+        continue-on-error: true
+        run: pnpm audit --prod --audit-level=high
+
+      - name: List pnpm overrides for review
+        run: |
+          node - <<'NODE'
+          const { readFileSync } = require('node:fs');
+          const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+          const overrides = pkg.pnpm?.overrides ?? {};
+          const entries = Object.entries(overrides);
+          console.log(`pnpm.overrides count: ${entries.length}`);
+          for (const [name, version] of entries) {
+            console.log(`- ${name} -> ${version}`);
+          }
+          NODE
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- target Dependabot npm and GitHub Actions updates at `develop` on a weekly Asia/Seoul schedule
- group Dependabot security updates separately from version updates
- add a CI dependency-audit job with `pnpm audit --prod --audit-level=high` as a warning step
- print current `pnpm.overrides` in CI so override drift is visible on PRs
- enabled GitHub automated security fixes for this repository

Closes #232

## Validation
- ruby YAML parse for `.github/workflows/ci.yml` and `.github/dependabot.yml`
- pnpm audit --prod --audit-level=high
- pnpm lint